### PR TITLE
server: cborplugin worker must always write a response

### DIFF
--- a/server/cborplugin/server.go
+++ b/server/cborplugin/server.go
@@ -65,10 +65,6 @@ func (s *Server) worker() {
 			reply, err := s.plugin.OnCommand(cmd)
 			if err != nil {
 				s.log.Debugf("plugin returned err: %s", err)
-				continue
-			}
-			if reply == nil {
-				continue
 			}
 			select {
 			case <-s.HaltCh():


### PR DESCRIPTION
this fixes a deadlock issue reported in #263 