### PR TITLE
Revert "stop running ci twice"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,8 +1,7 @@
 name: build
-on: [push]
+on: [push, pull_request]
 env:
   CGO_CFLAGS_ALLOW: "-DPARAMS=sphincs-shake-256f"
-
 jobs:
   test:
     strategy:


### PR DESCRIPTION
This reverts commit ee3c5bcfe82ce393dd969698c2c034427e6e3ed1.
This brings back CI to PRs so they can be merged.