### PR TITLE
Remove CGO_CFLAGS_ALLOW in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,16 @@
 all: server dirauth genconfig ping
 
 server:
-	cd server/cmd/server; CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go build
+	cd server/cmd/server; go build
 
 dirauth:
-	cd authority/cmd/voting; CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go build
+	cd authority/cmd/voting; go build
 
 genconfig:
-	cd genconfig; CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go build
+	cd genconfig; go build
 
 ping:
-	cd ping; CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go build
+	cd ping; go build
 
 clean:
 	rm -f server/cmd/server/server authority/cmd/voting/voting genconfig/genconfig ping/ping

--- a/authority/Makefile
+++ b/authority/Makefile
@@ -1,34 +1,33 @@
 warped?=false
-CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f"
 ldflags="-buildid= -X github.com/katzenpost/katzenpost/core/epochtime.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/server/internal/pki.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/minclient/pki.WarpedEpoch=${warped}"
 
 test:
-	CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f" go test -race -cover -v ./...
+	go test -race -cover -v ./...
 
 lint:
 	golint ./...
 
 test-internal:
-	CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f" go test -race -cover -v ./internal/...
+	go test -race -cover -v ./internal/...
 
 test-voting:
-	CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f" go test -race -cover -v ./voting/...
+	go test -race -cover -v ./voting/...
 
 # no tests here
 test-nonvoting:
-	CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f" go test -race -cover -v ./nonvoting/...
+	go test -race -cover -v ./nonvoting/...
 
 coverage-file:
-	CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f" go test ./... -coverprofile=coverage.out
+	go test ./... -coverprofile=coverage.out
 
 coverage-html:
-	CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f" go tool cover -html=coverage.out
+	go tool cover -html=coverage.out
 
 cmd/voting/voting: clean
-	cd cmd/voting && CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f" go build -trimpath -ldflags ${ldflags}
+	cd cmd/voting && go build -trimpath -ldflags ${ldflags}
 
 cmd/fetch/fetch: clean
-	cd cmd/fetch && CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f" go build -trimpath -ldflags ${ldflags}
+	cd cmd/fetch && go build -trimpath -ldflags ${ldflags}
 
 clean:
 	rm -f cmd/fetch/fetch cmd/voting/voting cmd/nonvoting/nonvoting

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,5 +1,4 @@
 warped?=true
-CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f"
 ldflags="-X github.com/katzenpost/katzenpost/core/epochtime.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/server/internal/pki.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/minclient/pki.WarpedEpoch=${warped}"
 uid=$(shell [ "$$SUDO_UID" != "" ] && echo "$$SUDO_UID" || id -u)
 gid=$(shell [ "$$SUDO_GID" != "" ] && echo "$$SUDO_GID" || id -g)
@@ -10,18 +9,18 @@ image=katzenpost-$(distro)_go_mod
 docker_args=--user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost -e GOCACHE=/tmp/gocache --network=host --rm
 
 test:
-	CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go test -v -race -timeout 0 -ldflags ${ldflags} .
+	go test -v -race -timeout 0 -ldflags ${ldflags} .
 
 lint:
 	golint ./...
 
 coverage-file:
-	CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go test ./... -coverprofile=coverage.out
+	go test ./... -coverprofile=coverage.out
 
 coverage-html:
-	CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go tool cover -html=coverage.out
+	go tool cover -html=coverage.out
 
 
 dockerdockertest:
 	$(docker) run ${docker_args} $(image) \
-		sh -c 'cd /go/katzenpost/bench/; GORACE=history_size=7 CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go test $(testargs) -ldflags ${ldflags} -tags=docker_test,prometheus -race -v -timeout 1h -run Docker'
+		sh -c 'cd /go/katzenpost/bench/; GORACE=history_size=7 go test $(testargs) -ldflags ${ldflags} -tags=docker_test,prometheus -race -v -timeout 1h -run Docker'

--- a/catshadow/Makefile
+++ b/catshadow/Makefile
@@ -1,5 +1,4 @@
 warped?=true
-CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f"
 ldflags="-X github.com/katzenpost/katzenpost/core/epochtime.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/server/internal/pki.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/minclient/pki.WarpedEpoch=${warped}"
 uid=$(shell [ "$$SUDO_UID" != "" ] && echo "$$SUDO_UID" || id -u)
 gid=$(shell [ "$$SUDO_GID" != "" ] && echo "$$SUDO_GID" || id -g)
@@ -11,4 +10,4 @@ docker_args=--user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost -e G
 
 dockerdockertest:
 	$(docker) run ${docker_args} $(image) \
-		sh -c 'cd /go/katzenpost/catshadow/; CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f GORACE=history_size=7 go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 0 -failfast -run Docker'
+		sh -c 'cd /go/katzenpost/catshadow/; GORACE=history_size=7 go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 0 -failfast -run Docker'

--- a/client/Makefile
+++ b/client/Makefile
@@ -1,5 +1,4 @@
 warped?=true
-CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f"
 ldflags="-X github.com/katzenpost/katzenpost/core/epochtime.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/server/internal/pki.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/minclient/pki.WarpedEpoch=${warped}"
 uid=$(shell [ "$$SUDO_UID" != "" ] && echo "$$SUDO_UID" || id -u)
 gid=$(shell [ "$$SUDO_GID" != "" ] && echo "$$SUDO_GID" || id -g)
@@ -10,18 +9,18 @@ image=katzenpost-$(distro)_go_mod
 docker_args=--user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost -e GOCACHE=/tmp/gocache --network=host --rm
 
 test:
-	CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go test -v -race -timeout 0 -ldflags ${ldflags} .
+	go test -v -race -timeout 0 -ldflags ${ldflags} .
 
 lint:
 	golint ./...
 
 coverage-file:
-	CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go test ./... -coverprofile=coverage.out
+	go test ./... -coverprofile=coverage.out
 
 coverage-html:
-	CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go tool cover -html=coverage.out
+	go tool cover -html=coverage.out
 
 
 dockerdockertest:
 	$(docker) run ${docker_args} $(image) \
-		sh -c 'cd /go/katzenpost/client/; GORACE=history_size=7 CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 1h -run Docker'
+		sh -c 'cd /go/katzenpost/client/; GORACE=history_size=7 go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 1h -run Docker'

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -57,13 +57,12 @@ log_level=DEBUG
 docker=$(shell if which podman|grep -q .; then echo podman; else echo docker; fi)
 
 ldflags="-buildid= -X github.com/katzenpost/katzenpost/core/epochtime.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/server/internal/pki.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/minclient/pki.WarpedEpoch=${warped}"
-CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f"
 
 uid?=$(shell [ "$$SUDO_UID" != "" ] && echo "$$SUDO_UID" || id -u)
 gid?=$(shell [ "$$SUDO_GID" != "" ] && echo "$$SUDO_GID" || id -g)
 
 docker_user?=$(shell if echo ${docker}|grep -q podman; then echo 0:0; else echo ${uid}:${gid}; fi)
-docker_args=--user ${docker_user} --volume $(shell readlink -f ..):/go/katzenpost --workdir /go/katzenpost -e CGO_CFLAGS_ALLOW=${CGO_CFLAGS_ALLOW}
+docker_args=--user ${docker_user} --volume $(shell readlink -f ..):/go/katzenpost --workdir /go/katzenpost
 
 replace_name=$(shell if echo ${docker}|grep -q podman; then echo " --replace --name"; else echo " --name"; fi)
 i_if_podman=$(shell if echo ${docker}|grep -q podman; then echo " -i"; else echo; fi)

--- a/memspool/Makefile
+++ b/memspool/Makefile
@@ -1,5 +1,4 @@
 warped?=true
-CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f"
 ldflags="-X github.com/katzenpost/katzenpost/core/epochtime.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/server/internal/pki.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/minclient/pki.WarpedEpoch=${warped}"
 uid=$(shell [ "$$SUDO_UID" != "" ] && echo "$$SUDO_UID" || id -u)
 gid=$(shell [ "$$SUDO_GID" != "" ] && echo "$$SUDO_GID" || id -g)
@@ -11,4 +10,4 @@ docker_args=--user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost -e G
 
 dockerdockertest:
 	$(docker) run ${docker_args} $(image) \
-		sh -c 'cd /go/katzenpost/memspool/client; CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f GORACE=history_size=7 go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 0 -failfast -run Docker'
+		sh -c 'cd /go/katzenpost/memspool/client; GORACE=history_size=7 go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 0 -failfast -run Docker'

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,14 +1,13 @@
 warped?=false
-CGO_CFLAGS_ALLOW="-DPARAMS=sphincs-shake-256f"
 ldflags="-buildid= -X github.com/katzenpost/katzenpost/core/epochtime.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/server/internal/pki.WarpedEpoch=${warped} -X github.com/katzenpost/katzenpost/minclient/pki.WarpedEpoch=${warped}"
 
 testnet-build:
 	go mod verify
-	cd cmd/server ; CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go build -trimpath -ldflags ${ldflags}
-	cd ../memspool/server/cmd/memspool ; CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go build -trimpath -ldflags ${ldflags}
-	cd ../reunion/servers/reunion_katzenpost_server ; CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go build -trimpath -ldflags ${ldflags}
-	cd ../panda/server/cmd/panda_server ; CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go build -trimpath -ldflags ${ldflags}
-	cd ../server_plugins/cbor_plugins/echo-go ; CGO_CFLAGS_ALLOW=-DPARAMS=sphincs-shake-256f go build -trimpath -o echo_server -ldflags ${ldflags}
+	cd cmd/server ; go build -trimpath -ldflags ${ldflags}
+	cd ../memspool/server/cmd/memspool ; go build -trimpath -ldflags ${ldflags}
+	cd ../reunion/servers/reunion_katzenpost_server ; go build -trimpath -ldflags ${ldflags}
+	cd ../panda/server/cmd/panda_server ; go build -trimpath -ldflags ${ldflags}
+	cd ../server_plugins/cbor_plugins/echo-go ; go build -trimpath -o echo_server -ldflags ${ldflags}
 
 testnet-install:
 	mv /go/katzenpost/server/cmd/server/server /$(net_name)/server.$(distro)


### PR DESCRIPTION
These changes remove CGO_CFLAGS_ALLOW from Makefiles in the monorepo.