### PR TITLE
This PR fixes a few more blocking channel operations in minclient and catshadow

### DIFF
--- a/minclient/connection.go
+++ b/minclient/connection.go
@@ -763,6 +763,9 @@ func (c *connection) getConsensus(ctx context.Context, epoch uint64) (*commands.
 			c.log.Debugf("Failed to dispatch GetConsensus: %v", err)
 			return nil, err
 		}
+	case <-ctx.Done():
+		// Canceled mid-fetch.
+		return nil, errGetConsensusCanceled
 	}
 
 	// Wait for the dispatch to complete.

--- a/minclient/connection.go
+++ b/minclient/connection.go
@@ -228,6 +228,12 @@ func (c *connection) connectWorker() {
 				timerFired = true
 			}
 		}
+
+		select {
+		case <-c.HaltCh():
+			return
+		default:
+		}
 		if !timerFired && !timer.Stop() {
 			select {
 			case <-c.HaltCh():


### PR DESCRIPTION
In each case, a channel read or write is wrapped in a select along with the halt channel so that it can halt; for the catshadow API methods, a requested shutdown would block API methods from returning.