### PR TITLE
Make SignDocument use certificate expirate derived from epoch base

### DIFF
--- a/authority/internal/s11n/descriptor_test.go
+++ b/authority/internal/s11n/descriptor_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/katzenpost/katzenpost/core/wire"
 )
 
-const debugTestEpoch = 0x23
+const debugTestEpoch = 0xFFFFFFFF
 
 func TestDescriptor(t *testing.T) {
 	assert := assert.New(t)

--- a/authority/internal/s11n/document.go
+++ b/authority/internal/s11n/document.go
@@ -99,7 +99,7 @@ func SignDocument(signer cert.Signer, d *Document) ([]byte, error) {
 	}
 
 	// Sign the document.
-	expiration := time.Now().Add(CertificateExpiration).Unix()
+	expiration := epochtime.Epoch.Add(time.Duration(d.Epoch+1) * epochtime.Period).Unix()
 	return cert.Sign(signer, payload, expiration)
 }
 


### PR DESCRIPTION
Fixes an issue where signatures may not agree due to differences in expiration time.

This should be validated with integration tests before merging