### PR TITLE
Add CreateRemoteSpoolOn(provider), GetPKIDocument(), GetSpoolProviders(), SpoolWriteDescriptor()  to catshadow

### DIFF
--- a/catshadow/client.go
+++ b/catshadow/client.go
@@ -527,7 +527,7 @@ func (c *Client) doCreateRemoteSpool(provider string, responseChan chan error) {
 			return
 		}
 		for _, d := range descs {
-			if d.Name == provider {
+			if d.Provider == provider {
 				desc = d
 				break
 			}

--- a/catshadow/client.go
+++ b/catshadow/client.go
@@ -1721,6 +1721,24 @@ func (c *Client) Offline() error {
 	return <-r
 }
 
+// SpoolWriteDescriptor() returns the SpoolWriteDescriptor for this client or nil
+func (c *Client) SpoolWriteDescriptor() *memspoolclient.SpoolWriteDescriptor {
+	r := make(chan *memspoolclient.SpoolWriteDescriptor, 1)
+	select {
+	case c.opCh <- &opSpoolWriteDescriptor{responseChan: r}:
+	case <-c.HaltCh():
+	}
+	return <-r
+}
+
+func (c *Client) getSpoolWriteDescriptor() *memspoolclient.SpoolWriteDescriptor {
+	if c.spoolReadDescriptor == nil {
+		return nil
+	} else {
+		return c.spoolReadDescriptor.GetWriteDescriptor()
+	}
+}
+
 // goOffline is called by worker routine when a goOffline is received
 func (c *Client) goOffline() error {
 	c.connMutex.Lock()

--- a/catshadow/client.go
+++ b/catshadow/client.go
@@ -60,7 +60,9 @@ var (
 	errProviderNotFound       = errors.New("Cannot find provider")
 	errBlobNotFound           = errors.New("Blob not found in store")
 	errNoSpool                = errors.New("No Spool Found")
+	errNotOnline              = errors.New("Client is not online")
 	errAlreadyHaveKeyExchange = errors.New("Already created KeyExchange with contact")
+	errHalted                 = errors.New("Halted")
 	pandaBlobSize             = 1000
 )
 
@@ -377,12 +379,12 @@ func (c *Client) CreateRemoteSpoolOn(provider string) error {
 	}
 	select {
 	case <-c.HaltCh():
-		return errors.New("Halted")
+		return errHalted
 	case c.opCh <- createSpoolOp:
 	}
 	select {
 	case <-c.HaltCh():
-		return errors.New("Halted")
+		return errHalted
 	case r := <-createSpoolOp.responseChan:
 		return r
 	}
@@ -397,12 +399,12 @@ func (c *Client) CreateRemoteSpool() error {
 	}
 	select {
 	case <-c.HaltCh():
-		return errors.New("Halted")
+		return errHalted
 	case c.opCh <- createSpoolOp:
 	}
 	select {
 	case <-c.HaltCh():
-		return errors.New("Halted")
+		return errHalted
 	case r := <-createSpoolOp.responseChan:
 		return r
 	}
@@ -417,7 +419,7 @@ func (c *Client) doCreateRemoteSpool(provider string, responseChan chan error) {
 		return
 	}
 	if !c.online {
-		responseChan <- errors.New("Client is not online")
+		responseChan <- errNotOnline
 		return
 	}
 	var desc *cUtils.ServiceDescriptor
@@ -769,7 +771,7 @@ func (c *Client) GetExpiration(name string) (time.Duration, error) {
 
 	select {
 	case <-c.HaltCh():
-		return 0, errors.New("Halted")
+		return 0, errHalted
 	case v := <-getExpirationOp.responseChan:
 		switch v := v.(type) {
 		case error:
@@ -1382,7 +1384,7 @@ func (c *Client) WipeConversation(nickname string) error {
 	case r := <-wipeConversationOp.responseChan:
 		return r
 	}
-	return errors.New("Halted")
+	return errHalted
 }
 
 func (c *Client) doWipeConversation(nickname string) error {

--- a/catshadow/client_docker_test.go
+++ b/catshadow/client_docker_test.go
@@ -547,7 +547,7 @@ func TestDockerChangeExpiration(t *testing.T) {
 	require.NoError(err)
 	require.Equal(exp, time.Duration(123))
 	_, err = a.GetExpiration("c")
-	require.Error(err, errContactNotFound)
+	require.Error(err, ErrContactNotFound)
 
 }
 
@@ -626,7 +626,7 @@ loop4:
 
 	t.Log("Removing contact b again, checking for err")
 	err = a.RemoveContact("b")
-	require.Error(err, errContactNotFound)
+	require.Error(err, ErrContactNotFound)
 
 	c := a.conversations["b"]
 	require.Equal(len(c), 0)

--- a/catshadow/client_test.go
+++ b/catshadow/client_test.go
@@ -78,6 +78,6 @@ func TestBlobStorage(t *testing.T) {
 	err = cs.DeleteBlob("foo")
 	require.NoError(err)
 	_, err = cs.GetBlob("foo")
-	require.Error(err, errBlobNotFound)
+	require.Error(err, ErrBlobNotFound)
 	stateWorker.Halt()
 }

--- a/catshadow/operations.go
+++ b/catshadow/operations.go
@@ -95,3 +95,7 @@ type opWipeConversation struct {
 type opGetPKIDocument struct {
 	responseChan chan interface{}
 }
+
+type opGetSpoolProviders struct {
+	responseChan chan interface{}
+}

--- a/catshadow/operations.go
+++ b/catshadow/operations.go
@@ -99,3 +99,7 @@ type opGetPKIDocument struct {
 type opGetSpoolProviders struct {
 	responseChan chan interface{}
 }
+
+type opSpoolWriteDescriptor struct {
+	responseChan chan *client.SpoolWriteDescriptor
+}

--- a/catshadow/operations.go
+++ b/catshadow/operations.go
@@ -32,6 +32,7 @@ type opOffline struct {
 }
 
 type opCreateSpool struct {
+	provider     string
 	responseChan chan error
 }
 

--- a/catshadow/operations.go
+++ b/catshadow/operations.go
@@ -91,3 +91,7 @@ type opWipeConversation struct {
 	name         string
 	responseChan chan error
 }
+
+type opGetPKIDocument struct {
+	responseChan chan interface{}
+}

--- a/catshadow/worker.go
+++ b/catshadow/worker.go
@@ -115,6 +115,8 @@ func (c *Client) worker() {
 				c.doGetConversation(op.name, op.responseChan)
 			case *opWipeConversation:
 				op.responseChan <- c.doWipeConversation(op.name)
+			case *opGetPKIDocument:
+				op.responseChan <- c.doGetPKIDocument()
 			default:
 				c.fatalErrCh <- errors.New("BUG, unknown operation type.")
 			}

--- a/catshadow/worker.go
+++ b/catshadow/worker.go
@@ -82,7 +82,7 @@ func (c *Client) worker() {
 				isConnected = false
 				c.haltKeyExchanges()
 			case *opCreateSpool:
-				c.doCreateRemoteSpool(op.responseChan)
+				c.doCreateRemoteSpool(op.provider, op.responseChan)
 			case *opUpdateSpool:
 				if op.descriptor != nil {
 					c.spoolReadDescriptor = op.descriptor

--- a/catshadow/worker.go
+++ b/catshadow/worker.go
@@ -117,8 +117,11 @@ func (c *Client) worker() {
 				op.responseChan <- c.doWipeConversation(op.name)
 			case *opGetPKIDocument:
 				op.responseChan <- c.doGetPKIDocument()
+			case *opGetSpoolProviders:
+				op.responseChan <- c.doGetSpoolProviders()
 			default:
 				c.fatalErrCh <- errors.New("BUG, unknown operation type.")
+
 			}
 		case update := <-c.pandaChan:
 			c.processPANDAUpdate(&update)

--- a/catshadow/worker.go
+++ b/catshadow/worker.go
@@ -119,6 +119,8 @@ func (c *Client) worker() {
 				op.responseChan <- c.doGetPKIDocument()
 			case *opGetSpoolProviders:
 				op.responseChan <- c.doGetSpoolProviders()
+			case *opSpoolWriteDescriptor:
+				op.responseChan <- c.getSpoolWriteDescriptor()
 			default:
 				c.fatalErrCh <- errors.New("BUG, unknown operation type.")
 

--- a/client/session.go
+++ b/client/session.go
@@ -255,9 +255,8 @@ func (s *Session) awaitFirstPKIDoc(ctx context.Context) error {
 	// NOT REACHED
 }
 
-// GetService returns a randomly selected service
-// matching the specified service name
-func (s *Session) GetService(serviceName string) (*utils.ServiceDescriptor, error) {
+// GetServices returns the services matching the specified service name
+func (s *Session) GetServices(serviceName string) ([]*utils.ServiceDescriptor, error) {
 	if s.minclient == nil {
 		return nil, errors.New("minclient is nil")
 	}
@@ -265,11 +264,25 @@ func (s *Session) GetService(serviceName string) (*utils.ServiceDescriptor, erro
 	if doc == nil {
 		return nil, errors.New("pki doc is nil")
 	}
-	serviceDescriptors := utils.FindServices(serviceName, doc)
-	if len(serviceDescriptors) == 0 {
+	descs := utils.FindServices(serviceName, doc)
+	if len(descs) == 0 {
 		return nil, errors.New("error, GetService failure, service not found in pki doc")
 	}
-	return &serviceDescriptors[rand.NewMath().Intn(len(serviceDescriptors))], nil
+	serviceDescriptors := make([]*utils.ServiceDescriptor, len(descs))
+	for i, s := range descs {
+		serviceDescriptors[i] = &s
+	}
+	return serviceDescriptors, nil
+}
+
+// GetService returns a randomly selected service
+// matching the specified service name
+func (s *Session) GetService(serviceName string) (*utils.ServiceDescriptor, error) {
+	serviceDescriptors, err := s.GetServices(serviceName)
+	if err != nil {
+		return nil, err
+	}
+	return serviceDescriptors[rand.NewMath().Intn(len(serviceDescriptors))], nil
 }
 
 // OnConnection will be called by the minclient api


### PR DESCRIPTION
This branch adds additional methods to catshadow so that a user of catshadow can create spools on a named provider.