### PR TITLE
genconfig, docker: make listening address configurable

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -46,6 +46,7 @@ DISTROS=alpine debian
 distro=alpine
 net_name=voting_mixnet
 base_port=30000
+bind_addr=127.0.0.1
 docker_compose_yml=$(net_name)/docker-compose.yml
 sh=$(shell if echo ${distro}|grep -q alpine; then echo sh; else echo bash; fi)
 SHELL=/bin/bash
@@ -75,7 +76,7 @@ $(net_name):
 $(docker_compose_yml): ../genconfig/main.go $(distro)_go_mod.stamp $(net_name)
 	$(docker) run -e --network=host ${docker_args} --rm katzenpost-$(distro)_go_mod \
 		$(sh) -c 'cd genconfig && go build && cd ../docker \
-		&& ../genconfig/genconfig -nv ${auths} -n ${mixes} -p ${providers} \
+		&& ../genconfig/genconfig -a ${bind_addr} -nv ${auths} -n ${mixes} -p ${providers} \
 		-sr ${sr} -mu ${mu} -muMax ${muMax} -lP ${lP} -lPMax ${lPMax} -lL ${lL} \
 		-lLMax ${lLMax} -lD ${lD} -lDMax ${lDMax} -lM ${lM} -lMMax ${lMMax} \
 		-S .$(distro) -v -o ./$(net_name) -b /$(net_name) -P $(base_port) \

--- a/genconfig/main.go
+++ b/genconfig/main.go
@@ -42,6 +42,7 @@ import (
 
 const (
 	basePort      = 30000
+	bindAddr      = "127.0.0.1"
 	nrLayers      = 3
 	nrNodes       = 6
 	nrProviders   = 2
@@ -62,6 +63,7 @@ type katzenpost struct {
 	nodeConfigs []*sConfig.Config
 	basePort    uint16
 	lastPort    uint16
+	bindAddr    string
 	nodeIdx     int
 	clientIdx   int
 	providerIdx int
@@ -137,7 +139,7 @@ func (s *katzenpost) genNodeConfig(isProvider bool, isVoting bool) error {
 	// Server section.
 	cfg.Server = new(sConfig.Server)
 	cfg.Server.Identifier = n
-	cfg.Server.Addresses = []string{fmt.Sprintf("127.0.0.1:%d", s.lastPort)}
+	cfg.Server.Addresses = []string{fmt.Sprintf("%s:%d", s.bindAddr, s.lastPort)}
 	cfg.Server.DataDir = filepath.Join(s.baseDir, n)
 	os.Mkdir(filepath.Join(s.outDir, cfg.Server.Identifier), 0700)
 	cfg.Server.IsProvider = isProvider
@@ -260,7 +262,7 @@ func (s *katzenpost) genVotingAuthoritiesCfg(numAuthorities int, parameters *vCo
 		cfg.SphinxGeometry = s.sphinxGeometry
 		cfg.Server = &vConfig.Server{
 			Identifier: fmt.Sprintf("auth%d", i),
-			Addresses:  []string{fmt.Sprintf("127.0.0.1:%d", s.lastPort)},
+			Addresses:  []string{fmt.Sprintf("%s:%d", s.bindAddr, s.lastPort)},
 			DataDir:    filepath.Join(s.baseDir, fmt.Sprintf("auth%d", i)),
 		}
 		os.Mkdir(filepath.Join(s.outDir, cfg.Server.Identifier), 0700)
@@ -333,6 +335,7 @@ func main() {
 	nrVoting := flag.Int("nv", nrAuthorities, "Generate voting configuration")
 	baseDir := flag.String("b", "", "Path to use as baseDir option")
 	basePort := flag.Int("P", basePort, "First port number to use")
+	bindAddr := flag.String("a", bindAddr, "Address to bind to")
 	outDir := flag.String("o", "", "Path to write files to")
 	dockerImage := flag.String("d", "katzenpost-go_mod", "Docker image for compose-compose")
 	binSuffix := flag.String("S", "", "suffix for binaries in docker-compose.yml")
@@ -383,6 +386,7 @@ func main() {
 	s.binSuffix = *binSuffix
 	s.basePort = uint16(*basePort)
 	s.lastPort = s.basePort + 1
+	s.bindAddr = *bindAddr
 
 	nrHops := *nrLayers + 2
 


### PR DESCRIPTION
this adds bind_addr environment variable that will configure the listening address for the mix and authority nodes. you can use this to make a testnet reachable via the public internet for testing or demonstration purposes.