### PR TITLE
Fix -g flag to dirauth server

### DIFF
--- a/authority/voting/server/config/config.go
+++ b/authority/voting/server/config/config.go
@@ -454,7 +454,7 @@ func (cfg *Config) ValidateAuthorities(linkPubKey kem.PublicKey) error {
 // FixupAndValidate applies defaults to config entries and validates the
 // supplied configuration.  Most people should call one of the Load variants
 // instead.
-func (cfg *Config) FixupAndValidate() error {
+func (cfg *Config) FixupAndValidate(forceGenOnly bool) error {
 
 	if cfg.SphinxGeometry == nil {
 		return errors.New("config: No SphinxGeometry block was present")
@@ -505,6 +505,10 @@ func (cfg *Config) FixupAndValidate() error {
 	}
 
 	var identityKey sign.PublicKey
+
+	if forceGenOnly {
+		return nil
+	}
 
 	idMap := make(map[string]*Node)
 	pkMap := make(map[[publicKeyHashSize]byte]*Node)
@@ -571,7 +575,7 @@ func Load(b []byte, forceGenOnly bool) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := cfg.FixupAndValidate(); err != nil {
+	if err := cfg.FixupAndValidate(forceGenOnly); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Merging this PR will fix a bug in the dirauth server thus allowing it to generate new keys with the -g flag.