### PR TITLE
core/crypto/cert: Sign current+2 so tests do not fail across epochs

### DIFF
--- a/core/crypto/cert/cert_test.go
+++ b/core/crypto/cert/cert_test.go
@@ -156,7 +156,7 @@ func TestVerifyAll(t *testing.T) {
 
 	current, _, _ := epochtime.Now()
 
-	certificate, err := Sign(signingPrivKey1, signingPubKey1, ephemeralPubKey.Bytes(), current+1)
+	certificate, err := Sign(signingPrivKey1, signingPubKey1, ephemeralPubKey.Bytes(), current+2)
 	assert.NoError(err)
 
 	certificate, err = SignMulti(signingPrivKey2, signingPubKey2, certificate)


### PR DESCRIPTION
this fixes a bug where tests occasionally fail due to a certificate expiration, presumably at an epoch bound