### PR TITLE
client: make NewTOFUSession and PKIBootstrap require context.Context

### DIFF
--- a/catshadow/client.go
+++ b/catshadow/client.go
@@ -19,6 +19,7 @@
 package catshadow
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -1408,7 +1409,10 @@ func (c *Client) goOnline() error {
 	c.connMutex.Unlock()
 
 	// try to connect
-	s, err := c.client.NewTOFUSession()
+	cfg := c.client.GetConfig()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.Debug.SessionDialTimeout)*time.Second)
+	defer cancel()
+	s, err := c.client.NewTOFUSession(ctx)
 
 	// re-obtain lock
 	c.connMutex.Lock()
@@ -1422,8 +1426,7 @@ func (c *Client) goOnline() error {
 	c.online = true
 	c.connMutex.Unlock()
 	// wait for pki document to arrive
-	s.WaitForDocument()
-	return nil
+	return s.WaitForDocument(ctx)
 }
 
 // Offline() tells the client to disconnect from network services and blocks until the client has disconnected.

--- a/client/client.go
+++ b/client/client.go
@@ -177,6 +177,6 @@ func (c *Client) NewTOFUSession(ctx context.Context) (*Session, error) {
 		return nil, err
 	}
 
-	c.session, err = NewSession(ctx, pkiclient, c.fatalErrCh, c.logBackend, c.cfg, linkKey, provider)
+	c.session, err = NewSession(ctx, pkiclient, doc, c.fatalErrCh, c.logBackend, c.cfg, linkKey, provider)
 	return c.session, err
 }

--- a/client/client.go
+++ b/client/client.go
@@ -55,15 +55,13 @@ func (c *Client) GetConfig() *config.Config {
 }
 
 // PKIBootstrap returns a pkiClient and fetches a consensus.
-func PKIBootstrap(c *Client, linkKey wire.PrivateKey) (pki.Client, *pki.Document, error) {
+func PKIBootstrap(ctx context.Context, c *Client, linkKey wire.PrivateKey) (pki.Client, *pki.Document, error) {
 	// Retrieve a copy of the PKI consensus document.
 	pkiClient, err := c.cfg.NewPKIClient(c.logBackend, c.cfg.UpstreamProxyConfig(), linkKey)
 	if err != nil {
 		return nil, nil, err
 	}
 	currentEpoch, _, _ := epochtime.FromUnix(time.Now().Unix())
-	ctx, cancel := context.WithTimeout(context.Background(), initialPKIConsensusTimeout)
-	defer cancel()
 	doc, _, err := pkiClient.Get(ctx, currentEpoch)
 	if err != nil {
 		return nil, nil, err
@@ -158,7 +156,7 @@ func (c *Client) halt() {
 }
 
 // NewTOFUSession creates and returns a new ephemeral session or an error.
-func (c *Client) NewTOFUSession() (*Session, error) {
+func (c *Client) NewTOFUSession(ctx context.Context) (*Session, error) {
 	var (
 		err      error
 		doc      *pki.Document
@@ -166,15 +164,11 @@ func (c *Client) NewTOFUSession() (*Session, error) {
 		linkKey  wire.PrivateKey
 	)
 
-	timeout := time.Duration(c.cfg.Debug.SessionDialTimeout) * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
 	// generate a linkKey
 	linkKey, _ = wire.DefaultScheme.GenerateKeypair(rand.Reader)
 
 	// fetch a pki.Document
-	pkiclient, doc, err := PKIBootstrap(c, linkKey)
+	pkiclient, doc, err := PKIBootstrap(ctx, c, linkKey)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client_docker_test.go
+++ b/client/client_docker_test.go
@@ -14,12 +14,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+//go:build docker_test
 // +build docker_test
 
 package client
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"sync"
 	"testing"
@@ -42,7 +44,7 @@ func TestDockerClientConnectShutdown(t *testing.T) {
 	client, err := New(cfg)
 	require.NoError(err)
 
-	session, err := client.NewTOFUSession()
+	session, err := client.NewTOFUSession(context.Background())
 	require.NoError(err)
 
 	<-session.EventSink
@@ -61,10 +63,11 @@ func TestDockerClientAsyncSendReceive(t *testing.T) {
 	client, err := New(cfg)
 	require.NoError(err)
 
-	clientSession, err := client.NewTOFUSession()
+	ctx := context.Background()
+	clientSession, err := client.NewTOFUSession(ctx)
 	require.NoError(err)
 
-	clientSession.WaitForDocument()
+	clientSession.WaitForDocument(ctx)
 	desc, err := clientSession.GetService(constants.LoopService)
 	require.NoError(err)
 
@@ -111,10 +114,11 @@ func TestDockerClientAsyncSendReceiveWithDecoyTraffic(t *testing.T) {
 	client, err := New(cfg)
 	require.NoError(err)
 
-	clientSession, err := client.NewTOFUSession()
+	ctx := context.Background()
+	clientSession, err := client.NewTOFUSession(ctx)
 	require.NoError(err)
 
-	clientSession.WaitForDocument()
+	clientSession.WaitForDocument(ctx)
 	desc, err := clientSession.GetService(constants.LoopService)
 	require.NoError(err)
 
@@ -160,7 +164,7 @@ func TestDockerClientTestGarbageCollection(t *testing.T) {
 	client, err := New(cfg)
 	require.NoError(err)
 
-	clientSession, err := client.NewTOFUSession()
+	clientSession, err := client.NewTOFUSession(context.Background())
 	require.NoError(err)
 
 	msgID := [constants.MessageIDLength]byte{}
@@ -191,10 +195,11 @@ func TestDockerClientTestIntegrationGarbageCollection(t *testing.T) {
 	client, err := New(cfg)
 	require.NoError(err)
 
-	clientSession, err := client.NewTOFUSession()
+	ctx := context.Background()
+	clientSession, err := client.NewTOFUSession(ctx)
 	require.NoError(err)
 
-	clientSession.WaitForDocument()
+	clientSession.WaitForDocument(ctx)
 	desc, err := clientSession.GetService(constants.LoopService)
 	require.NoError(err)
 

--- a/client/session.go
+++ b/client/session.go
@@ -142,11 +142,14 @@ func NewSession(
 }
 
 // WaitForDocument blocks until a pki fetch has completed
-func (s *Session) WaitForDocument() {
+func (s *Session) WaitForDocument(ctx context.Context) error {
 	select {
+	case <-ctx.Done():
+		return errors.New("Cancelled")
 	case <-s.newPKIDoc:
 	case <-s.HaltCh():
 	}
+	return nil
 }
 
 func (s *Session) eventSinkWorker() {
@@ -240,7 +243,7 @@ func (s *Session) onConnection(err error) {
 	}
 	select {
 	case <-s.HaltCh():
-	case s.opCh <- opConnStatusChanged{ isConnected: err == nil, }:
+	case s.opCh <- opConnStatusChanged{isConnected: err == nil}:
 	}
 }
 

--- a/client/session.go
+++ b/client/session.go
@@ -79,6 +79,7 @@ type Session struct {
 func NewSession(
 	ctx context.Context,
 	pkiClient pki.Client,
+	cachedDoc *pki.Document,
 	fatalErrCh chan error,
 	logBackend *log.Backend,
 	cfg *config.Config,
@@ -116,6 +117,7 @@ func NewSession(
 		LinkKey:             s.linkKey,
 		LogBackend:          logBackend,
 		PKIClient:           pkiClient,
+		CachedDocument:      cachedDoc,
 		OnConnFn:            s.onConnection,
 		OnMessageFn:         s.onMessage,
 		OnACKFn:             s.onACK,

--- a/memspool/client/client_docker_test.go
+++ b/memspool/client/client_docker_test.go
@@ -21,6 +21,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	cc "github.com/katzenpost/katzenpost/client"
@@ -39,11 +40,11 @@ func TestDockerUnreliableSpoolService(t *testing.T) {
 	client, err := cc.New(cfg)
 	require.NoError(err)
 
-	s, err := client.NewTOFUSession()
+	s, err := client.NewTOFUSession(context.Background())
 
 	require.NoError(err)
 
-	s.WaitForDocument()
+	s.WaitForDocument(context.Background())
 
 	// look up a spool provider
 	desc, err := s.GetService(common.SpoolServiceName)
@@ -114,10 +115,10 @@ func TestDockerUnreliableSpoolServiceMore(t *testing.T) {
 	client, err := cc.New(cfg)
 	require.NoError(err)
 
-	s, err := client.NewTOFUSession()
+	s, err := client.NewTOFUSession(context.Background())
 	require.NoError(err)
 
-	s.WaitForDocument()
+	s.WaitForDocument(context.Background())
 
 	// look up a spool provider
 	desc, err := s.GetService(common.SpoolServiceName)
@@ -165,10 +166,10 @@ func TestDockerGetSpoolServices(t *testing.T) {
 	client, err := cc.New(cfg)
 	require.NoError(err)
 
-	s, err := client.NewTOFUSession()
+	s, err := client.NewTOFUSession(context.Background())
 	require.NoError(err)
 
-	s.WaitForDocument()
+	s.WaitForDocument(context.Background())
 
 	spoolServices, err := s.GetServices(common.SpoolServiceName)
 	require.NoError(err)

--- a/minclient/client.go
+++ b/minclient/client.go
@@ -57,6 +57,11 @@ type ClientConfig struct {
 	// PKIClient is the PKI Document data source.
 	PKIClient cpki.Client
 
+	// CachedDocument is a PKI Document that has a MixDescriptor
+	// containg the Addresses and LinkKeys of minclient's Provider
+	// so that it can connect directly without contacting an Authority.
+	CachedDocument *cpki.Document
+
 	// OnConnFn is the callback function that will be called when the
 	// connection status changes.  The error parameter will be nil on
 	// successful connection establishment, otherwise it will be set

--- a/minclient/client.go
+++ b/minclient/client.go
@@ -213,6 +213,9 @@ func New(cfg *ClientConfig) (*Client, error) {
 	c.pki = newPKI(c)
 	c.pki.start()
 	c.conn.start()
-
+	if c.cfg.CachedDocument != nil {
+		// connectWorker waits for a pki fetch, we already have a document cached, so wake the worker
+		c.conn.onPKIFetch()
+	}
 	return c, nil
 }

--- a/minclient/connection.go
+++ b/minclient/connection.go
@@ -173,9 +173,11 @@ func (c *connection) getDescriptor() error {
 	}()
 
 	doc := c.c.CurrentDocument()
-	if doc == nil {
-		c.log.Debugf("No PKI document for current epoch.")
+	if doc == nil && c.c.cfg.CachedDocument == nil {
+		c.log.Debugf("No PKI document for current epoch or cached PKI document provide.")
 		return newPKIError("no PKI document for current epoch")
+	} else if c.c.cfg.CachedDocument != nil {
+		doc = c.c.cfg.CachedDocument
 	}
 	desc, err := doc.GetProvider(c.c.cfg.Provider)
 	if err != nil {

--- a/minclient/pki.go
+++ b/minclient/pki.go
@@ -282,5 +282,10 @@ func newPKI(c *Client) *pki {
 	p.log = c.cfg.LogBackend.GetLogger("minclient/pki:" + c.displayName)
 	p.failedFetches = make(map[uint64]error)
 	p.forceUpdateCh = make(chan interface{}, 1)
+	// Save cached documents
+	d := c.cfg.CachedDocument
+	if d != nil {
+		p.docs.Store(d.Epoch, d)
+	}
 	return p
 }

--- a/panda/client/client.go
+++ b/panda/client/client.go
@@ -58,8 +58,8 @@ func (p *Panda) Padding() int {
 }
 
 // Exchange performs a PANDA protocol message exchange
-func (p *Panda) Exchange(id, message []byte, shutdown chan struct{}) ([]byte, error) {
-	delay := 15 * time.Second
+func (p *Panda) Exchange(id, message []byte, shutdown <-chan interface{}) ([]byte, error) {
+	delay := 1 * time.Second
 	for {
 		request := common.PandaRequest{
 			Version: common.PandaVersion,

--- a/panda/crypto/panda.go
+++ b/panda/crypto/panda.go
@@ -20,7 +20,7 @@ var ShutdownErrMessage = "panda: shutdown requested"
 
 type MeetingPlace interface {
 	Padding() int
-	Exchange(id, message []byte, shutdown chan struct{}) ([]byte, error)
+	Exchange(id, message []byte, shutdown <-chan interface{}) ([]byte, error)
 }
 
 type PandaUpdate struct {
@@ -34,7 +34,7 @@ type KeyExchange struct {
 	sync.Mutex
 
 	log          *logging.Logger
-	shutdownChan chan struct{}
+	shutdownChan <-chan interface{}
 
 	pandaChan chan PandaUpdate
 	contactID uint64
@@ -53,7 +53,7 @@ type KeyExchange struct {
 	message1, message2      []byte
 }
 
-func NewKeyExchange(rand io.Reader, log *logging.Logger, meetingPlace MeetingPlace, sharedRandom []byte, sharedSecret []byte, kxBytes []byte, contactID uint64, pandaChan chan PandaUpdate, shutdownChan chan struct{}) (*KeyExchange, error) {
+func NewKeyExchange(rand io.Reader, log *logging.Logger, meetingPlace MeetingPlace, sharedRandom []byte, sharedSecret []byte, kxBytes []byte, contactID uint64, pandaChan chan PandaUpdate, shutdownChan <-chan interface{}) (*KeyExchange, error) {
 	if 24 /* nonce */ +4 /* length */ +len(kxBytes)+secretbox.Overhead > meetingPlace.Padding() {
 		return nil, errors.New("panda: key exchange too large for meeting place")
 	}
@@ -86,7 +86,7 @@ func NewKeyExchange(rand io.Reader, log *logging.Logger, meetingPlace MeetingPla
 	return kx, nil
 }
 
-func UnmarshalKeyExchange(rand io.Reader, log *logging.Logger, meetingPlace MeetingPlace, serialised []byte, contactID uint64, pandaChan chan PandaUpdate, shutdownChan chan struct{}) (*KeyExchange, error) {
+func UnmarshalKeyExchange(rand io.Reader, log *logging.Logger, meetingPlace MeetingPlace, serialised []byte, contactID uint64, pandaChan chan PandaUpdate, shutdownChan <-chan interface{}) (*KeyExchange, error) {
 	var p panda_proto.KeyExchange
 	if err := proto.Unmarshal(serialised, &p); err != nil {
 		return nil, err


### PR DESCRIPTION
This PR changes the client API slightly so that the caller can cancel a session rather than using a baked-in timeout of 45s