### PR TITLE
docker: fix DOCKER_HOST env as newer versions of docker-compose needs a URL

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -69,7 +69,7 @@ replace_name=$(shell if echo ${docker}|grep -q podman; then echo " --replace --n
 i_if_podman=$(shell if echo ${docker}|grep -q podman; then echo " -i"; else echo; fi)
 mount_net_name=-v `pwd`/$(net_name):/$(net_name)
 
-docker_compose?= $(shell if echo ${docker}|grep -q podman; then echo DOCKER_HOST="unix:$$XDG_RUNTIME_DIR/podman/podman.sock" docker-compose; else echo docker-compose; fi)
+docker_compose?= $(shell if echo ${docker}|grep -q podman; then echo DOCKER_HOST="unix://$$XDG_RUNTIME_DIR/podman/podman.sock" docker-compose; else echo docker-compose; fi)
 
 make_args=--no-print-directory net_name=$(net_name) docker=$(docker) distro=$(distro) warped=$(warped) docker_user=$(docker_user)
 


### PR DESCRIPTION
I noticed that docker-compose stopped working when upgrading from alpine 3.17 to alpine 3.18. (docker-cli-compose 2.15.1-r3 -> 2.17.3-r6)