### PR TITLE
sphinx: improve tests

### DIFF
--- a/core/crypto/nike/ctidh1024/ctidh.go
+++ b/core/crypto/nike/ctidh1024/ctidh.go
@@ -1,3 +1,5 @@
+//go:build ctidh1024
+
 // ctidh.go - Adapts ctidh module to our NIKE interface.
 // Copyright (C) 2022  David Stainton.
 //

--- a/core/crypto/nike/ctidh1024/ctidh_test.go
+++ b/core/crypto/nike/ctidh1024/ctidh_test.go
@@ -1,3 +1,5 @@
+//go:build ctidh1024
+
 // ctidh_test.go - Adapts ctidh module to our NIKE interface.
 // Copyright (C) 2022  David Stainton.
 //

--- a/core/crypto/nike/ctidh2048/ctidh.go
+++ b/core/crypto/nike/ctidh2048/ctidh.go
@@ -1,3 +1,5 @@
+//go:build ctidh2048
+
 // ctidh.go - Adapts ctidh module to our NIKE interface.
 // Copyright (C) 2022  David Stainton.
 //

--- a/core/crypto/nike/ctidh2048/ctidh_test.go
+++ b/core/crypto/nike/ctidh2048/ctidh_test.go
@@ -1,3 +1,5 @@
+//go:build ctidh2048
+
 // ctidh_test.go - Adapts ctidh module to our NIKE interface.
 // Copyright (C) 2022  David Stainton.
 //

--- a/core/crypto/nike/ctidh511/ctidh.go
+++ b/core/crypto/nike/ctidh511/ctidh.go
@@ -1,3 +1,5 @@
+//go:build ctidh511
+
 // ctidh.go - Adapts ctidh module to our NIKE interface.
 // Copyright (C) 2022  David Stainton.
 //

--- a/core/crypto/nike/ctidh511/ctidh_test.go
+++ b/core/crypto/nike/ctidh511/ctidh_test.go
@@ -1,3 +1,5 @@
+//go:build ctidh511
+
 // ctidh_test.go - Adapts ctidh module to our NIKE interface.
 // Copyright (C) 2022  David Stainton.
 //

--- a/core/crypto/nike/ctidh512/ctidh.go
+++ b/core/crypto/nike/ctidh512/ctidh.go
@@ -1,3 +1,5 @@
+//go:build ctidh512
+
 // ctidh.go - Adapts ctidh module to our NIKE interface.
 // Copyright (C) 2022  David Stainton.
 //

--- a/core/crypto/nike/ctidh512/ctidh_test.go
+++ b/core/crypto/nike/ctidh512/ctidh_test.go
@@ -1,3 +1,5 @@
+//go:build ctidh512
+
 // ctidh_test.go - Adapts ctidh module to our NIKE interface.
 // Copyright (C) 2022  David Stainton.
 //

--- a/core/sphinx/ctidh1024_benchmark_test.go
+++ b/core/sphinx/ctidh1024_benchmark_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/katzenpost/katzenpost/core/crypto/kem/adapter"
-	"github.com/katzenpost/katzenpost/core/crypto/nike/ctidh"
+	ctidh "github.com/katzenpost/katzenpost/core/crypto/nike/ctidh1024"
 )
 
 func BenchmarkCtidh1024SphinxUnwrap(b *testing.B) {
@@ -33,6 +33,6 @@ func BenchmarkCtidh1024SphinxUnwrap(b *testing.B) {
 	benchmarkSphinxUnwrap(b, ctidh.CTIDH1024Scheme)
 }
 
-func BenchmarkKEMSphinxUnwrapCSTIDH1024(b *testing.B) {
+func BenchmarkKEMSphinxUnwrapCTIDH1024(b *testing.B) {
 	benchmarkKEMSphinxUnwrap(b, adapter.FromNIKE(ctidh.CTIDH1024Scheme))
 }

--- a/core/sphinx/ctidh2048_benchmark_test.go
+++ b/core/sphinx/ctidh2048_benchmark_test.go
@@ -22,9 +22,9 @@ package sphinx
 import (
 	"testing"
 
-	ctidhnike "github.com/katzenpost/katzenpost/core/crypto/nike/ctidh"
+	ctidh "github.com/katzenpost/katzenpost/core/crypto/nike/ctidh2048"
 )
 
 func BenchmarkCtidh2048SphinxUnwrap(b *testing.B) {
-	benchmarkSphinxUnwrap(b, ctidhnike.NewCtidhNike())
+	benchmarkSphinxUnwrap(b, ctidh.CTIDH2048Scheme)
 }

--- a/core/sphinx/ctidh511_benchmark_test.go
+++ b/core/sphinx/ctidh511_benchmark_test.go
@@ -22,9 +22,9 @@ package sphinx
 import (
 	"testing"
 
-	ctidhnike "github.com/katzenpost/katzenpost/core/crypto/nike/ctidh"
+	ctidhnike "github.com/katzenpost/katzenpost/core/crypto/nike/ctidh511"
 )
 
 func BenchmarkCtidh511SphinxUnwrap(b *testing.B) {
-	benchmarkSphinxUnwrap(b, ctidhnike.NewCtidhNike())
+	benchmarkSphinxUnwrap(b, ctidhnike.CTIDH511Scheme)
 }

--- a/core/sphinx/ctidh512_benchmark_test.go
+++ b/core/sphinx/ctidh512_benchmark_test.go
@@ -22,9 +22,9 @@ package sphinx
 import (
 	"testing"
 
-	ctidhnike "github.com/katzenpost/katzenpost/core/crypto/nike/ctidh"
+	ctidhnike "github.com/katzenpost/katzenpost/core/crypto/nike/ctidh512"
 )
 
 func BenchmarkCtidh512SphinxUnwrap(b *testing.B) {
-	benchmarkSphinxUnwrap(b, ctidhnike.NewCtidhNike())
+	benchmarkSphinxUnwrap(b, ctidhnike.CTIDH512Scheme)
 }

--- a/core/sphinx/kemsphinx_test.go
+++ b/core/sphinx/kemsphinx_test.go
@@ -26,12 +26,13 @@ import (
 	"github.com/cloudflare/circl/kem/kyber/kyber512"
 	"github.com/cloudflare/circl/kem/kyber/kyber768"
 	"github.com/katzenpost/katzenpost/core/sphinx/commands"
+	"github.com/katzenpost/katzenpost/core/sphinx/constants"
 	"github.com/katzenpost/katzenpost/core/sphinx/geo"
 	"github.com/stretchr/testify/require"
 )
 
 type kemNodeParams struct {
-	id         []byte
+	id         [constants.NodeIDLength]byte
 	privateKey kem.PrivateKey
 	publicKey  kem.PublicKey
 }
@@ -104,6 +105,16 @@ func TestKEMForwardSphinx(t *testing.T) {
 	testForwardKEMSphinx(t, mykem, sphinx, []byte(testPayload))
 }
 
+func TestKEMSphinxSURB(t *testing.T) {
+	t.Parallel()
+	const testPayload = "The smallest minority on earth is the individual.  Those who deny individual rights cannot claim to be defenders of minorities."
+
+	mykem := hybrid.Kyber768X25519()
+	g := geo.KEMGeometryFromUserForwardPayloadLength(mykem, len(testPayload), false, 20)
+	sphinx := NewKEMSphinx(mykem, g)
+	testSURBKEMSphinx(t, mykem, sphinx, []byte(testPayload))
+}
+
 func newKEMNode(require *require.Assertions, mykem kem.Scheme) *kemNodeParams {
 	n := new(kemNodeParams)
 
@@ -171,7 +182,7 @@ func testForwardKEMSphinx(t *testing.T, mykem kem.Scheme, sphinx *Sphinx, testPa
 
 		// Unwrap the packet, validating the output.
 		for i := range nodes {
-			b, _, cmds, err := sphinx.unwrapKem(nodes[i].privateKey, pkt)
+			b, _, cmds, err := sphinx.Unwrap(nodes[i].privateKey, pkt)
 			require.NoErrorf(err, "Hop %d: Unwrap failed", i)
 
 			if i == len(path)-1 {
@@ -180,6 +191,7 @@ func testForwardKEMSphinx(t *testing.T, mykem kem.Scheme, sphinx *Sphinx, testPa
 
 				require.Equalf(b, payload, "Hop %d: payload mismatch", i)
 			} else {
+				require.Equal(sphinx.Geometry().PacketLength, len(pkt))
 				require.Equalf(2, len(cmds), "Hop %d: Unexpected number of commands", i)
 				require.EqualValuesf(path[i].Commands[0], cmds[0], "Hop %d: delay mismatch", i)
 
@@ -188,6 +200,62 @@ func testForwardKEMSphinx(t *testing.T, mykem kem.Scheme, sphinx *Sphinx, testPa
 				require.Equalf(path[i+1].ID, nextNode.ID, "Hop %d: NextNodeHop.ID mismatch", i)
 
 				require.Nil(b, "Hop %d: returned payload", i)
+			}
+		}
+	}
+}
+
+func testSURBKEMSphinx(t *testing.T, mykem kem.Scheme, sphinx *Sphinx, testPayload []byte) {
+	require := require.New(t)
+
+	require.Equal(sphinx.Geometry().NIKEName, "")
+	require.NotEqual(sphinx.Geometry().KEMName, "")
+	require.Nil(sphinx.nike)
+	require.NotNil(sphinx.kem)
+
+	for nrHops := 1; nrHops <= sphinx.Geometry().NrHops; nrHops++ {
+		t.Logf("Testing %d hop(s).", nrHops)
+
+		// Generate the "nodes" and path for the SURB.
+		nodes, path := newKEMPathVector(require, mykem, nrHops, true)
+
+		// Create the SURB.
+		surb, surbKeys, err := sphinx.NewSURB(rand.Reader, path)
+		require.NoError(err, "NewSURB failed")
+		require.Equal(sphinx.Geometry().SURBLength, len(surb), "SURB length")
+
+		// Create a reply packet using the SURB.
+		payload := []byte(testPayload)
+		pkt, firstHop, err := sphinx.NewPacketFromSURB(surb, payload)
+		require.NoError(err, "NewPacketFromSURB failed")
+		//require.EqualValues(&nodes[0].id, firstHop, "NewPacketFromSURB: 0th hop")
+		require.NotNil(firstHop)
+		require.NotNil(nodes[0].id)
+
+		// Unwrap the packet, valdiating the output.
+		for i := range nodes {
+			// There's no sensible way to validate that `tag` is correct.
+			b, _, cmds, err := sphinx.Unwrap(nodes[i].privateKey, pkt)
+			require.NoErrorf(err, "SURB Hop %d: Unwrap failed", i)
+
+			if i == len(path)-1 {
+				require.Equalf(2, len(cmds), "SURB Hop %d: Unexpected number of commands", i)
+				require.EqualValuesf(path[i].Commands[0], cmds[0], "SURB Hop %d: recipient mismatch", i)
+				require.EqualValuesf(path[i].Commands[1], cmds[1], "SURB Hop %d: surb_reply mismatch", i)
+
+				b, err = sphinx.DecryptSURBPayload(b, surbKeys)
+				require.NoError(err, "DecrytSURBPayload")
+				require.Equalf(b, payload, "SURB Hop %d: payload mismatch", i)
+			} else {
+				require.Equal(sphinx.Geometry().PacketLength, len(pkt))
+				require.Equalf(2, len(cmds), "SURB Hop %d: Unexpected number of commands", i)
+				require.EqualValuesf(path[i].Commands[0], cmds[0], "SURB Hop %d: delay mismatch", i)
+
+				nextNode, ok := cmds[1].(*commands.NextNodeHop)
+				require.Truef(ok, "SURB Hop %d: cmds[1] is not a NextNodeHop", i)
+				require.Equalf(path[i+1].ID, nextNode.ID, "SURB Hop %d: NextNodeHop.ID mismatch", i)
+
+				require.Nil(b, "SURB Hop %d: returned payload", i)
 			}
 		}
 	}

--- a/core/sphinx/sphinx_ctidh1024_test.go
+++ b/core/sphinx/sphinx_ctidh1024_test.go
@@ -1,0 +1,69 @@
+//go:build ctidh1024
+
+// sphinx_ctidh_test.go - Sphinx Packet Format tests.
+// Copyright (C) 2022  David Stainton.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package sphinx
+
+import (
+	"testing"
+
+	ctidh "github.com/katzenpost/katzenpost/core/crypto/nike/ctidh1024"
+	"github.com/katzenpost/katzenpost/core/crypto/nike/hybrid"
+	"github.com/katzenpost/katzenpost/core/sphinx/geo"
+)
+
+func TestHybridCtidhForwardSphinx(t *testing.T) {
+	const testPayload = "It is the stillest words that bring on the storm.  Thoughts that come on doves’ feet guide the world."
+
+	mynike := hybrid.CTIDH1024X25519
+	g := geo.GeometryFromUserForwardPayloadLength(mynike, len(testPayload), false, 5)
+
+	t.Logf("NIKE: %s", g.NIKEName)
+	t.Logf("KEM: %s", g.KEMName)
+
+	sphinx := NewNIKESphinx(mynike, g)
+
+	testForwardSphinx(t, mynike, sphinx, []byte(testPayload))
+}
+
+func TestCtidhForwardSphinx(t *testing.T) {
+	const testPayload = "It is the stillest words that bring on the storm.  Thoughts that come on doves’ feet guide the world."
+
+	mynike := ctidh.CTIDH1024Scheme
+	geo := geo.GeometryFromUserForwardPayloadLength(mynike, len(testPayload), false, 5)
+	sphinx := NewNIKESphinx(mynike, geo)
+
+	testForwardSphinx(t, mynike, sphinx, []byte(testPayload))
+}
+
+func TestCtidhSURB(t *testing.T) {
+	const testPayload = "The smallest minority on earth is the individual.  Those who deny individual rights cannot claim to be defenders of minorities."
+
+	mynike := ctidh.CTIDH1024Scheme
+	geo := geo.GeometryFromUserForwardPayloadLength(mynike, len(testPayload), false, 5)
+	sphinx := NewNIKESphinx(mynike, geo)
+
+	testSURB(t, mynike, sphinx, []byte(testPayload))
+}
+
+func TestCTIDHSphinxGeometry(t *testing.T) {
+	withSURB := false
+	g := geo.GeometryFromUserForwardPayloadLength(ctidh.CTIDH1024Scheme, 512, withSURB, 5)
+	t.Logf("NIKE Sphinx CTIDH 5 hops: HeaderLength = %d", g.HeaderLength)
+	g = geo.GeometryFromUserForwardPayloadLength(ctidh.CTIDH1024Scheme, 512, withSURB, 10)
+	t.Logf("NIKE Sphinx CTIDH 10 hops: HeaderLength = %d", g.HeaderLength)
+}

--- a/core/sphinx/sphinx_ctidh2048_test.go
+++ b/core/sphinx/sphinx_ctidh2048_test.go
@@ -1,5 +1,4 @@
-//go:build ctidh
-// +build ctidh
+//go:build ctidh2048
 
 // sphinx_ctidh_test.go - Sphinx Packet Format tests.
 // Copyright (C) 2022  David Stainton.
@@ -20,23 +19,17 @@
 package sphinx
 
 import (
-	"crypto/rand"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/katzenpost/katzenpost/core/crypto/nike"
-	"github.com/katzenpost/katzenpost/core/crypto/nike/ctidh"
-	ecdhnike "github.com/katzenpost/katzenpost/core/crypto/nike/ecdh"
+	ctidh "github.com/katzenpost/katzenpost/core/crypto/nike/ctidh2048"
 	"github.com/katzenpost/katzenpost/core/crypto/nike/hybrid"
 	"github.com/katzenpost/katzenpost/core/sphinx/geo"
 )
 
 func TestHybridCtidhForwardSphinx(t *testing.T) {
-	t.Parallel()
 	const testPayload = "It is the stillest words that bring on the storm.  Thoughts that come on doves’ feet guide the world."
 
-	mynike := hybrid.CTIDH1024X25519
+	mynike := hybrid.CTIDH2048X25519
 	g := geo.GeometryFromUserForwardPayloadLength(mynike, len(testPayload), false, 5)
 
 	t.Logf("NIKE: %s", g.NIKEName)
@@ -47,30 +40,10 @@ func TestHybridCtidhForwardSphinx(t *testing.T) {
 	testForwardSphinx(t, mynike, sphinx, []byte(testPayload))
 }
 
-func TestSphinxConstruction(t *testing.T) {
-	var mynike nike.Scheme
-	mynike = ecdhnike.NewEcdhNike(rand.Reader)
-	g := geo.GeometryFromUserForwardPayloadLength(mynike, 12345, false, 5)
-	t.Logf("NIKEName %s", g.NIKEName)
-	sphinx := NewSphinx(g)
-	require.NotNil(t, sphinx.nike)
-
-	/* XXX this code panics if CTIDH1024Scheme isn't included in the
-	   NIKE Scheme map in the nike/schemes module.
-
-			mynike = ctidh.CTIDH1024Scheme
-			g = geo.GeometryFromUserForwardPayloadLength(mynike, 12345, false, 5)
-			t.Logf("NIKEName %s", g.NIKEName)
-			sphinx = NewSphinx(g)
-			require.NotNil(t, sphinx.nike)
-	*/
-}
-
 func TestCtidhForwardSphinx(t *testing.T) {
-	t.Parallel()
 	const testPayload = "It is the stillest words that bring on the storm.  Thoughts that come on doves’ feet guide the world."
 
-	mynike := ctidh.CTIDH1024Scheme
+	mynike := ctidh.CTIDH2048Scheme
 	geo := geo.GeometryFromUserForwardPayloadLength(mynike, len(testPayload), false, 5)
 	sphinx := NewNIKESphinx(mynike, geo)
 
@@ -78,10 +51,9 @@ func TestCtidhForwardSphinx(t *testing.T) {
 }
 
 func TestCtidhSURB(t *testing.T) {
-	t.Parallel()
 	const testPayload = "The smallest minority on earth is the individual.  Those who deny individual rights cannot claim to be defenders of minorities."
 
-	mynike := ctidh.CTIDH1024Scheme
+	mynike := ctidh.CTIDH2048Scheme
 	geo := geo.GeometryFromUserForwardPayloadLength(mynike, len(testPayload), false, 5)
 	sphinx := NewNIKESphinx(mynike, geo)
 
@@ -89,10 +61,9 @@ func TestCtidhSURB(t *testing.T) {
 }
 
 func TestCTIDHSphinxGeometry(t *testing.T) {
-	t.Parallel()
 	withSURB := false
-	g := geo.GeometryFromUserForwardPayloadLength(ctidh.CTIDH1024Scheme, 512, withSURB, 5)
+	g := geo.GeometryFromUserForwardPayloadLength(ctidh.CTIDH2048Scheme, 512, withSURB, 5)
 	t.Logf("NIKE Sphinx CTIDH 5 hops: HeaderLength = %d", g.HeaderLength)
-	g = geo.GeometryFromUserForwardPayloadLength(ctidh.CTIDH1024Scheme, 512, withSURB, 10)
+	g = geo.GeometryFromUserForwardPayloadLength(ctidh.CTIDH2048Scheme, 512, withSURB, 10)
 	t.Logf("NIKE Sphinx CTIDH 10 hops: HeaderLength = %d", g.HeaderLength)
 }

--- a/core/sphinx/sphinx_ctidh511_test.go
+++ b/core/sphinx/sphinx_ctidh511_test.go
@@ -1,0 +1,69 @@
+//go:build ctidh511
+
+// sphinx_ctidh_test.go - Sphinx Packet Format tests.
+// Copyright (C) 2022  David Stainton.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package sphinx
+
+import (
+	"testing"
+
+	ctidh "github.com/katzenpost/katzenpost/core/crypto/nike/ctidh511"
+	"github.com/katzenpost/katzenpost/core/crypto/nike/hybrid"
+	"github.com/katzenpost/katzenpost/core/sphinx/geo"
+)
+
+func TestHybridCtidhForwardSphinx(t *testing.T) {
+	const testPayload = "It is the stillest words that bring on the storm.  Thoughts that come on doves’ feet guide the world."
+
+	mynike := hybrid.CTIDH511X25519
+	g := geo.GeometryFromUserForwardPayloadLength(mynike, len(testPayload), false, 5)
+
+	t.Logf("NIKE: %s", g.NIKEName)
+	t.Logf("KEM: %s", g.KEMName)
+
+	sphinx := NewNIKESphinx(mynike, g)
+
+	testForwardSphinx(t, mynike, sphinx, []byte(testPayload))
+}
+
+func TestCtidhForwardSphinx(t *testing.T) {
+	const testPayload = "It is the stillest words that bring on the storm.  Thoughts that come on doves’ feet guide the world."
+
+	mynike := ctidh.CTIDH511Scheme
+	geo := geo.GeometryFromUserForwardPayloadLength(mynike, len(testPayload), false, 5)
+	sphinx := NewNIKESphinx(mynike, geo)
+
+	testForwardSphinx(t, mynike, sphinx, []byte(testPayload))
+}
+
+func TestCtidhSURB(t *testing.T) {
+	const testPayload = "The smallest minority on earth is the individual.  Those who deny individual rights cannot claim to be defenders of minorities."
+
+	mynike := ctidh.CTIDH511Scheme
+	geo := geo.GeometryFromUserForwardPayloadLength(mynike, len(testPayload), false, 5)
+	sphinx := NewNIKESphinx(mynike, geo)
+
+	testSURB(t, mynike, sphinx, []byte(testPayload))
+}
+
+func TestCTIDHSphinxGeometry(t *testing.T) {
+	withSURB := false
+	g := geo.GeometryFromUserForwardPayloadLength(ctidh.CTIDH511Scheme, 512, withSURB, 5)
+	t.Logf("NIKE Sphinx CTIDH 5 hops: HeaderLength = %d", g.HeaderLength)
+	g = geo.GeometryFromUserForwardPayloadLength(ctidh.CTIDH511Scheme, 512, withSURB, 10)
+	t.Logf("NIKE Sphinx CTIDH 10 hops: HeaderLength = %d", g.HeaderLength)
+}

--- a/core/sphinx/sphinx_ctidh512_test.go
+++ b/core/sphinx/sphinx_ctidh512_test.go
@@ -1,0 +1,69 @@
+//go:build ctidh512
+
+// sphinx_ctidh_test.go - Sphinx Packet Format tests.
+// Copyright (C) 2022  David Stainton.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package sphinx
+
+import (
+	"testing"
+
+	ctidh "github.com/katzenpost/katzenpost/core/crypto/nike/ctidh512"
+	"github.com/katzenpost/katzenpost/core/crypto/nike/hybrid"
+	"github.com/katzenpost/katzenpost/core/sphinx/geo"
+)
+
+func TestHybridCtidhForwardSphinx(t *testing.T) {
+	const testPayload = "It is the stillest words that bring on the storm.  Thoughts that come on doves’ feet guide the world."
+
+	mynike := hybrid.CTIDH512X25519
+	g := geo.GeometryFromUserForwardPayloadLength(mynike, len(testPayload), false, 5)
+
+	t.Logf("NIKE: %s", g.NIKEName)
+	t.Logf("KEM: %s", g.KEMName)
+
+	sphinx := NewNIKESphinx(mynike, g)
+
+	testForwardSphinx(t, mynike, sphinx, []byte(testPayload))
+}
+
+func TestCtidhForwardSphinx(t *testing.T) {
+	const testPayload = "It is the stillest words that bring on the storm.  Thoughts that come on doves’ feet guide the world."
+
+	mynike := ctidh.CTIDH512Scheme
+	geo := geo.GeometryFromUserForwardPayloadLength(mynike, len(testPayload), false, 5)
+	sphinx := NewNIKESphinx(mynike, geo)
+
+	testForwardSphinx(t, mynike, sphinx, []byte(testPayload))
+}
+
+func TestCtidhSURB(t *testing.T) {
+	const testPayload = "The smallest minority on earth is the individual.  Those who deny individual rights cannot claim to be defenders of minorities."
+
+	mynike := ctidh.CTIDH512Scheme
+	geo := geo.GeometryFromUserForwardPayloadLength(mynike, len(testPayload), false, 5)
+	sphinx := NewNIKESphinx(mynike, geo)
+
+	testSURB(t, mynike, sphinx, []byte(testPayload))
+}
+
+func TestCTIDHSphinxGeometry(t *testing.T) {
+	withSURB := false
+	g := geo.GeometryFromUserForwardPayloadLength(ctidh.CTIDH512Scheme, 512, withSURB, 5)
+	t.Logf("NIKE Sphinx CTIDH 5 hops: HeaderLength = %d", g.HeaderLength)
+	g = geo.GeometryFromUserForwardPayloadLength(ctidh.CTIDH512Scheme, 512, withSURB, 10)
+	t.Logf("NIKE Sphinx CTIDH 10 hops: HeaderLength = %d", g.HeaderLength)
+}

--- a/core/sphinx/sphinx_test.go
+++ b/core/sphinx/sphinx_test.go
@@ -110,6 +110,7 @@ func testForwardSphinx(t *testing.T, mynike nike.Scheme, sphinx *Sphinx, testPay
 
 				require.Equalf(b, payload, "Hop %d: payload mismatch", i)
 			} else {
+				require.Equal(sphinx.Geometry().PacketLength, len(pkt))
 				require.Equalf(2, len(cmds), "Hop %d: Unexpected number of commands", i)
 				require.EqualValuesf(path[i].Commands[0], cmds[0], "Hop %d: delay mismatch", i)
 
@@ -158,7 +159,7 @@ func testSURB(t *testing.T, mynike nike.Scheme, sphinx *Sphinx, testPayload []by
 				require.NoError(err, "DecrytSURBPayload")
 				require.Equalf(b, payload, "SURB Hop %d: payload mismatch", i)
 			} else {
-
+				require.Equal(sphinx.Geometry().PacketLength, len(pkt))
 				require.Equalf(2, len(cmds), "SURB Hop %d: Unexpected number of commands", i)
 				require.EqualValuesf(path[i].Commands[0], cmds[0], "SURB Hop %d: delay mismatch", i)
 


### PR DESCRIPTION
This change makes sure that the Sphinx unit tests are testing for the correct packet size at each stop in the packet unwarp. Here we also add a SURB test for KEM Sphinx. And we fix the CTIDH Sphinx tests.