### PR TITLE
server/internal/pki: publish descriptor first, before fetching consensus

### DIFF
--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -123,6 +123,17 @@ func (p *pki) worker() {
 			<-timer.C
 		}
 
+		// Check to see if we need to publish the descriptor, and do so, along
+		// with all the key rotation bits.
+		err := p.publishDescriptorIfNeeded(pkiCtx)
+		if isCanceled() {
+			// Canceled mid-post
+			return
+		}
+		if err != nil {
+			p.log.Warningf("Failed to post to PKI: %v", err)
+		}
+
 		// Fetch the PKI documents as required.
 		var didUpdate bool
 		for _, epoch := range p.documentsToFetch() {
@@ -182,17 +193,6 @@ func (p *pki) worker() {
 
 			// If the PKI document map changed, kick the connector worker.
 			p.glue.Connector().ForceUpdate()
-		}
-
-		// Check to see if we need to publish the descriptor, and do so, along
-		// with all the key rotation bits.
-		err := p.publishDescriptorIfNeeded(pkiCtx)
-		if isCanceled() {
-			// Canceled mid-post
-			return
-		}
-		if err != nil {
-			p.log.Warningf("Failed to post to PKI: %v", err)
 		}
 
 		// Internal component depend on network wide paramemters, and or the


### PR DESCRIPTION
if there are enough bootstrapping/failed authorities and no consensus is found before the MixDescriptor publish deadline, the mix server may not publish a descriptor in time.