### PR TITLE
Pki retry threshold

### DIFF
--- a/authority/voting/client/client.go
+++ b/authority/voting/client/client.go
@@ -241,20 +241,19 @@ func (p *connector) fetchConsensus(ctx context.Context, linkKey wire.PrivateKey,
 	peerIndex := r.Intn(len(p.cfg.Authorities))
 
 	// check for a document from threshold authorities
-	i := 0;
-	for i < len(p.cfg.Authorities)/2 {
-		auth := p.cfg.Authorities[peerIndex + i % len(p.cfg.Authorities)]
+
+	for i := 0; i < len(p.cfg.Authorities)/2; i++ {
+		auth := p.cfg.Authorities[peerIndex+i%len(p.cfg.Authorities)]
 		conn, err := p.initSession(ctx, doneCh, linkKey, nil, auth)
 		if err != nil {
 			return nil, err
 		}
 		p.log.Debugf("sending getConsensus to %s", auth.Identifier)
 		resp, err := p.roundTrip(conn.session, cmd)
+		p.log.Debugf("got response (err=%v) from %s", err, auth.Identifier)
 		if err == pki.ErrNoDocument {
 			continue
 		}
-		p.log.Debugf("got response (err=%v) from %s", err, auth.Identifier)
-		i++
 		return resp, err
 	}
 	return nil, pki.ErrNoDocument

--- a/authority/voting/client/client.go
+++ b/authority/voting/client/client.go
@@ -229,7 +229,7 @@ func (p *connector) allPeersRoundTrip(ctx context.Context, linkKey wire.PrivateK
 	return responses, nil
 }
 
-func (p *connector) fetchConsensus(ctx context.Context, linkKey wire.PrivateKey, cmd commands.Command) (commands.Command, error) {
+func (p *connector) fetchConsensus(ctx context.Context, linkKey wire.PrivateKey, epoch uint64) (commands.Command, error) {
 	doneCh := make(chan interface{})
 	defer close(doneCh)
 
@@ -249,6 +249,7 @@ func (p *connector) fetchConsensus(ctx context.Context, linkKey wire.PrivateKey,
 			return nil, err
 		}
 		p.log.Debugf("sending getConsensus to %s", auth.Identifier)
+		cmd := &commands.GetConsensus{Epoch: epoch}
 		resp, err := p.roundTrip(conn.session, cmd)
 		p.log.Debugf("got response (err=%v) from %s", err, auth.Identifier)
 		if err == pki.ErrNoDocument {
@@ -324,8 +325,7 @@ func (c *Client) Get(ctx context.Context, epoch uint64) (*pki.Document, []byte, 
 	defer close(doneCh)
 
 	// Dispatch the get_consensus command.
-	cmd := &commands.GetConsensus{Epoch: epoch}
-	resp, err := c.pool.fetchConsensus(ctx, linkKey, cmd)
+	resp, err := c.pool.fetchConsensus(ctx, linkKey, epoch)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -47,13 +47,16 @@ docker_compose?= $(shell if echo ${docker}|grep -q podman; then echo DOCKER_HOST
 
 make_args=--no-print-directory net_name=$(net_name) docker=$(docker) distro=$(distro) warped=$(warped) docker_user=$(docker_user)
 
-$(docker_compose_yml): ../genconfig/main.go $(distro)_go_mod.stamp
+$(net_name):
+	mkdir -p $(net_name)
+
+$(docker_compose_yml): ../genconfig/main.go $(distro)_go_mod.stamp $(net_name)
 	$(docker) run -e --network=host ${docker_args} --rm katzenpost-$(distro)_go_mod \
-		$(sh) -c 'cd genconfig && go build && cd ../docker && mkdir -p $(net_name) \
+		$(sh) -c 'cd genconfig && go build && cd ../docker \
 		&& ../genconfig/genconfig -nv ${auths} -n ${mixes} -p ${providers} -S .$(distro) -t $(params)\
 		-v -o ./$(net_name) -b /$(net_name) -P $(base_port) -d katzenpost-$(distro)_go_mod'
 
-$(net_name)/running.stamp:
+$(net_name)/running.stamp: $(net_name)
 	make $(make_args) start
 
 run: $(docker_compose_yml) $(net_name)/server.$(distro) $(net_name)/voting.$(distro)
@@ -138,17 +141,17 @@ go-mod-upgrade: $(distro)_go_mod.stamp
 		&& $(docker) commit katzenpost_$(distro)_go_mod katzenpost-$(distro)_go_mod \
 		&& $(docker) rm katzenpost_$(distro)_go_mod
 
-$(net_name)/server.$(distro): $(distro)_go_mod.stamp $(docker_compose_yml)
+$(net_name)/server.$(distro): $(distro)_go_mod.stamp $(docker_compose_yml) $(net_name)
 		$(docker) run ${docker_args} $(mount_net_name) --rm katzenpost-$(distro)_go_mod \
 			$(sh) -c 'cd server && make $(make_args) testnet-build testnet-install'
 
-$(net_name)/voting.$(distro): $(distro)_go_mod.stamp $(docker_compose_yml)
+$(net_name)/voting.$(distro): $(distro)_go_mod.stamp $(docker_compose_yml) $(net_name)
 		$(docker) run ${docker_args} $(mount_net_name) katzenpost-$(distro)_go_mod \
 			$(sh) -c 'cd authority/cmd/voting && go mod verify && \
 			go build -trimpath -ldflags ${ldflags} && \
 			mv voting /$(net_name)/voting.$(distro)'
 
-$(net_name)/ping.$(distro): $(distro)_go_mod.stamp
+$(net_name)/ping.$(distro): $(distro)_go_mod.stamp $(net_name)
 		$(docker) run ${docker_args} $(mount_net_name) katzenpost-$(distro)_go_mod \
 			$(sh) -c 'cd ping && go mod verify && go build -ldflags ${ldflags} && \
 			mv ping /$(net_name)/ping.$(distro)'
@@ -184,7 +187,7 @@ run-ping: $(net_name)/ping.$(distro) $(net_name)/running.stamp
 	$(docker) run --network=host ${docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_go_mod \
         /$(net_name)/ping.$(distro) -c /go/katzenpost/docker/$(net_name)/client/client.toml -s echo -printDiff -n 1
 
-shell: $(distro)_go_mod.stamp
+shell: $(distro)_go_mod.stamp $(net_name)
 	$(docker) run -e --network=host ${docker_args} $(mount_net_name) --rm -it katzenpost-$(distro)_go_mod $(sh)
 
 # this is for running with docker, where we are root outside and (except for


### PR DESCRIPTION
this PR changes the pki client (authority/voting/client) Get() behavior so that if an authority tells the client that there will never be a document for the current epoch the client will retry and ask other authorities up to threshold (number of authorities / 2) times before returning ErrNoDocument.

this fixes #180  