### PR TITLE
eddsa/blinded25519: the Tor V3 onion key blinding scheme for ed25519

### DIFF
--- a/core/crypto/eddsa/blinded25519.go
+++ b/core/crypto/eddsa/blinded25519.go
@@ -1,0 +1,169 @@
+// blinded25519.go - blinded EdDSA signatures
+// License: AGPL version 3
+// Copyright: 2021 - Anonymous contributor
+
+// This module implements the blinded signature scheme as used in
+// Tor for OnionV3, see A.2. Tor's key derivation scheme:
+// https://github.com/torproject/torspec/blob/main/rend-spec-v3.txt#L2268-L2326
+// Note that this implementation of the scheme uses different constants
+// for hashing the (factor)s and as thus is not wire format compatible.
+
+// Note that the reason that Tor doesn't need a separate Sign() function
+// for blinded private keys is that they use a different in-memory
+// representation of secret keys where the nonce seed is stored in expanded
+// form (instead of deriving it with sha512 for each signature)
+
+// It would be kind of useful to have
+// BlindedPrivateKey.FromBytes()
+// BlindedPrivateKey.ToBytes()
+// to enable passing around the derived keys, for instance to pass on
+// delegated privileges. Unfortunately checking the private scalars does
+// not seem trivial (since they are "malformed", ie no clamping), so it
+// seems like it could be a great footgun. Leaving it out for now, but
+// it's something to consider for the future I guess.
+
+// Note that use of Scalar.SetUniformBytes() is a bit unorthodox:
+// The API was designed to take 64 uniformly random bytes,
+// which are then reduced mod L. We "abuse" it by providing
+// our 32byte scalars as the 32 lower bytes and the upper 32 bytes all-zero
+// --- This way we get to initialize Scalar objects without the usual clamping.
+// There doesn't seem to be another API that lets us initialize 32-byte scalars
+// directly.
+
+// And lastly, note that it would be interesting to come up with a
+// blinding scheme that preserves the "validity" of the derived secret key
+// for use with x25519, perhaps a way to modify `factor` such that
+//            clamp(a)*clamp(factor)
+// ===  clamp(clamp(a)*clamp(factor))
+
+package eddsa
+
+import (
+	"crypto/ed25519"
+	"crypto/sha512"
+	"filippo.io/edwards25519"
+)
+
+type BlindedPrivateKey struct {
+	blinded ed25519.PrivateKey
+}
+
+func (bpk *BlindedPrivateKey) PublicKey() *PublicKey {
+	pub := new(PublicKey)
+	err := pub.FromBytes(bpk.blinded[32:])
+	if err != nil {
+		// This should not be possible:
+		panic(err)
+	}
+	return pub
+}
+
+func (privateKey *BlindedPrivateKey) Sign(message []byte) [64]byte {
+	signature := [64]byte{}
+	// vendored version of ed25519.sign() except it uses the
+	// secret/private scalar directly as expandedSecretKey
+	// instead of deriving from hash each time.
+	// It is a bit unfortunate that this needs to be here...
+	blindedSecretKey := [64]byte{}
+	copy(blindedSecretKey[:], privateKey.blinded[:32])
+	expandedSecretKey := new(edwards25519.Scalar)
+	expandedSecretKey.SetUniformBytes(blindedSecretKey[:])
+
+	// secret_salt <- sha512(private)
+	digest1 := sha512.Sum512(privateKey.blinded[:32])
+
+	// very important that nonce is never repeated for different messages;
+	// ensured here by deriving nonce from a hash of the message.
+	// the second appendix of secret_salt below is not part of the spec:
+	// nonce := sha512(secret_salt[32:64] || message || secret_salt[33:64])
+	h := sha512.New()
+	h.Write(digest1[32:])
+	h.Write(message)
+	h.Write(digest1[33:])
+	messageDigest := h.Sum(nil)
+
+	// messageDigestReduced <- (nonce mod L)
+	mdReduced, _ := new(edwards25519.Scalar).SetUniformBytes(messageDigest[:64])
+
+	// R <- messageDigestReduced * B
+	var encodedR [32]byte
+	copy(encodedR[:], new(edwards25519.Point).ScalarBaseMult(mdReduced).Bytes())
+
+	// hramDigestReduced := sha512(R || public || message) mod L
+	h.Reset()
+	h.Write(encodedR[:])
+	h.Write(privateKey.blinded[32:])
+	h.Write(message)
+	hramDigest := h.Sum(nil)
+	hramDigestReduced, _ := new(edwards25519.Scalar).SetUniformBytes(hramDigest[:])
+	//     s := (hRamDigestReduced*secret + messageDigestReduced) mod L
+	// <-> s := (   (sha512(R || public || message) mod L)*secret
+	//            + (nonce mod L)
+	//          ) mod L
+	s_new := new(edwards25519.Scalar).MultiplyAdd(hramDigestReduced,
+		expandedSecretKey,
+		mdReduced)
+
+	copy(signature[:], encodedR[:])
+	copy(signature[32:], s_new.Bytes())
+	return signature
+}
+
+func hash_factor_inplace(factor *[32]byte) {
+	h := sha512.Sum512_256(factor[:])
+	copy(factor[:], h[:])
+	// needs to be clamped for scalar multiplication,
+	// but Scalar.SetBytesWithClamping takes care of that.
+}
+
+func (secret *PrivateKey) Blind(factor [32]byte) *BlindedPrivateKey {
+	hash_factor_inplace(&factor)
+	factor_sc, err := new(edwards25519.Scalar).SetBytesWithClamping(factor[:])
+	if err != nil {
+		// This only happens if factor is not 32 bytes.
+		panic(err)
+	}
+
+	// Here digest is the actual secret key derived from the seed:
+	digest := sha512.Sum512(secret.Bytes()[:32])
+	bb_sc, err := new(edwards25519.Scalar).SetBytesWithClamping(digest[:32])
+
+	// (ab + c) mod l = ScMulAdd(out, a, b, c)
+	// a := factor
+	// b := secret
+	// c := 0
+	// the (c*B) multiplication here is unfortunate but that was the easiest API
+	// to use in edwards25519, so...
+	// oo <- factor * bb + 0*B
+	oo_sc := new(edwards25519.Scalar).Multiply(factor_sc, bb_sc)
+
+	newsec := make(ed25519.PrivateKey, 64)
+	copy(newsec[:32], oo_sc.Bytes())
+
+	// calculates and sets the public key corresponding to the
+	// private scalar (used when we have derived a new private scalar)
+	newsec_a := [64]byte{}
+	copy(newsec_a[:], oo_sc.Bytes()[:32])
+	newsec_scalar, _ := new(edwards25519.Scalar).SetUniformBytes(newsec_a[:])
+	pkxA_n := new(edwards25519.Point).ScalarBaseMult(newsec_scalar)
+	copy(newsec[32:], pkxA_n.Bytes())
+
+	bpk := new(BlindedPrivateKey)
+	bpk.blinded = newsec
+	return bpk
+}
+
+func (mypub *PublicKey) Blind(factor [32]byte) *PublicKey {
+	// out <- factor*pkA + zero*Basepoint
+
+	hash_factor_inplace(&factor)
+	factor_sc, _ := new(edwards25519.Scalar).SetBytesWithClamping(factor[:])
+	out, _ := new(edwards25519.Point).SetBytes(mypub.Bytes())
+	newkey := new(PublicKey)
+	err := newkey.FromBytes(out.ScalarMult(factor_sc, out).Bytes())
+	if err != nil {
+		// Again this should not happen; but in case it does:
+		panic(err)
+	}
+	return newkey
+}

--- a/core/crypto/eddsa/blinded25519.go
+++ b/core/crypto/eddsa/blinded25519.go
@@ -86,8 +86,7 @@ func (privateKey *BlindedPrivateKey) Sign(message []byte) [64]byte {
 	mdReduced, _ := new(edwards25519.Scalar).SetUniformBytes(messageDigest[:64])
 
 	// R <- messageDigestReduced * B
-	var encodedR [32]byte
-	copy(encodedR[:], new(edwards25519.Point).ScalarBaseMult(mdReduced).Bytes())
+	encodedR := new(edwards25519.Point).ScalarBaseMult(mdReduced).Bytes()
 
 	// hramDigestReduced := sha512(R || public || message) mod L
 	h.Reset()

--- a/core/crypto/eddsa/blinded25519.go
+++ b/core/crypto/eddsa/blinded25519.go
@@ -121,7 +121,8 @@ func hash_factor_inplace(factor *[32]byte) {
 	// but Scalar.SetBytesWithClamping takes care of that.
 }
 
-// secret.Blind(factor) is secret*factor using unclamped scalar multiplication.
+// secret.Blind(factor) is secret*hash(factor)
+// using unclamped scalar multiplication.
 // This blinding scheme exploits the equivalence of
 // G*(secret*factor) == (G*secret)*factor
 // e.g. secret.Blind(factor).PublicKey() == secret.PublicKey().Blind(factor)
@@ -165,7 +166,7 @@ func (secret *PrivateKey) Blind(factor [32]byte) *BlindedPrivateKey {
 	return bpk
 }
 
-// given (G*secret == mypub) and (factor), compute mypub*factor to enable
+// given (G*secret == mypub) and (factor), compute mypub*hash(factor) to enable
 // verification of blinded signatures.
 func (mypub *PublicKey) Blind(factor [32]byte) *PublicKey {
 	// out <- factor*pkA + zero*Basepoint

--- a/core/crypto/eddsa/blinded25519_test.go
+++ b/core/crypto/eddsa/blinded25519_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io"
+	"bytes"
 	"math/rand"
 	"testing"
 	"testing/quick"
@@ -15,16 +16,14 @@ var identity_element = [32]byte{1, 0}
 func check_public_key(pk *PublicKey) bool {
 	// here we do scalar multiplication with L as the scalar;
 	// the result should be 1 if the public key is valid.
-	var result [32]byte
 	order_64 := [64]byte{0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c,
 		0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}
 	order_sc, _ := new(edwards25519.Scalar).SetUniformBytes(order_64[:])
 	pkA_n, _ := new(edwards25519.Point).SetBytes(pk.Bytes())
 	pkA_n.ScalarMult(order_sc, pkA_n)
-	copy(result[:], pkA_n.Bytes())
 	// non-constant time comparison, only for use in the test suite:
-	return (identity_element == result)
+	return bytes.Equal(pkA_n.Bytes(), identity_element[:])
 }
 
 func bothWork(assertx *assert.Assertions, t require.TestingT, rng io.Reader) bool {

--- a/core/crypto/eddsa/blinded25519_test.go
+++ b/core/crypto/eddsa/blinded25519_test.go
@@ -1,0 +1,133 @@
+package eddsa
+
+import (
+	"filippo.io/edwards25519"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"math/rand"
+	"testing"
+	"testing/quick"
+)
+
+var identity_element = [32]byte{1, 0}
+
+func check_public_key(pk *PublicKey) bool {
+	// here we do scalar multiplication with L as the scalar;
+	// the result should be 1 if the public key is valid.
+	var result [32]byte
+	order_64 := [64]byte{0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c,
+		0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}
+	order_sc, _ := new(edwards25519.Scalar).SetUniformBytes(order_64[:])
+	pkA_n, _ := new(edwards25519.Point).SetBytes(pk.Bytes())
+	pkA_n.ScalarMult(order_sc, pkA_n)
+	copy(result[:], pkA_n.Bytes())
+	// non-constant time comparison, only for use in the test suite:
+	return (identity_element == result)
+}
+
+func bothWork(assertx *assert.Assertions, t require.TestingT, rng io.Reader) bool {
+	assert := assertx
+	unblinded, err := NewKeypair(rng)
+	require.NoError(t, err, "NewKeypair(1)")
+	assert.Equal(true, check_public_key(unblinded.PublicKey()))
+
+	factor := [32]byte{}
+	rng.Read(factor[:])
+	f1_blind_secret := unblinded.Blind(factor)
+	f1_blind_public := unblinded.PublicKey().Blind(factor)
+	f1_derived_public := f1_blind_secret.PublicKey()
+	assert.Equal(f1_blind_public, f1_derived_public)
+
+	// check public keys: multiply by L and verify we get identity element
+	assert.NotEqual(identity_element, unblinded.PublicKey())
+	assert.NotEqual(identity_element, f1_blind_public)
+
+	// Check that using the same factor to blind two different keys
+	// results in distinct secret + public keys (ie we don't always just return
+	// the same secret/public pair)
+	unblinded_x, err := NewKeypair(rng)
+	require.NoError(t, err, "NewKeypair(2)")
+	assert.NotEqual(unblinded_x.Bytes(), unblinded.Bytes())
+	f1_blind_public_x := unblinded_x.PublicKey().Blind(factor)
+	f1_blind_secret_x := unblinded_x.Blind(factor)
+	assert.NotEqual(f1_blind_public, f1_blind_public_x)
+	f1_derived_public_x := f1_blind_secret_x.PublicKey()
+	assert.Equal(f1_blind_public_x, f1_derived_public_x)
+
+	factor2 := [32]byte{}
+	rng.Read(factor2[:])
+	// we just need to ensure that the factors are different,
+	// ie we could copy factor and xor a byte in the range 1..30
+	// note that factor gets clamped, so we can't use[0] or [31] here
+	assert.NotEqual(factor, factor2)
+	f2_blind_secret := unblinded.Blind(factor2)
+	f2_blind_public := unblinded.PublicKey().Blind(factor2)
+	f2_derived_public := f2_blind_secret.PublicKey()
+	assert.Equal(f2_blind_public, f2_derived_public)
+	assert.NotEqual(f2_blind_public, f1_blind_public)
+
+	assert.Equal(true, check_public_key(f1_blind_public))
+	assert.Equal(true, check_public_key(f1_blind_public_x))
+	assert.Equal(true, check_public_key(f2_blind_public))
+
+	// Check signature creation and validation:
+	msg := [5]byte{'a', 'b', 'c', 'd', 'e'}
+	msg_x := [5]byte{'a', 'b', 'c', 'd', 'x'}
+	f1_sig := f1_blind_secret.Sign(msg[:])
+	f2_sig := f2_blind_secret.Sign(msg[:])
+	f1_res1 := f1_blind_public.Verify(f1_sig[:], msg[:])
+	f2_res1 := f2_blind_public.Verify(f2_sig[:], msg[:])
+	assert.Equal(true, f1_res1)
+	assert.Equal(true, f2_res1)
+
+	// signature: (R,s)  ;  check that s < L:
+	// the new edwards25519 library doesn't export ScMinimal (scMinimal),
+	// but it carries the function under the name "isReduced" which is
+	// called from Scalar.SetCanonicalBytes(), so by looking at the (err)
+	// from that we can determine the outcome:
+	// nil | ScMinimal(s) === true
+	// err | ScMinimal(s) === false
+	f1_sig_s := [32]byte{}
+	copy(f1_sig_s[:], f1_sig[32:])
+	// old: assert.Equal(true, edwards25519.ScMinimal(&f1_sig_s))
+	_, scMinimal := new(edwards25519.Scalar).SetCanonicalBytes(f1_sig_s[:])
+	assert.Equal(nil, scMinimal)
+	f2_sig_s := [32]byte{}
+	copy(f2_sig_s[:], f2_sig[32:])
+	_, scMinimal = new(edwards25519.Scalar).SetCanonicalBytes(f2_sig_s[:])
+	//assert.Equal(true, edwards25519.ScMinimal(&f2_sig_s))
+	assert.Equal(nil, scMinimal)
+
+	// Check that giving arguments in wrong order doesn't work:
+	f2_res2_wrong_arg_order := f2_blind_public.Verify(msg[:], f2_sig[:])
+	assert.Equal(false, f2_res2_wrong_arg_order)
+
+	// Check that we can't verify messages with the other's PK:
+	f1_res3 := f1_blind_public.Verify(f2_sig[:], msg[:])
+	f2_res3 := f2_blind_public.Verify(f1_sig[:], msg[:])
+	assert.Equal(false, f1_res3)
+	assert.Equal(false, f2_res3)
+
+	// Check that the signature contains the message:
+	f1_res4 := f1_blind_public.Verify(f1_sig[:], msg_x[:])
+	assert.Equal(false, f1_res4)
+
+	// Checking a random "signature" should obviously fail:
+	random_sig := [64]byte{}
+	f1_res5 := f1_blind_public.Verify(random_sig[:], msg[:])
+	assert.Equal(false, f1_res5)
+
+	return true
+}
+
+func TestBlinding(t *testing.T) {
+	assertx := assert.New(t)
+	rng := rand.New(rand.NewSource(0))
+	config := &quick.Config{Rand: rng}
+	assert_bothwork := func() bool { return bothWork(assertx, t, rng) }
+	if err := quick.Check(assert_bothwork, config); err != nil {
+		t.Error("failed bothwork", err)
+	}
+}

--- a/core/crypto/eddsa/eddsa.go
+++ b/core/crypto/eddsa/eddsa.go
@@ -18,6 +18,7 @@
 package eddsa
 
 import (
+	"crypto/sha512"
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
@@ -29,8 +30,8 @@ import (
 	"os"
 
 	"crypto/ed25519"
+	"filippo.io/edwards25519"
 	"github.com/katzenpost/katzenpost/core/crypto/ecdh"
-	"github.com/katzenpost/katzenpost/core/crypto/extra25519"
 	"github.com/katzenpost/katzenpost/core/utils"
 )
 
@@ -144,13 +145,9 @@ func (k *PublicKey) ToPEMFile(f string) error {
 
 // ToECDH converts the PublicKey to the corresponding ecdh.PublicKey.
 func (k *PublicKey) ToECDH() *ecdh.PublicKey {
-	var dhBytes, dsaBytes [32]byte
-	copy(dsaBytes[:], k.Bytes())
-	defer utils.ExplicitBzero(dsaBytes[:])
-	extra25519.PublicKeyToCurve25519(&dhBytes, &dsaBytes)
-	defer utils.ExplicitBzero(dhBytes[:])
+	ed_pub, _ := new(edwards25519.Point).SetBytes(k.Bytes())
 	r := new(ecdh.PublicKey)
-	r.FromBytes(dhBytes[:])
+	r.FromBytes(ed_pub.BytesMontgomery())
 	return r
 }
 
@@ -238,16 +235,12 @@ func (k *PrivateKey) KeyType() string {
 
 // ToECDH converts the PrivateKey to the corresponding ecdh.PrivateKey.
 func (k *PrivateKey) ToECDH() *ecdh.PrivateKey {
-	var dsaBytes [64]byte
-	defer utils.ExplicitBzero(dsaBytes[:])
-	copy(dsaBytes[:], k.Bytes())
-
-	var dhBytes [32]byte
-	extra25519.PrivateKeyToCurve25519(&dhBytes, &dsaBytes)
-	defer utils.ExplicitBzero(dhBytes[:])
-
+	dhBytes := sha512.Sum512(k.Bytes()[:32])
+	dhBytes[0] &= 248
+	dhBytes[31] &= 127
+	dhBytes[31] |= 64
 	r := new(ecdh.PrivateKey)
-	r.FromBytes(dhBytes[:])
+	r.FromBytes(dhBytes[:32])
 	return r
 }
 

--- a/core/crypto/eddsa/eddsa_test.go
+++ b/core/crypto/eddsa/eddsa_test.go
@@ -72,3 +72,24 @@ func TestEdDSAOps(t *testing.T) {
 	dhPubKey := privKey.PublicKey().ToECDH()
 	assert.True(dhPrivKey.PublicKey().Equal(dhPubKey), "ToECDH() basic sanity")
 }
+
+func TestCheckEdDSA(t *testing.T) {
+	// check that EdDSA signing works like the first test vector in
+	// https://ed25519.cr.yp.to/python/sign.input
+	// (this is a sanity check to ensure (R,s) is computed as it should
+	// as it was non-obvious to me that the nonce is being clamped
+	assert := assert.New(t)
+	vector_signed := [64]byte{229, 86, 67, 0, 195, 96, 172, 114, 144, 134, 226, 204, 128, 110, 130, 138, 132, 135, 127, 30, 184, 229, 217, 116, 216, 115, 224, 101, 34, 73, 1, 85, 95, 184, 130, 21, 144, 163, 59, 172, 198, 30, 57, 112, 28, 249, 180, 107, 210, 91, 245, 240, 89, 91, 190, 36, 101, 81, 65, 67, 142, 122, 16, 11}
+	tsk := [64]byte{157, 97, 177, 157, 239, 253, 90, 96, 186, 132, 74, 244, 146, 236, 44, 196, 68, 73, 197, 105, 123, 50, 105, 25, 112, 59, 172, 3, 28, 174, 127, 96, 215, 90, 152, 1, 130, 177, 10, 183, 213, 75, 254, 211, 201, 100, 7, 58, 14, 225, 114, 243, 218, 166, 35, 37, 175, 2, 26, 104, 247, 7, 81, 26}
+	tpk := [32]byte{215, 90, 152, 1, 130, 177, 10, 183, 213, 75, 254, 211, 201, 100, 7, 58, 14, 225, 114, 243, 218, 166, 35, 37, 175, 2, 26, 104, 247, 7, 81, 26}
+	rsk := new(PrivateKey)
+	rsk.FromBytes(tsk[:])
+	assert.Equal(tpk[:], rsk.PublicKey().Bytes())
+	actual_signed := rsk.Sign([]byte{})
+	assert.Equal(vector_signed[:], actual_signed)
+	verify_res := rsk.PublicKey().Verify(vector_signed[:], []byte{})
+	assert.Equal(true, verify_res)
+	// and 1 was NOT the message, so that shouldn't check out:
+	verify_res = rsk.PublicKey().Verify(vector_signed[:], []byte{1})
+	assert.Equal(false, verify_res)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/katzenpost/katzenpost
 go 1.16
 
 require (
+	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
 	github.com/BurntSushi/toml v0.4.1
 	github.com/awnumar/memguard v0.22.2
 	github.com/cockroachdb/apd v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+filippo.io/edwards25519 v1.0.0-rc.1 h1:m0VOOB23frXZvAOK44usCgLWvtsxIoMCTBGJZlpmGfU=
+filippo.io/edwards25519 v1.0.0-rc.1/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
This is a port of the scheme used by Tor. It will be useful as a building block
for features that are supposed to be unlinkable-to-some-but-not-everybody, where
we can use it to derive spool IDs and other identifiers asynchronously.