### PR TITLE
use highctidh.ctidh1024 golang module

### DIFF
--- a/core/crypto/nike/ctidh/ctidh.go
+++ b/core/crypto/nike/ctidh/ctidh.go
@@ -1,6 +1,3 @@
-//go:build ctidh
-// +build ctidh
-
 // ctidh.go - Adapts ctidh module to our NIKE interface.
 // Copyright (C) 2022  David Stainton.
 //
@@ -23,41 +20,41 @@ import (
 	"encoding/base64"
 	"io"
 
-	ctidh "github.com/katzenpost/ctidh_cgo"
+	ctidh "codeberg.org/vula/highctidh/ctidh1024"
 
 	"github.com/katzenpost/katzenpost/core/crypto/nike"
 )
 
 // CTIDH implements the Nike interface using our CTIDH module.
-type Ctidh1024Nike struct{}
+type Nike struct{}
 
-var CTIDH1024Scheme *Ctidh1024Nike
+var CTIDH1024Scheme *Nike
 
 var _ nike.PrivateKey = (*PrivateKey)(nil)
 var _ nike.PublicKey = (*PublicKey)(nil)
-var _ nike.Scheme = (*Ctidh1024Nike)(nil)
+var _ nike.Scheme = (*Nike)(nil)
 
-func (e *Ctidh1024Nike) Name() string {
+func (e *Nike) Name() string {
 	return "ctidh"
 }
 
 // PublicKeySize returns the size in bytes of the public key.
-func (e *Ctidh1024Nike) PublicKeySize() int {
-	return ctidh.Ctidh1024PublicKeySize
+func (e *Nike) PublicKeySize() int {
+	return ctidh.PublicKeySize
 }
 
 // PrivateKeySize returns the size in bytes of the private key.
-func (e *Ctidh1024Nike) PrivateKeySize() int {
-	return ctidh.Ctidh1024PrivateKeySize
+func (e *Nike) PrivateKeySize() int {
+	return ctidh.PrivateKeySize
 }
 
 // NewEmptyPublicKey returns an uninitialized
 // PublicKey which is suitable to be loaded
 // via some serialization format via FromBytes
 // or FromPEMFile methods.
-func (e *Ctidh1024Nike) NewEmptyPublicKey() nike.PublicKey {
+func (e *Nike) NewEmptyPublicKey() nike.PublicKey {
 	return &PublicKey{
-		publicKey: ctidh.NewEmptyCtidh1024PublicKey(),
+		publicKey: ctidh.NewEmptyPublicKey(),
 	}
 }
 
@@ -65,20 +62,20 @@ func (e *Ctidh1024Nike) NewEmptyPublicKey() nike.PublicKey {
 // PrivateKey which is suitable to be loaded
 // via some serialization format via FromBytes
 // or FromPEMFile methods.
-func (e *Ctidh1024Nike) NewEmptyPrivateKey() nike.PrivateKey {
+func (e *Nike) NewEmptyPrivateKey() nike.PrivateKey {
 	return &PrivateKey{
-		privateKey: ctidh.NewEmptyCtidh1024PrivateKey(),
+		privateKey: ctidh.NewEmptyPrivateKey(),
 	}
 }
 
-func (e *Ctidh1024Nike) GeneratePrivateKey(rng io.Reader) nike.PrivateKey {
+func (e *Nike) GeneratePrivateKey(rng io.Reader) nike.PrivateKey {
 	return &PrivateKey{
-		privateKey: ctidh.GenerateCtidh1024PrivateKey(rng),
+		privateKey: ctidh.GeneratePrivateKey(rng),
 	}
 }
 
-func (e *Ctidh1024Nike) GenerateKeyPairFromEntropy(rng io.Reader) (nike.PublicKey, nike.PrivateKey, error) {
-	privKey, pubKey := ctidh.GenerateCtidh1024KeyPairWithRNG(rng)
+func (e *Nike) GenerateKeyPairFromEntropy(rng io.Reader) (nike.PublicKey, nike.PrivateKey, error) {
+	privKey, pubKey := ctidh.GenerateKeyPairWithRNG(rng)
 	return &PublicKey{
 			publicKey: pubKey,
 		}, &PrivateKey{
@@ -87,8 +84,8 @@ func (e *Ctidh1024Nike) GenerateKeyPairFromEntropy(rng io.Reader) (nike.PublicKe
 }
 
 // GenerateKeyPair creates a new key pair.
-func (e *Ctidh1024Nike) GenerateKeyPair() (nike.PublicKey, nike.PrivateKey, error) {
-	privKey, pubKey := ctidh.GenerateCtidh1024KeyPair()
+func (e *Nike) GenerateKeyPair() (nike.PublicKey, nike.PrivateKey, error) {
+	privKey, pubKey := ctidh.GenerateKeyPair()
 	return &PublicKey{
 			publicKey: pubKey,
 		}, &PrivateKey{
@@ -98,19 +95,19 @@ func (e *Ctidh1024Nike) GenerateKeyPair() (nike.PublicKey, nike.PrivateKey, erro
 
 // DeriveSecret derives a shared secret given a private key
 // from one party and a public key from another.
-func (e *Ctidh1024Nike) DeriveSecret(privKey nike.PrivateKey, pubKey nike.PublicKey) []byte {
-	return ctidh.DeriveSecretCtidh1024(privKey.(*PrivateKey).privateKey, pubKey.(*PublicKey).publicKey)
+func (e *Nike) DeriveSecret(privKey nike.PrivateKey, pubKey nike.PublicKey) []byte {
+	return ctidh.DeriveSecret(privKey.(*PrivateKey).privateKey, pubKey.(*PublicKey).publicKey)
 }
 
 // DerivePublicKey derives a public key given a private key.
-func (e *Ctidh1024Nike) DerivePublicKey(privKey nike.PrivateKey) nike.PublicKey {
+func (e *Nike) DerivePublicKey(privKey nike.PrivateKey) nike.PublicKey {
 	return &PublicKey{
-		publicKey: ctidh.DeriveCtidh1024PublicKey(privKey.(*PrivateKey).privateKey),
+		publicKey: ctidh.DerivePublicKey(privKey.(*PrivateKey).privateKey),
 	}
 }
 
-func (e *Ctidh1024Nike) Blind(groupMember nike.PublicKey, blindingFactor nike.PrivateKey) nike.PublicKey {
-	blinded, err := ctidh.BlindCtidh1024(
+func (e *Nike) Blind(groupMember nike.PublicKey, blindingFactor nike.PrivateKey) nike.PublicKey {
+	blinded, err := ctidh.Blind(
 		blindingFactor.(*PrivateKey).privateKey,
 		groupMember.(*PublicKey).publicKey,
 	)
@@ -122,8 +119,8 @@ func (e *Ctidh1024Nike) Blind(groupMember nike.PublicKey, blindingFactor nike.Pr
 	}
 }
 
-func (e *Ctidh1024Nike) UnmarshalBinaryPublicKey(b []byte) (nike.PublicKey, error) {
-	pubkey := ctidh.NewEmptyCtidh1024PublicKey()
+func (e *Nike) UnmarshalBinaryPublicKey(b []byte) (nike.PublicKey, error) {
+	pubkey := ctidh.NewEmptyPublicKey()
 	err := pubkey.FromBytes(b)
 	if err != nil {
 		return nil, err
@@ -133,8 +130,8 @@ func (e *Ctidh1024Nike) UnmarshalBinaryPublicKey(b []byte) (nike.PublicKey, erro
 	}, nil
 }
 
-func (e *Ctidh1024Nike) UnmarshalBinaryPrivateKey(b []byte) (nike.PrivateKey, error) {
-	privkey := ctidh.NewEmptyCtidh1024PrivateKey()
+func (e *Nike) UnmarshalBinaryPrivateKey(b []byte) (nike.PrivateKey, error) {
+	privkey := ctidh.NewEmptyPrivateKey()
 	err := privkey.FromBytes(b)
 	if err != nil {
 		return nil, err
@@ -145,7 +142,7 @@ func (e *Ctidh1024Nike) UnmarshalBinaryPrivateKey(b []byte) (nike.PrivateKey, er
 }
 
 type PublicKey struct {
-	publicKey *ctidh.Ctidh1024PublicKey
+	publicKey *ctidh.PublicKey
 }
 
 func (p *PublicKey) Blind(blindingFactor nike.PrivateKey) error {
@@ -193,7 +190,7 @@ func (p *PublicKey) UnmarshalText(data []byte) error {
 }
 
 type PrivateKey struct {
-	privateKey *ctidh.Ctidh1024PrivateKey
+	privateKey *ctidh.PrivateKey
 }
 
 func (p *PrivateKey) Public() nike.PublicKey {
@@ -231,5 +228,5 @@ func (p *PrivateKey) UnmarshalText(data []byte) error {
 }
 
 func init() {
-	CTIDH1024Scheme = &Ctidh1024Nike{}
+	CTIDH1024Scheme = &Nike{}
 }

--- a/core/crypto/nike/ctidh/ctidh_test.go
+++ b/core/crypto/nike/ctidh/ctidh_test.go
@@ -1,6 +1,3 @@
-//go:build ctidh
-// +build ctidh
-
 // ctidh_test.go - Adapts ctidh module to our NIKE interface.
 // Copyright (C) 2022  David Stainton.
 //
@@ -22,17 +19,17 @@ package ctidh
 import (
 	"testing"
 
-	ctidh "github.com/katzenpost/ctidh_cgo"
+	ctidh "codeberg.org/vula/highctidh/ctidh1024"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCtidhNike(t *testing.T) {
-	ctidhNike := new(Ctidh1024Nike)
+	ctidhNike := new(Nike)
 
 	alicePublicKey, alicePrivateKey, err := ctidhNike.GenerateKeyPair()
 	require.NoError(t, err)
 
-	tmp := ctidh.DeriveCtidh1024PublicKey(alicePrivateKey.(*PrivateKey).privateKey)
+	tmp := ctidh.DerivePublicKey(alicePrivateKey.(*PrivateKey).privateKey)
 	require.Equal(t, alicePublicKey.Bytes(), tmp.Bytes())
 
 	bobPubKey, bobPrivKey, err := ctidhNike.GenerateKeyPair()
@@ -40,6 +37,6 @@ func TestCtidhNike(t *testing.T) {
 
 	aliceS := ctidhNike.DeriveSecret(alicePrivateKey, bobPubKey)
 
-	bobS := ctidh.DeriveSecretCtidh1024(bobPrivKey.(*PrivateKey).privateKey, alicePublicKey.(*PublicKey).publicKey)
+	bobS := ctidh.DeriveSecret(bobPrivKey.(*PrivateKey).privateKey, alicePublicKey.(*PublicKey).publicKey)
 	require.Equal(t, bobS, aliceS)
 }

--- a/core/crypto/nike/hybrid/ctidh.go
+++ b/core/crypto/nike/hybrid/ctidh.go
@@ -1,6 +1,3 @@
-//go:build ctidh
-// +build ctidh
-
 package hybrid
 
 import (

--- a/core/crypto/nike/schemes/schemes.go
+++ b/core/crypto/nike/schemes/schemes.go
@@ -9,14 +9,10 @@ import (
 	"github.com/katzenpost/katzenpost/core/crypto/rand"
 )
 
-// NOTE(david): The CTIDH schemes won't work unless you build with
-// "ctidh" build tag.
 var allSchemes = [...]nike.Scheme{
 	ecdh.NewEcdhNike(rand.Reader),
-	hybrid.NOBS_CSIDH512X25519,
-	// Must build with `ctidh` build tag (and other supporting env vars)
-	// for CTIDH usage:
-	// hybrid.CTIDH1024X25519,
+	hybrid.NOBS_CSIDH512X25519, // This should be removed once ctidh is fully integrated
+	hybrid.CTIDH1024X25519,
 }
 
 var allSchemeNames map[string]nike.Scheme

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/katzenpost/katzenpost
 go 1.19
 
 require (
+	codeberg.org/vula/highctidh v1.0.2023120600
 	filippo.io/edwards25519 v1.0.0
 	github.com/BurntSushi/toml v1.2.1
 	github.com/awnumar/memguard v0.22.3
@@ -15,11 +16,10 @@ require (
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/katzenpost/chacha20 v0.0.0-20190910113340-7ce890d6a556
 	github.com/katzenpost/chacha20poly1305 v0.0.0-20211026103954-7b6fb2fc0129
-	github.com/katzenpost/ctidh_cgo v0.0.0-20230423225118-4c507e31dd9a
 	github.com/katzenpost/nyquist v0.0.0-20231024064113-96ae83e5c09b
 	github.com/katzenpost/sntrup4591761 v0.0.0-20231024131303-8755eb1986b8
 	github.com/prometheus/client_golang v1.14.0
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.4
 	github.com/ugorji/go/codec v1.2.8
 	github.com/yawning/bloom v0.0.0-20181019144233-44d6c5c71ed1
 	gitlab.com/yawning/aez.git v0.0.0-20211027044916-e49e68abd344

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+codeberg.org/vula/highctidh v1.0.2023120600 h1:V3RYHy2A2aesbfqj4/SLEn16ig+JyqJ1gXZjf08h3nQ=
+codeberg.org/vula/highctidh v1.0.2023120600/go.mod h1:ckK/64QwzjHuezu/k0JytpQtbs84PkESUuSK39j1TTw=
 filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
 filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
@@ -49,8 +51,6 @@ github.com/katzenpost/chacha20 v0.0.0-20190910113340-7ce890d6a556 h1:9gHByAWH1Ly
 github.com/katzenpost/chacha20 v0.0.0-20190910113340-7ce890d6a556/go.mod h1:d9kxwmGOcutgP6bQwr2xaLInaW5yJsxsoPRyUIG0J/E=
 github.com/katzenpost/chacha20poly1305 v0.0.0-20211026103954-7b6fb2fc0129 h1:BkXIK2/3bAtqFbzea4tMVfhu8BQ9j05yCVy/z8iCz3s=
 github.com/katzenpost/chacha20poly1305 v0.0.0-20211026103954-7b6fb2fc0129/go.mod h1:moU3dWG1uk4xayUNdUPs2Q3dx2Zsk5i9Ysfx+ujQrwM=
-github.com/katzenpost/ctidh_cgo v0.0.0-20230423225118-4c507e31dd9a h1:E/wT0j3Bo1wNPXez4wm2v6taCFFsB9mZIOVzWd9qHX4=
-github.com/katzenpost/ctidh_cgo v0.0.0-20230423225118-4c507e31dd9a/go.mod h1:xqyj8Y3rR3PfAPoDvhriOtNLPr2VXjlFj1LqGR5xA88=
 github.com/katzenpost/nyquist v0.0.0-20231024064113-96ae83e5c09b h1:Bji/WmibCApgR1/epqQNVN3eIQD7sYEz78IB7h4pabk=
 github.com/katzenpost/nyquist v0.0.0-20231024064113-96ae83e5c09b/go.mod h1:1x/VqOl8InVjCeUS91EJYjHp+uU1EEJUEvAZhKBUyT0=
 github.com/katzenpost/sntrup4591761 v0.0.0-20231024131303-8755eb1986b8 h1:TsKxH0x2RUwf5rBw67k15bqVM3oVbexA9oaTZQLIy3Y=
@@ -87,15 +87,11 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/ugorji/go/codec v1.2.8 h1:sgBJS6COt0b/P40VouWKdseidkDgHxYGm0SAglUHfP0=
 github.com/ugorji/go/codec v1.2.8/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/sphincsplus/ref/randombytes.h
+++ b/sphincsplus/ref/randombytes.h
@@ -1,8 +1,6 @@
 #ifndef SPX_RANDOMBYTES_H
 #define SPX_RANDOMBYTES_H
 
-extern void randombytes(unsigned char * x,unsigned long long xlen);
-
-#define _randombytes(x, xlen) randombytes(x, xlen)
+void _randombytes(unsigned char * x,unsigned long long xlen);
 
 #endif


### PR DESCRIPTION
This uses a new highctih golang module that replaces the use of `ctidh_cgo` which previously required a system library. The new highctidh golang modules do not require a system library and behave as a normal golang module.

    $ go test -v

    === RUN   TestCtidhNike
    --- PASS: TestCtidhNike (8.41s)
    PASS
    ok  	github.com/katzenpost/katzenpost/core/crypto/nike/ctidh	8.426s