### PR TITLE
Extend MixDescriptor certificate expiration to 3 epochs

### DIFF
--- a/authority/internal/s11n/descriptor.go
+++ b/authority/internal/s11n/descriptor.go
@@ -120,9 +120,9 @@ func SignDescriptor(signer cert.Signer, verifier cert.Verifier, base *pki.MixDes
 		return nil, err
 	}
 
-	// Sign the descriptor.
+	// Sign the descriptor. Descriptor will become valid in the next epoch, for 3 epochs.
 	epoch, _, _ := epochtime.Now()
-	signed, err := cert.Sign(signer, verifier, payload, epoch+2)
+	signed, err := cert.Sign(signer, verifier, payload, epoch+4)
 	if err != nil {
 		return nil, err
 	}

--- a/authority/internal/s11n/document.go
+++ b/authority/internal/s11n/document.go
@@ -98,7 +98,7 @@ func SignDocument(signer cert.Signer, verifier cert.Verifier, d *Document) ([]by
 	}
 
 	// Sign the document.
-	return cert.Sign(signer, verifier, payload, d.Epoch+1)
+	return cert.Sign(signer, verifier, payload, d.Epoch+4)
 }
 
 // MultiSignDocument signs and serializes the document with the provided signing key, adding the signature to the existing signatures.
@@ -113,7 +113,7 @@ func MultiSignDocument(signer cert.Signer, verifier cert.Verifier, peerSignature
 	}
 
 	// Sign the document.
-	signed, err := cert.Sign(signer, verifier, payload, d.Epoch+1)
+	signed, err := cert.Sign(signer, verifier, payload, d.Epoch+4)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The next epoch the descriptor becomes valid, and contains 3 epochs worth of MixKeys, so it should be valid for current epoch + 4

See #83

