### PR TITLE
Remove the need for setting CGO_CFLAGS_ALLOW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: all test clean server dirauth genconfig ping
+.PHONY: all test sphincsplus clean server dirauth genconfig ping
 
 all: server dirauth genconfig ping
 
@@ -18,6 +18,9 @@ ping:
 clean:
 	rm -f server/cmd/server/server authority/cmd/voting/voting genconfig/genconfig ping/ping
 
+sphincsplus:
+	cd sphincsplus/ref && go test -v -race -timeout 0 ./...
+
 test:
-	CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go test -v -race -timeout 0 ./...
+	go test -v -race -timeout 0 ./...
 

--- a/sphincsplus/ref/binding.go
+++ b/sphincsplus/ref/binding.go
@@ -1,7 +1,6 @@
 package sphincsplus
 
 //#cgo linux LDFLAGS: "-L./ -L/usr/lib/x86_64-linux-gnu/ -lcrypto"
-//#cgo CFLAGS: -DPARAMS=sphincs-shake-256f
 //#include "api.h"
 import "C"
 import (

--- a/sphincsplus/ref/params.h
+++ b/sphincsplus/ref/params.h
@@ -1,5 +1,6 @@
 #define str(s) #s
 #define xstr(s) str(s)
+#define PARAMS sphincs-shake-256f
 
 #include xstr(params/params-PARAMS.h)
 

--- a/sphincsplus/ref/raft/PQCgenKAT_sign.c
+++ b/sphincsplus/ref/raft/PQCgenKAT_sign.c
@@ -55,14 +55,14 @@ main()
     for (int i=0; i<48; i++)
         entropy_input[i] = (unsigned char)i;
 
-    randombytes_init(entropy_input, NULL);
+    _randombytes_init(entropy_input, NULL);
     for (int i=0; i<100; i++) {
         fprintf(fp_req, "count = %d\n", i);
-        randombytes(seed, 48);
+        _randombytes(seed, 48);
         fprintBstr(fp_req, "seed = ", seed, 48);
         mlen = (unsigned long long int)(33*(i+1));
         fprintf(fp_req, "mlen = %llu\n", mlen);
-        randombytes(msg, mlen);
+        _randombytes(msg, mlen);
         fprintBstr(fp_req, "msg = ", msg, mlen);
         fprintf(fp_req, "pk =\n");
         fprintf(fp_req, "sk =\n");
@@ -94,7 +94,7 @@ main()
         }
         fprintBstr(fp_rsp, "seed = ", seed, 48);
 
-        randombytes_init(seed, NULL);
+        _randombytes_init(seed, NULL);
 
         if ( FindMarker(fp_req, "mlen = ") )
             ret_val = fscanf(fp_req, "%llu", &mlen);

--- a/sphincsplus/ref/raft/rng.c
+++ b/sphincsplus/ref/raft/rng.c
@@ -133,7 +133,7 @@ AES256_ECB(unsigned char *key, unsigned char *ctr, unsigned char *buffer)
 }
 
 void
-randombytes_init(unsigned char *entropy_input,
+_randombytes_init(unsigned char *entropy_input,
                  unsigned char *personalization_string)
 {
     unsigned char   seed_material[48];
@@ -149,7 +149,7 @@ randombytes_init(unsigned char *entropy_input,
 }
 
 int
-randombytes(unsigned char *x, unsigned long long xlen)
+_randombytes(unsigned char *x, unsigned long long xlen)
 {
     unsigned char   block[16];
     int             i = 0;

--- a/sphincsplus/ref/randombytes.c
+++ b/sphincsplus/ref/randombytes.c
@@ -9,7 +9,7 @@ This code was taken from the SPHINCS reference implementation and is public doma
 
 static int fd = -1;
 
-void randombytes(unsigned char *x, unsigned long long xlen)
+void _randombytes(unsigned char *x, unsigned long long xlen)
 {
     int i;
 

--- a/sphincsplus/ref/randombytes.h
+++ b/sphincsplus/ref/randombytes.h
@@ -3,6 +3,6 @@
 
 extern void randombytes(unsigned char * x,unsigned long long xlen);
 
-#define _randombytes(x) randombytes(x)
+#define _randombytes(x, xlen) randombytes(x, xlen)
 
 #endif

--- a/sphincsplus/ref/randombytes.h
+++ b/sphincsplus/ref/randombytes.h
@@ -3,4 +3,6 @@
 
 extern void randombytes(unsigned char * x,unsigned long long xlen);
 
+#define _randombytes(x) randombytes(x)
+
 #endif

--- a/sphincsplus/ref/rng.h
+++ b/sphincsplus/ref/rng.h
@@ -45,10 +45,10 @@ int
 seedexpander(AES_XOF_struct *ctx, unsigned char *x, unsigned long xlen);
 
 void
-randombytes_init(unsigned char *entropy_input,
+_randombytes_init(unsigned char *entropy_input,
                  unsigned char *personalization_string);
 
 int
-randombytes(unsigned char *x, unsigned long long xlen);
+_randombytes(unsigned char *x, unsigned long long xlen);
 
 #endif /* rng_h */

--- a/sphincsplus/ref/sign.c
+++ b/sphincsplus/ref/sign.c
@@ -83,7 +83,7 @@ int crypto_sign_seed_keypair(unsigned char *pk, unsigned char *sk,
 int crypto_sign_keypair(unsigned char *pk, unsigned char *sk)
 {
   unsigned char seed[CRYPTO_SEEDBYTES];
-  randombytes(seed, CRYPTO_SEEDBYTES);
+  _randombytes(seed, CRYPTO_SEEDBYTES);
   crypto_sign_seed_keypair(pk, sk, seed);
 
   return 0;
@@ -122,7 +122,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     /* Optionally, signing can be made non-deterministic using optrand.
        This can help counter side-channel attacks that would benefit from
        getting a large number of traces when the signer uses the same nodes. */
-    randombytes(optrand, SPX_N);
+    _randombytes(optrand, SPX_N);
     /* Compute the digest randomization value. */
     gen_message_random(sig, sk_prf, optrand, m, mlen, &ctx);
 

--- a/sphincsplus/ref/test/benchmark.c
+++ b/sphincsplus/ref/test/benchmark.c
@@ -135,8 +135,8 @@ int main()
     double result;
     int i;
 
-    randombytes(m, SPX_MLEN);
-    randombytes(addr, SPX_ADDR_BYTES);
+    _randombytes(m, SPX_MLEN);
+    _randombytes(addr, SPX_ADDR_BYTES);
 
     printf("Parameters: n = %d, h = %d, d = %d, b = %d, k = %d, w = %d\n",
            SPX_N, SPX_FULL_HEIGHT, SPX_D, SPX_FORS_HEIGHT, SPX_FORS_TREES,

--- a/sphincsplus/ref/test/fors.c
+++ b/sphincsplus/ref/test/fors.c
@@ -20,10 +20,10 @@ int main()
     unsigned char m[SPX_FORS_MSG_BYTES];
     uint32_t addr[8] = {0};
 
-    randombytes(ctx.sk_seed, SPX_N);
-    randombytes(ctx.pub_seed, SPX_N);
-    randombytes(m, SPX_FORS_MSG_BYTES);
-    randombytes((unsigned char *)addr, 8 * sizeof(uint32_t));
+    _randombytes(ctx.sk_seed, SPX_N);
+    _randombytes(ctx.pub_seed, SPX_N);
+    _randombytes(m, SPX_FORS_MSG_BYTES);
+    _randombytes((unsigned char *)addr, 8 * sizeof(uint32_t));
 
     printf("Testing FORS signature and PK derivation.. ");
 

--- a/sphincsplus/ref/test/haraka.c
+++ b/sphincsplus/ref/test/haraka.c
@@ -20,7 +20,7 @@ static int test_haraka_S_incremental(void) {
     int squeezed;
     int returncode = 0;
 
-    randombytes(input, 521);
+    _randombytes(input, 521);
 
     haraka_S(check, 521, input, 521);
 

--- a/sphincsplus/ref/test/spx.c
+++ b/sphincsplus/ref/test/spx.c
@@ -25,7 +25,7 @@ int main()
     unsigned long long smlen;
     unsigned long long mlen;
 
-    randombytes(m, SPX_MLEN);
+    _randombytes(m, SPX_MLEN);
 
     printf("Generating keypair.. ");
 


### PR DESCRIPTION
This change removes the need to set `CGO_CFLAGS_ALLOW` before building sphincsplus, and it adds a `Makefile` target called `sphincsplus` to run relevant tests:

$ make sphincsplus
cd sphincsplus/ref && go test -v -race -timeout 0 ./...
=== RUN   TestSignVerify
=== PAUSE TestSignVerify
=== RUN   TestSerialization
=== PAUSE TestSerialization
=== RUN   TestSizes
=== PAUSE TestSizes
=== RUN   TestSignVerifyVector
--- PASS: TestSignVerifyVector (0.06s)
=== CONT  TestSignVerify
=== CONT  TestSizes
=== CONT  TestSerialization
=== CONT  TestSizes
    binding_test.go:62: PrivateKeySize 128
    binding_test.go:63: PublicKeySize 64
    binding_test.go:64: SignatureSize 49856
--- PASS: TestSizes (2.27s)
--- PASS: TestSerialization (4.68s)
--- PASS: TestSignVerify (6.91s)
PASS
ok  	github.com/katzenpost/katzenpost/sphincsplus/ref	(cached)
?   	github.com/katzenpost/katzenpost/sphincsplus/ref/params	[no test files]