### PR TITLE
docker: Less aggressive default decoy traffic

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -30,7 +30,7 @@ lL=0.0005
 lLMax=1000
 lD=0.0005
 lDMax=3000
-lM=0.2
+lM=0.0005
 lMMax=100
 
 UserForwardPayloadLength=2000


### PR DESCRIPTION
The current default docker decoy traffic setting is so aggressive that my laptop freezes up for a few seconds at a time while I'm trying to type into my text editor and I am very frustrated. Let's merge this.