### PR TITLE
Add pem helper

### DIFF
--- a/authority/Makefile
+++ b/authority/Makefile
@@ -28,7 +28,13 @@ build-voting:
 	cd ../sphincsplus/ref/ && make && cd ../../authority
 	cd cmd/voting; go build -ldflags ${ldflags}
 
+install-voting: build-voting
+	cd cmd/voting; go install -ldflags ${ldflags}
+
 build-nonvoting:
 	go mod verify
 	cd ../sphincsplus/ref/ && make && cd ../../authority
 	cd cmd/nonvoting; go build -ldflags ${ldflags}
+
+install-nonvoting:
+	cd cmd/nonvoting; go install -ldflags ${ldflags}

--- a/authority/Makefile
+++ b/authority/Makefile
@@ -1,3 +1,6 @@
+warped?=false
+ldflags="-X github.com/katzenpost/katzenpost/core/epochtime.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/server/internal/pki.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/minclient/pki.WarpedEpoch=${warped}"
+
 test:
 	go test -cover -v ./...
 
@@ -19,3 +22,13 @@ coverage-file:
 
 coverage-html:
 	go tool cover -html=coverage.out
+
+build-voting:
+	go mod verify
+	cd ../sphincsplus/ref/ && make && cd ../../authority
+	cd cmd/voting; go build -ldflags ${ldflags}
+
+build-nonvoting:
+	go mod verify
+	cd ../sphincsplus/ref/ && make && cd ../../authority
+	cd cmd/nonvoting; go build -ldflags ${ldflags}

--- a/authority/README.rst
+++ b/authority/README.rst
@@ -23,9 +23,7 @@ For more info about go-modules, see: https://github.com/golang/go/wiki/Modules
 Build the mix server like this:
 ::
 
-  export GO111MODULE=on
-  cd cmd/voting # (or cmd/nonvoting)
-  go build
+  make build-voting # (or make build-nonvoting)
 
 
 license

--- a/authority/cmd/nonvoting/authority.toml.sample
+++ b/authority/cmd/nonvoting/authority.toml.sample
@@ -8,7 +8,7 @@
 
   # Addresses are the IP address/port combinations that the authority will bind
   # to for incoming connections.
-  Addresses = [ "172.28.1.2:29483", "[2001:DB8::1]:29483" ]
+  Addresses = [ "127.0.0.1:29483", "[::1]:29483" ]
 
   # DataDir is the absolute path to the server's state files.
   # Must have 700 permissions.
@@ -81,15 +81,15 @@
   # IdentityKey is the node's EdDSA signing key, in either Base16 OR Base64
   # format.
   # mix1
-  IdentityKey = "4r9jePAbuzhytcnM3nbD5UQOmzl1X1hI8QOMbhTrg8s="
+  IdentityPublicKeyPem = "mix1_id_pub.pem"
 
 [[Mixes]]
   # mix2
-  IdentityKey = "1x8tq04hY+i83o9Yn2nrfTkFj4jXIMWCWilR7fgrWyM="
+  IdentityPublicKeyPem = "mix2_id_pub.pem"
 
 [[Mixes]]
   # mix3
-  IdentityKey = "La2FnsbKoU8dzQhfN4zkxSYn6T7LRWmFn0JgtlEklQw="
+  IdentityPublicKeyPem = "mix3_id_pub.pem"
 
 #
 # The Providers array defines the list of white-listed Provider nodes.
@@ -100,10 +100,8 @@
   Identifier = "provider2"
   # IdentityKey is the provider's EdDSA signing key, in either Base16 OR Base64
   # format.
-  IdentityKey = "imigzI26tTRXyYLXujLEPI9QrNYOEgC4DElsFdP9acQ="
+  IdentityPublicKeyPem = "provider2_id_pub.pem"
 
 [[Providers]]
   Identifier = "provider1"
-  IdentityKey = "2krwfNDfbakZCSTUUZYKXwdduzlEgS9Jfwm7eyZ0sCg="
-
-
+  IdentityPublicKeyPem = "provider1_id_pub.pem"

--- a/authority/cmd/voting/authority.toml.sample
+++ b/authority/cmd/voting/authority.toml.sample
@@ -98,15 +98,15 @@
   # mix1
   # IdentityKey is the node's EdDSA signing key, in either Base16 OR Base64
   # format.
-  IdentityKeyPem = "mix1_id_pub.pem"
+  IdentityPublicKeyPem = "mix1_id_pub.pem"
 
 [[Mixes]]
   # mix2
-  IdentityKeyPem = "mix2_id_pub.pem"
+  IdentityPublicKeyPem = "mix2_id_pub.pem"
 
 [[Mixes]]
   # mix3
-  IdentityKeyPem = "mix3_id_pub.pem"
+  IdentityPublicKeyPem = "mix3_id_pub.pem"
 
 #
 # The Providers array defines the list of white-listed Provider nodes.
@@ -114,25 +114,25 @@
 
 [[Providers]]
   Identifier = "provider2"
-  IdentityKeyPem = "provider2_id_pub.pem"
+  IdentityPublicKeyPem = "provider2_id_pub.pem"
 
 [[Providers]]
   Identifier = "provider1"
-  IdentityKeyPem = "provider1_id_pub.pem"
+  IdentityPublicKeyPem = "provider1_id_pub.pem"
 
 # Topology defines the layers of mix nodes
 [Topology]
 # Layer 1
 [[Topology.Layers]]
 [[Topology.Layers.Nodes]]
-  IdentityKeyPem = "mix1_id_pub.pem"
+  IdentityPublicKeyPem = "mix1_id_pub.pem"
 
 # Layer 2
 [[Topology.Layers]]
 [[Topology.Layers.Nodes]]
-  IdentityKeyPem = "mix2_id_pub.pem"
+  IdentityPublicKeyPem = "mix2_id_pub.pem"
 
 # Layer 3
 [[Topology.Layers]]
 [[Topology.Layers.Nodes]]
-  IdentityKeyPem = "mix3_id_pub.pem"
+  IdentityPublicKeyPem = "mix3_id_pub.pem"

--- a/authority/nonvoting/server/config/config.go
+++ b/authority/nonvoting/server/config/config.go
@@ -281,8 +281,8 @@ type Node struct {
 	// the node is a Provider.
 	Identifier string
 
-	// IdentityKeyPem is the node's identity signing key pem file path.
-	IdentityKeyPem string
+	// IdentityPublicKeyPem is the node's identity signing key pem file path.
+	IdentityPublicKeyPem string
 }
 
 func (n *Node) validate(isProvider bool) error {
@@ -300,8 +300,8 @@ func (n *Node) validate(isProvider bool) error {
 	} else if n.Identifier != "" {
 		return fmt.Errorf("config: %v: Node has Identifier set", section)
 	}
-	if n.IdentityKeyPem == "" {
-		return fmt.Errorf("config: %v: Node is missing IdentityKeyPem", section)
+	if n.IdentityPublicKeyPem == "" {
+		return fmt.Errorf("config: %v: Node is missing IdentityPublicKeyPem", section)
 	}
 	return nil
 }
@@ -372,13 +372,13 @@ func (cfg *Config) FixupAndValidate() error {
 	pkMap := make(map[[publicKeyHashSize]byte]*Node)
 	for _, v := range allNodes {
 		_, idkey := cert.Scheme.NewKeypair()
-		err := pem.FromFile(filepath.Join(cfg.Authority.DataDir, v.IdentityKeyPem), idkey)
+		err := pem.FromFile(filepath.Join(cfg.Authority.DataDir, v.IdentityPublicKeyPem), idkey)
 		if err != nil {
 			return err
 		}
 		idKeyHash := idkey.Sum256()
 		if _, ok := pkMap[idKeyHash]; ok {
-			return fmt.Errorf("config: Nodes: IdentityKey '%v' is present more than once", v.IdentityKeyPem)
+			return fmt.Errorf("config: Nodes: IdentityKey '%v' is present more than once", v.IdentityPublicKeyPem)
 		}
 		pkMap[idKeyHash] = v
 	}

--- a/authority/nonvoting/server/state.go
+++ b/authority/nonvoting/server/state.go
@@ -681,7 +681,7 @@ func newState(s *Server) (*state, error) {
 	st.authorizedMixes = make(map[[sign.PublicKeyHashSize]byte]bool)
 	for _, v := range st.s.cfg.Mixes {
 		_, idKey := cert.Scheme.NewKeypair()
-		err := pem.FromFile(filepath.Join(s.cfg.Authority.DataDir, v.IdentityKeyPem), idKey)
+		err := pem.FromFile(filepath.Join(s.cfg.Authority.DataDir, v.IdentityPublicKeyPem), idKey)
 		if err != nil {
 			return nil, err
 		}
@@ -692,7 +692,7 @@ func newState(s *Server) (*state, error) {
 	st.authorizedProviders = make(map[[sign.PublicKeyHashSize]byte]string)
 	for _, v := range st.s.cfg.Providers {
 		_, idKey := cert.Scheme.NewKeypair()
-		err := pem.FromFile(filepath.Join(s.cfg.Authority.DataDir, v.IdentityKeyPem), idKey)
+		err := pem.FromFile(filepath.Join(s.cfg.Authority.DataDir, v.IdentityPublicKeyPem), idKey)
 		if err != nil {
 			return nil, err
 		}

--- a/authority/voting/server/config/config.go
+++ b/authority/voting/server/config/config.go
@@ -420,7 +420,7 @@ func (cfg *Config) FixupAndValidate() error {
 	_, identityKey := cert.Scheme.NewKeypair()
 	pkMap := make(map[[publicKeyHashSize]byte]*Node)
 	for _, v := range allNodes {
-		err := pem.FromFile(filepath.Join(cfg.Authority.DataDir, v.IdentityPublicKeyPem), identityKey)
+		err := cfg.PubKeyFromPEM(v.IdentityPublicKeyPem, identityKey)
 		if err != nil {
 			return err
 		}
@@ -439,6 +439,25 @@ func (cfg *Config) FixupAndValidate() error {
 		}
 	}
 
+	return nil
+}
+
+// helper to parse PEM encoded data or files
+func (cfg *Config) PubKeyFromPEM(pemthing string, pubKey pem.KeyMaterial) error {
+	if filepath.IsAbs(pemthing) {
+		err := pem.FromFile(pemthing, pubKey)
+		if err == nil {
+			return err
+		}
+	}
+	pemFilePath := filepath.Join(cfg.Authority.DataDir, pemthing)
+	err := pem.FromFile(pemFilePath, pubKey)
+	if err != nil {
+		err = pem.FromPEMString(pemthing, pubKey)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/authority/voting/server/server.go
+++ b/authority/voting/server/server.go
@@ -204,17 +204,17 @@ func New(cfg *config.Config) (*Server, error) {
 	}
 
 	// Initialize the authority identity key.
-	identityPrivateKeyFile := filepath.Join(s.cfg.Authority.DataDir, "identity.private.pem")
-	identityPublicKeyFile := filepath.Join(s.cfg.Authority.DataDir, "identity.public.pem")
+	identityPrivateKeyFile := "identity.private.pem"
+	identityPublicKeyFile := "identity.public.pem"
 
 	s.identityPrivateKey, s.identityPublicKey = cert.Scheme.NewKeypair()
 	var err error
 	if pem.BothExists(identityPrivateKeyFile, identityPublicKeyFile) {
-		err = pem.FromFile(identityPrivateKeyFile, s.identityPrivateKey)
+		err = s.cfg.PubKeyFromPEM(identityPrivateKeyFile, s.identityPrivateKey)
 		if err != nil {
 			return nil, err
 		}
-		err = pem.FromFile(identityPublicKeyFile, s.identityPublicKey)
+		err = s.cfg.PubKeyFromPEM(identityPublicKeyFile, s.identityPublicKey)
 		if err != nil {
 			return nil, err
 		}
@@ -232,8 +232,8 @@ func New(cfg *config.Config) (*Server, error) {
 	}
 
 	scheme := wire.DefaultScheme
-	linkPrivateKeyFile := filepath.Join(s.cfg.Authority.DataDir, "link.private.pem")
-	linkPublicKeyFile := filepath.Join(s.cfg.Authority.DataDir, "link.public.pem")
+	linkPrivateKeyFile := "link.private.pem"
+	linkPublicKeyFile := "link.public.pem"
 
 	var linkPrivateKey wire.PrivateKey = nil
 	var linkPublicKey wire.PublicKey = nil

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -64,7 +64,7 @@ server: deps
 voting_authority: deps
 	if ! docker images|grep katzenpost/voting_authority; then \
 		docker run ${docker_args} --name katzenpost_voting_authority katzenpost/deps \
-			bash -c 'cd authority && make install-voting' \
+			bash -c 'cd authority && warped=${warped} make install-voting' \
 		&& docker commit katzenpost_voting_authority katzenpost/voting_authority \
 		&& docker rm katzenpost_voting_authority; \
         fi
@@ -72,7 +72,7 @@ voting_authority: deps
 nonvoting_authority: deps
 	if ! docker images|grep katzenpost/nonvoting_authority; then \
 		docker run ${docker_args} --name katzenpost_nonvoting_authority katzenpost/deps \
-			bash -c 'cd authority/cmd/nonvoting && make install-nonvoting' \
+			bash -c 'cd authority/cmd/nonvoting && warped=${warped} make install-nonvoting' \
 		&& docker commit katzenpost_nonvoting_authority katzenpost/nonvoting_authority \
 		&& docker rm katzenpost_nonvoting_authority; \
         fi

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -64,7 +64,7 @@ server: deps
 voting_authority: deps
 	if ! docker images|grep katzenpost/voting_authority; then \
 		docker run ${docker_args} --name katzenpost_voting_authority katzenpost/deps \
-			bash -c 'cd authority/cmd/voting && go mod verify && go install -ldflags ${ldflags}' \
+			bash -c 'cd authority && make install-voting' \
 		&& docker commit katzenpost_voting_authority katzenpost/voting_authority \
 		&& docker rm katzenpost_voting_authority; \
         fi
@@ -72,7 +72,7 @@ voting_authority: deps
 nonvoting_authority: deps
 	if ! docker images|grep katzenpost/nonvoting_authority; then \
 		docker run ${docker_args} --name katzenpost_nonvoting_authority katzenpost/deps \
-			bash -c 'cd authority/cmd/nonvoting && go mod verify && go install -ldflags ${ldflags}' \
+			bash -c 'cd authority/cmd/nonvoting && make install-nonvoting' \
 		&& docker commit katzenpost_nonvoting_authority katzenpost/nonvoting_authority \
 		&& docker rm katzenpost_nonvoting_authority; \
         fi

--- a/docker/voting_mixnet/conf/auth1/authority.toml
+++ b/docker/voting_mixnet/conf/auth1/authority.toml
@@ -171,7 +171,11 @@ J36qY23I6qGScGjq4tPu3w==
 
 [[Mixes]]
   # mix1
-  IdentityPublicKeyPem = "mix1_id_pub_key.pem"
+  IdentityPublicKeyPem = """-----BEGIN ED25519 SPHINCS+ PUBLIC KEY-----
+2JQzwEwGBxBkQ0quWab4MD2T3E/WozBsfAMzp9wDLDaSm4jMADucY0gHAxX08iM3
+e/o5l00d9jhM5Gr51yY5FT8acP8IdPeDS1ccwW1HTpmAWMQOJyZwvo9jwiog9IVq
+-----END ED25519 SPHINCS+ PUBLIC KEY-----
+"""
 
 [[Mixes]]
   # mix2

--- a/server/Makefile
+++ b/server/Makefile
@@ -19,3 +19,6 @@ build:
 	go mod verify
 	cd ../sphincsplus/ref/ && make && cd ../../server
 	cd cmd/server ; go build -ldflags ${ldflags}
+
+install: build
+	cd cmd/server ; go install -ldflags ${ldflags}

--- a/server/Makefile
+++ b/server/Makefile
@@ -15,3 +15,7 @@ testnet-install:
 	cp /go/katzenpost/reunion/servers/reunion_katzenpost_server/reunion_katzenpost_server /go/bin/reunion_katzenpost_server
 	cp /go/katzenpost/panda/server/cmd/panda_server/panda_server /go/bin/panda_server
 	cp /go/katzenpost/server_plugins/cbor_plugins/echo-go/echo_server /go/bin/echo_server
+build:
+	go mod verify
+	cd ../sphincsplus/ref/ && make && cd ../../server
+	cd cmd/server ; go build -ldflags ${ldflags}

--- a/server/README.rst
+++ b/server/README.rst
@@ -18,9 +18,7 @@ For more info on go-modules, see: https://github.com/golang/go/wiki/Modules
 Build the mix server like this:
 ::
 
-  export GO111MODULE=on
-  cd cmd/server
-  go build
+  make build
 
 
 

--- a/server/cmd/server/katzenpost.toml.sample
+++ b/server/cmd/server/katzenpost.toml.sample
@@ -69,12 +69,12 @@
     Disable = false
 
   # Here's an example external Kaetzchen service plugin config
-  [[Provider.PluginKaetzchen]]
-    Capability = "echo"
-    Endpoint = "+echo"
-    Disable = false
-    Command = "/var/lib/katzenpost/plugins/echo"
-    MaxConcurrency = 3
+  #[[Provider.CBORPluginKaetzchen]]
+  #  Capability = "echo"
+  #  Endpoint = "+echo"
+  #  Disable = false
+  #  Command = "/var/lib/katzenpost/plugins/echo"
+  #  MaxConcurrency = 3
 
   # UserDB is the user database configuration.  If left empty the simple
   # BoltDB backed user database will be used with the default database.


### PR DESCRIPTION
This PR adds a helper to authority so that PEM files or PEM-encoded strings can be used with the configuration.

I might need to add another helper for the mix server as well.