### PR TITLE
ForceFetchPKI when readInbox fails

### DIFF
--- a/client/session.go
+++ b/client/session.go
@@ -357,6 +357,10 @@ func (s *Session) GetPandaConfig() *config.Panda {
 	return s.cfg.Panda
 }
 
+func (s *Session) ForceFetchPKI() {
+	s.minclient.ForceFetchPKI()
+}
+
 func (s *Session) Shutdown() {
 	s.Halt()
 	s.rescheduler.timerQ.Halt()

--- a/minclient/send.go
+++ b/minclient/send.go
@@ -136,17 +136,17 @@ func (c *Client) makePath(recipient, provider string, surbID *[sConstants.SURBID
 	// Get the current PKI document.
 	doc := c.CurrentDocument()
 	if doc == nil {
-		return nil, time.Time{}, fmt.Errorf("minclient: no PKI document for current epoch")
+		return nil, time.Time{}, newPKIError("minclient: no PKI document for current epoch")
 	}
 
 	// Get the descriptors.
 	src, err := doc.GetProvider(srcProvider)
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("minclient: failed to find source Provider: %v", err)
+		return nil, time.Time{}, newPKIError("minclient: failed to find source Provider: %v", err)
 	}
 	dst, err := doc.GetProvider(dstProvider)
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("minclient: failed to find destination Provider: %v", err)
+		return nil, time.Time{}, newPKIError("minclient: failed to find destination Provider: %v", err)
 	}
 
 	p, t, err := path.New(c.rng, doc, []byte(recipient), src, dst, surbID, baseTime, true, isForward)


### PR DESCRIPTION
This is to address the case when a client reconnects (e.g. after a
computer comes out of a suspended state) and the PKI is not valid, but
it is not yet time to fetch the next epoch's PKI document.