### PR TITLE
fix for half of #133

### DIFF
--- a/server/internal/decoy/decoy.go
+++ b/server/internal/decoy/decoy.go
@@ -429,7 +429,14 @@ func (d *decoy) sweepSURBCtxs() {
 	var swept int
 	iter := d.surbETAs.Iterator(avl.Forward)
 	for node := iter.First(); node != nil; node = iter.Next() {
-		surbCtxs := node.Value.([]*surbCtx)
+		var surbCtxs []*surbCtx
+		switch surbCtxOrSlice := node.Value.(type) {
+			case []*surbCtx:
+				surbCtxs = surbCtxOrSlice
+			case *surbCtx:
+				surbCtxs = make([]*surbCtx, 1)
+				surbCtxs[0] = surbCtxOrSlice
+		}
 		if surbCtxs[0].eta+slack > now {
 			break
 		}


### PR DESCRIPTION
This PR fixes first crash bug from issue https://github.com/katzenpost/katzenpost/issues/133
It is a workaround style bug fix where we know for sure (because of gaurantees of golang type system) that the bug is in the AVL library. See ticket to replace with priority queue here: https://github.com/katzenpost/katzenpost/issues/134