### PR TITLE
authority/client/connector: return on error, simplify conn.Close logic

### DIFF
--- a/authority/voting/client/client.go
+++ b/authority/voting/client/client.go
@@ -142,13 +142,6 @@ func (p *connector) initSession(ctx context.Context, doneCh <-chan interface{}, 
 		}
 	}
 
-	var isOk bool
-	defer func() {
-		if !isOk {
-			conn.Close()
-		}
-	}()
-
 	peerAuthenticator := &authorityAuthenticator{
 		IdentityPublicKey: peer.IdentityPublicKey,
 		LinkPublicKey:     peer.LinkPublicKey,
@@ -184,9 +177,9 @@ func (p *connector) initSession(ctx context.Context, doneCh <-chan interface{}, 
 
 	// Handshake.
 	if err = s.Initialize(conn); err != nil {
+		conn.Close()
 		return nil, err
 	}
-	isOk = true
 
 	return &connection{
 		conn:    conn,


### PR DESCRIPTION
this fixes a nil ptr panic when every connection fails and conn is nil