### PR TITLE
add configurable metrics endpoint address

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"net/mail"
 	"net/url"
 	"os"
@@ -96,6 +97,9 @@ type Server struct {
 	// and do NOT send any of the Addresses.
 	OnlyAdvertiseAltAddresses bool
 
+	// MetricsAddress is the address/port to bind the prometheus metrics endpoint to.
+	MetricsAddress string
+
 	// DataDir is the absolute path to the server's state files.
 	DataDir string
 
@@ -161,6 +165,9 @@ func (sCfg *Server) validate() error {
 
 	if !filepath.IsAbs(sCfg.DataDir) {
 		return fmt.Errorf("config: Server: DataDir '%v' is not an absolute path", sCfg.DataDir)
+	}
+	if _, err := netip.ParseAddrPort(sCfg.MetricsAddress); err != nil {
+		return fmt.Errorf("config: Server: MetricsAddress '%v' is invalid: %v", sCfg.MetricsAddress, err)
 	}
 	return nil
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -166,8 +166,10 @@ func (sCfg *Server) validate() error {
 	if !filepath.IsAbs(sCfg.DataDir) {
 		return fmt.Errorf("config: Server: DataDir '%v' is not an absolute path", sCfg.DataDir)
 	}
-	if _, err := netip.ParseAddrPort(sCfg.MetricsAddress); err != nil {
-		return fmt.Errorf("config: Server: MetricsAddress '%v' is invalid: %v", sCfg.MetricsAddress, err)
+	if sCfg.MetricsAddress != ""  {
+		if _, err := netip.ParseAddrPort(sCfg.MetricsAddress); err != nil {
+			return fmt.Errorf("config: Server: MetricsAddress '%v' is invalid: %v", sCfg.MetricsAddress, err)
+		}
 	}
 	return nil
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -57,6 +57,7 @@ Identifier = "katzenpost.example.com"
 Addresses = [ "127.0.0.1:29483", "[::1]:29483" ]
 DataDir = "%s"
 IsProvider = true
+MetricsAddress = "127.0.0.1:6543"
 
 [Provider]
   [[Provider.Kaetzchen]]

--- a/server/internal/instrument/prometheus.go
+++ b/server/internal/instrument/prometheus.go
@@ -163,9 +163,6 @@ var (
 	)
 )
 
-var kaetzchenRequestsTimer *prometheus.Timer
-var fetchedPKIDocsTimer *prometheus.Timer
-
 // StartPrometheusListener starts the Prometheus metrics UNIX domain socket listener.
 func StartPrometheusListener(glue glue.Glue) {
 
@@ -250,16 +247,6 @@ func KaetzchenRequests() {
 	kaetzchenRequests.Inc()
 }
 
-// SetKaetzchenRequestsTimer sets the kaetzchen requests timer struct
-func SetKaetzchenRequestsTimer() {
-	kaetzchenRequestsTimer = prometheus.NewTimer(kaetzchenRequestsDuration)
-}
-
-// TimeKaetzchenRequestsDuration times how long it takes for a ketzchen request to execute
-func TimeKaetzchenRequestsDuration() {
-	kaetzchenRequestsTimer.ObserveDuration()
-}
-
 // KaetzchenRequestsDropped increments the counter for the number of dropped kaetzchen requests
 func KaetzchenRequestsDropped(dropCounter uint64) {
 	kaetzchenRequestsDropped.Add(float64(dropCounter))
@@ -308,16 +295,6 @@ func CancelledOutgoing() {
 // FetchedPKIDocs increments the counter for the number of fetched PKI docs per epoch
 func FetchedPKIDocs(epoch string) {
 	fetchedPKIDocs.With(prometheus.Labels{"epoch": epoch})
-}
-
-// SetFetchedPKIDocsTimer sets a timer for the fetchedPKIDocs variable
-func SetFetchedPKIDocsTimer() {
-	fetchedPKIDocsTimer = prometheus.NewTimer(fetchedPKIDocsDuration)
-}
-
-// TimeFetchedPKIDocsDuration times the duration of how long it takes to fetch a PKI Doc
-func TimeFetchedPKIDocsDuration() {
-	fetchedPKIDocsTimer.ObserveDuration()
 }
 
 // FailedFetchPKIDocs increments the counter for the number of times fetching a PKI doc failed per epoch

--- a/server/internal/instrument/prometheus.go
+++ b/server/internal/instrument/prometheus.go
@@ -1,5 +1,5 @@
-//go:build prometheus
-// +build prometheus
+//go:build !noprometheus
+// +build !noprometheus
 
 package instrument
 

--- a/server/internal/instrument/prometheus.go
+++ b/server/internal/instrument/prometheus.go
@@ -5,9 +5,13 @@ package instrument
 
 import (
 	"fmt"
+	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 
 	"github.com/katzenpost/katzenpost/core/wire/commands"
+	"github.com/katzenpost/katzenpost/server/internal/glue"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -162,9 +166,9 @@ var (
 var kaetzchenRequestsTimer *prometheus.Timer
 var fetchedPKIDocsTimer *prometheus.Timer
 
-// Init initialize instrumentation
-func Init() {
-	// Register metrics
+// StartPrometheusListener starts the Prometheus metrics UNIX domain socket listener.
+func StartPrometheusListener(glue glue.Glue) {
+
 	prometheus.MustRegister(deadlineBlownPacketsDropped)
 	prometheus.MustRegister(incomingConns)
 	prometheus.MustRegister(invalidPacketsDropped)
@@ -189,9 +193,19 @@ func Init() {
 	prometheus.MustRegister(failedPKICacheGeneration)
 	prometheus.MustRegister(invalidPKICache)
 
-	// Expose registered metrics via HTTP
-	http.Handle("/metrics", promhttp.Handler())
-	go http.ListenAndServe("127.0.0.1:6543", nil)
+	socketPath := filepath.Join(glue.Config().Server.DataDir, "prom.socket")
+
+	os.Remove(socketPath)
+
+	server := http.Server{
+		Handler: promhttp.Handler(),
+	}
+
+	unixListener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		panic(err)
+	}
+	go server.Serve(unixListener)
 }
 
 // Incoming increments the counter for incoming requests

--- a/server/internal/instrument/prometheus_dummy.go
+++ b/server/internal/instrument/prometheus_dummy.go
@@ -5,10 +5,11 @@ package instrument
 
 import (
 	"github.com/katzenpost/katzenpost/core/wire/commands"
+	"github.com/katzenpost/katzenpost/server/internal/glue"
 )
 
-// Init instrumentation
-func Init() {}
+// StartPrometheusListener does nothing
+func StartPrometheusListener(glue glue.Glue) {}
 
 // Incoming increments the counter for incoming requests
 func Incoming(cmd commands.Command) {}

--- a/server/internal/instrument/prometheus_dummy.go
+++ b/server/internal/instrument/prometheus_dummy.go
@@ -1,5 +1,5 @@
-//go:build !prometheus
-// +build !prometheus
+//go:build noprometheus
+// +build noprometheus
 
 package instrument
 

--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -126,7 +126,6 @@ func (p *pki) worker() {
 		// Fetch the PKI documents as required.
 		var didUpdate bool
 		for _, epoch := range p.documentsToFetch() {
-			instrument.SetFetchedPKIDocsTimer()
 			// Certain errors in fetching documents are treated as hard
 			// failures that suppress further attempts to fetch the document
 			// for the epoch.
@@ -174,7 +173,6 @@ func (p *pki) worker() {
 			p.Unlock()
 			didUpdate = true
 			instrument.FetchedPKIDocs(fmt.Sprintf("%v", epoch))
-			instrument.TimeFetchedPKIDocsDuration()
 		}
 
 		p.pruneFailures()

--- a/server/internal/provider/kaetzchen/kaetzchen.go
+++ b/server/internal/provider/kaetzchen/kaetzchen.go
@@ -186,7 +186,6 @@ func (k *KaetzchenWorker) worker() {
 }
 
 func (k *KaetzchenWorker) processKaetzchen(pkt *packet.Packet) {
-	instrument.SetKaetzchenRequestsTimer()
 	defer pkt.Dispose()
 
 	payload, surb, err := packet.ParseForwardPacket(pkt)
@@ -237,7 +236,6 @@ func (k *KaetzchenWorker) processKaetzchen(pkt *packet.Packet) {
 		// implementation should have caught this.
 		k.log.Debugf("Kaetzchen message: %v (Has reply but no SURB)", pkt.ID)
 	}
-	instrument.TimeKaetzchenRequestsDuration()
 }
 
 func (k *KaetzchenWorker) KaetzchenForPKI() map[string]map[string]interface{} {

--- a/server/server.go
+++ b/server/server.go
@@ -233,7 +233,7 @@ func New(cfg *config.Config) (*Server, error) {
 	if err := s.initLogging(); err != nil {
 		return nil, err
 	}
-	instrument.Init()
+	instrument.StartPrometheusListener(goo)
 
 	s.log.Notice("Katzenpost is still pre-alpha.  DO NOT DEPEND ON IT FOR STRONG SECURITY OR ANONYMITY.")
 	if s.cfg.Logging.Level == "DEBUG" {


### PR DESCRIPTION
Adds MetricsAddress to the mix server config so that the operator can configure a metrics listener that will work with the prometheus collector, or disable prometheus entirely.
fixes https://github.com/katzenpost/katzenpost/issues/363 , builds on https://github.com/katzenpost/katzenpost/pull/390