### PR TITLE
Fix allowlist bug

### DIFF
--- a/authority/voting/server/state.go
+++ b/authority/voting/server/state.go
@@ -847,8 +847,10 @@ func (s *state) tallyVotes(epoch uint64) ([]*descriptor, *config.Parameters, err
 				return nil, nil, err
 			}
 
-			// XXX: this should verify that the descriptor is in our whitelist, but it doesn't.
-			nodes = append(nodes, &descriptor{desc: desc, raw: []byte(rawDesc)})
+			// only add nodes we have authorized
+			if s.isDescriptorAuthorized(desc) {
+				nodes = append(nodes, &descriptor{desc: desc, raw: []byte(rawDesc)})
+			}
 		}
 	}
 	// include parameters that have a threshold of votes

--- a/authority/voting/server/state.go
+++ b/authority/voting/server/state.go
@@ -182,9 +182,11 @@ func (s *state) fsm() <-chan time.Time {
 		if s.genesisEpoch == 0 {
 			// Is there a prior consensus? If so, obtain the GenesisEpoch and prior SRV values
 			if d, ok := s.documents[s.votingEpoch-1]; ok {
+				s.log.Debugf("Restoring genesisEpoch %d from document cache", d.doc.GenesisEpoch)
 				s.genesisEpoch = d.doc.GenesisEpoch
 				s.priorSRV = d.doc.PriorSharedRandom
 			} else {
+				s.log.Debugf("Setting genesisEpoch %d from votingEpoch", s.votingEpoch)
 				s.genesisEpoch = s.votingEpoch
 			}
 		}
@@ -476,6 +478,14 @@ func (s *state) vote(epoch uint64) (*document, error) {
 		return nil, err
 	}
 
+
+	// we need to do this because our stupid duplication of formats everywhere
+	ourvote, err := s11n.VerifyAndParseDocument(signedVote.raw, s.verifiers[s.s.identityPublicKey.Sum256()])
+	if err != nil {
+		panic(err)
+	}
+
+	s.log.Debugf("Ready to send our vote:\n%s", ourvote)
 	// save our own vote
 	if _, ok := s.votes[epoch]; !ok {
 		s.votes[epoch] = make(map[[publicKeyHashSize]byte]*document)
@@ -927,7 +937,13 @@ func (s *state) tabulate(epoch uint64) ([]byte, error) {
 	}
 	s.certificates[epoch][s.identityPubKeyHash()] = signed
 	if raw, err := cert.GetCertified(signed); err == nil {
-		s.log.Debugf("Document for epoch %v saved", epoch)
+
+		// we need to do this because our stupid duplication of formats everywhere
+		ourvote, err := s11n.VerifyAndParseDocument(signed, s.verifiers[s.s.identityPublicKey.Sum256()])
+		if err != nil {
+			panic(err)
+		}
+		s.log.Debugf("Ready to send our vote:\n%s", ourvote)
 		s.log.Debugf("sha256(certified): %s", sha256b64(raw))
 	}
 	return signed, nil
@@ -1245,11 +1261,12 @@ func (s *state) onVoteUpload(vote *commands.Vote) commands.Command {
 			raw: vote.Payload,
 			doc: doc,
 		}
-		s.log.Debug("Vote OK.")
+		s.log.Debug("Vote OK from:\n%x\n%s", vote.PublicKey.Sum256(), doc)
 		resp.ErrorCode = commands.VoteOk
 	} else {
 		// peer has voted previously, and has not yet submitted a signature
 		if !s.dupSig(*vote) {
+			s.log.Debug("Consensus from:\n%x\n%s", vote.PublicKey.Sum256(), doc)
 			s.certificates[s.votingEpoch][vote.PublicKey.Sum256()] = vote.Payload
 			if raw, err := cert.GetCertified(vote.Payload); err == nil {
 				s.log.Debugf("Certificate for epoch %v saved", vote.Epoch)

--- a/core/pki/pki.go
+++ b/core/pki/pki.go
@@ -118,17 +118,6 @@ type Document struct {
 
 // String returns a string representation of a Document.
 func (d *Document) String() string {
-	stringifyDescSlice := func(nodes []*MixDescriptor) string {
-		s := ""
-		for idx, v := range nodes {
-			s += fmt.Sprintf("%+v", v)
-			if idx != len(nodes)-1 {
-				s += ","
-			}
-		}
-		return s
-	}
-
 	srv := base64.StdEncoding.EncodeToString(d.SharedRandomValue)
 	psrv := "["
 	for i, p := range d.PriorSharedRandom {
@@ -139,17 +128,15 @@ func (d *Document) String() string {
 	}
 	psrv += "]"
 
-	s := fmt.Sprintf("&{Epoch:%v GenesisEpoch: %v SendRatePerMinute: %v Mu: %v MuMaxDelay: %v LambdaP:%v LambdaPMaxDelay:%v LambdaL:%v LambdaLMaxDelay:%v LambdaD:%v LambdaDMaxDelay:%v LambdaM: %v LambdaMMaxDelay: %v SharedRandomValue: %v PriorSharedRandom: %v Topology:", d.Epoch, d.GenesisEpoch, d.SendRatePerMinute, d.Mu, d.MuMaxDelay, d.LambdaP, d.LambdaPMaxDelay, d.LambdaL, d.LambdaLMaxDelay, d.LambdaD, d.LambdaDMaxDelay, d.LambdaM, d.LambdaMMaxDelay, srv, psrv)
+	s := fmt.Sprintf("&{Epoch: %v GenesisEpoch: %v\nSendRatePerMinute: %v Mu: %v MuMaxDelay: %v LambdaP:%v LambdaPMaxDelay:%v LambdaL:%v LambdaLMaxDelay:%v LambdaD:%v LambdaDMaxDelay:%v LambdaM: %v LambdaMMaxDelay: %v\nSharedRandomValue: %v PriorSharedRandom: %v\nTopology:\n", d.Epoch, d.GenesisEpoch, d.SendRatePerMinute, d.Mu, d.MuMaxDelay, d.LambdaP, d.LambdaPMaxDelay, d.LambdaL, d.LambdaLMaxDelay, d.LambdaD, d.LambdaDMaxDelay, d.LambdaM, d.LambdaMMaxDelay, srv, psrv)
 	for l, nodes := range d.Topology {
-		s += fmt.Sprintf("[%v]{", l)
-		s += stringifyDescSlice(nodes)
-		if l != len(nodes)-1 {
-			s += "},"
-		}
+		s += fmt.Sprintf("  [%v]{", l)
+		s += fmt.Sprintf("%v",nodes)
+		s += "}\n"
 	}
 
-	s += "}, Providers:[]{"
-	s += stringifyDescSlice(d.Providers)
+	s += "}\n"
+	s += fmt.Sprintf("Providers:[]{%v}", d.Providers)
 	s += "}}"
 	return s
 }
@@ -296,6 +283,17 @@ type MixDescriptor struct {
 
 	// AuthenticationType is the authentication mechanism required
 	AuthenticationType string
+}
+
+// String returns a human readable MixDescriptor
+func (d *MixDescriptor) String() string {
+	k := ""
+	if len(d.Kaetzchen) > 0 {
+		k = fmt.Sprintf("%v", d.Kaetzchen)
+	}
+		
+	return fmt.Sprintf("{%s %v %v %s}",
+	d.Name, d.Addresses, k, d.AuthenticationType)
 }
 
 // Client is the abstract interface used for PKI interaction.

--- a/core/pki/pki.go
+++ b/core/pki/pki.go
@@ -285,15 +285,17 @@ type MixDescriptor struct {
 	AuthenticationType string
 }
 
-// String returns a human readable MixDescriptor
+// String returns a human readable MixDescriptor suitable for terse logging.
 func (d *MixDescriptor) String() string {
-	k := ""
+	kaetzchen := ""
 	if len(d.Kaetzchen) > 0 {
-		k = fmt.Sprintf("%v", d.Kaetzchen)
+		kaetzchen = fmt.Sprintf("%v", d.Kaetzchen)
 	}
-		
-	return fmt.Sprintf("{%s %v %v %s}",
-	d.Name, d.Addresses, k, d.AuthenticationType)
+	bs := d.IdentityKey.Sum256()
+	identity := base64.StdEncoding.EncodeToString(bs[:])
+	s := fmt.Sprintf("{%s %s %v", d.Name, identity, d.Addresses)
+	s += kaetzchen + d.AuthenticationType + "}"
+	return s
 }
 
 // Client is the abstract interface used for PKI interaction.


### PR DESCRIPTION
This adds some extra verbose logging to the voting authority and fixes a bug where MixDescriptors sent by another authority were included in consensus without checking that they were authorized.