### PR TITLE
authority/voting/server: omit logging PII upon GetConsensus failure

### DIFF
--- a/authority/voting/server/wire_handler.go
+++ b/authority/voting/server/wire_handler.go
@@ -149,7 +149,6 @@ func (s *Server) onGetConsensus(rAddr net.Addr, cmd *commands.GetConsensus) comm
 	resp := &commands.Consensus{}
 	doc, err := s.state.documentForEpoch(cmd.Epoch)
 	if err != nil {
-		s.log.Errorf("Peer %v: Failed to retrieve document for epoch '%v': %v", rAddr, cmd.Epoch, err)
 		switch err {
 		case errGone:
 			resp.ErrorCode = commands.ConsensusGone


### PR DESCRIPTION
If there is no document available for the requested epoch, the requesting client IP is being logged.
