### PR TITLE
tallyVotes: return err when decoding bs (params) fails

### DIFF
--- a/authority/voting/server/state.go
+++ b/authority/voting/server/state.go
@@ -971,17 +971,19 @@ func (s *state) tallyVotes(epoch uint64) ([]*pki.MixDescriptor, *config.Paramete
 		if len(votes) >= s.threshold {
 			params := &config.Parameters{}
 			d := gob.NewDecoder(strings.NewReader(bs))
-			if err := d.Decode(params); err == nil {
-				sortNodesByPublicKey(nodes)
-				// successful tally
-				return nodes, params, nil
+			if err := d.Decode(params); err != nil {
+				s.log.Errorf("tallyVotes: failed to decode params: err=%v: bs=%v", err, bs)
+				return nil, nil, err
 			}
+			sortNodesByPublicKey(nodes)
+			// successful tally
+			return nodes, params, nil
 		} else if len(votes) >= s.dissenters {
 			return nil, nil, errors.New("a consensus partition")
 		}
 
 	}
-	return nil, nil, errors.New("consensus failure")
+	return nil, nil, errors.New("consensus failure (mixParams empty)")
 }
 
 func (s *state) computeSharedRandom(epoch uint64, commits map[[publicKeyHashSize]byte][]byte, reveals map[[publicKeyHashSize]byte][]byte) ([]byte, error) {


### PR DESCRIPTION
see #302 and #305 
We weren't returning the `err` so we got the nondescript catch-all error in this case.
