### PR TITLE
core/pki: get rid of Transport type alias

### DIFF
--- a/authority/voting/client/client_test.go
+++ b/authority/voting/client/client_test.go
@@ -120,8 +120,8 @@ func generateNodes(isServiceNode, isGateway bool, num int, epoch uint64) ([]*pki
 			IdentityKey: blob,
 			LinkKey:     linkKeyBlob,
 			MixKeys:     mixKeys,
-			Addresses: map[pki.Transport][]string{
-				pki.Transport("tcp4"): []string{fmt.Sprintf("127.0.0.1:%d", i+1)},
+			Addresses: map[string][]string{
+				"tcp4": []string{fmt.Sprintf("127.0.0.1:%d", i+1)},
 			},
 			Kaetzchen:     nil,
 			IsGatewayNode: isGateway,

--- a/authority/voting/server/state_test.go
+++ b/authority/voting/server/state_test.go
@@ -222,7 +222,7 @@ func TestVote(t *testing.T) {
 	serviceDescs := make([]*pki.MixDescriptor, 0)
 	for i := 0; i < len(mixCfgs); i++ {
 		mkeys := genMixKeys(votingEpoch)
-		addr := make(map[pki.Transport][]string)
+		addr := make(map[string][]string)
 		addr[pki.TransportTCPv4] = []string{"127.0.0.1:1234"}
 		linkPubKey, _, err := testingScheme.GenerateKeyPair()
 		linkBlob, err := linkPubKey.MarshalBinary()

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -96,7 +96,7 @@ type Debug struct {
 
 	// PreferedTransports is a list of the transports will be used to make
 	// outgoing network connections, with the most prefered first.
-	PreferedTransports []pki.Transport
+	PreferedTransports []string
 }
 
 func (d *Debug) fixup() {

--- a/core/pki/descriptor.go
+++ b/core/pki/descriptor.go
@@ -119,7 +119,7 @@ type MixDescriptor struct {
 
 	// Addresses is the map of transport to address combinations that can
 	// be used to reach the node.
-	Addresses map[Transport][]string
+	Addresses map[string][]string
 
 	// Kaetzchen is the map of provider autoresponder agents by capability
 	// to parameters.

--- a/core/pki/descriptor_test.go
+++ b/core/pki/descriptor_test.go
@@ -43,7 +43,7 @@ func TestDescriptor(t *testing.T) {
 
 	// Build a well formed descriptor.
 	d.Name = "hydra-dominatus.example.net"
-	d.Addresses = map[Transport][]string{
+	d.Addresses = map[string][]string{
 		TransportTCPv4: []string{"192.0.2.1:4242", "192.0.2.1:1234", "198.51.100.2:4567"},
 		TransportTCPv6: []string{"[2001:DB8::1]:8901"},
 	}

--- a/core/pki/document.go
+++ b/core/pki/document.go
@@ -360,30 +360,27 @@ func (d *Document) GetNodeByKeyHash(keyhash *[32]byte) (*MixDescriptor, error) {
 	return nil, fmt.Errorf("pki: node not found")
 }
 
-// Transport is a link transport protocol.
-type Transport string
-
 var (
 	// TransportInvalid is the invalid transport.
-	TransportInvalid Transport
+	TransportInvalid string
 
 	// TransportTCP is TCP, with the IP version determined by the results of
 	// a name server lookup.
-	TransportTCP Transport = "tcp"
+	TransportTCP string = "tcp"
 
 	// TransportTCPv4 is TCP over IPv4.
-	TransportTCPv4 Transport = "tcp4"
+	TransportTCPv4 string = "tcp4"
 
 	// TransportTCPv6 is TCP over IPv6.
-	TransportTCPv6 Transport = "tcp6"
+	TransportTCPv6 string = "tcp6"
 
 	// InternalTransports is the list of transports used for non-client related
 	// communications.
-	InternalTransports = []Transport{TransportTCPv4, TransportTCPv6}
+	InternalTransports = []string{TransportTCPv4, TransportTCPv6}
 
 	// ClientTransports is the list of transports used by default for client
 	// to provider communication.
-	ClientTransports = []Transport{TransportTCP, TransportTCPv4, TransportTCPv6}
+	ClientTransports = []string{TransportTCP, TransportTCPv4, TransportTCPv6}
 )
 
 // FromPayload deserializes, then verifies a Document, and returns the Document or error.

--- a/core/pki/document_test.go
+++ b/core/pki/document_test.go
@@ -37,7 +37,7 @@ var testingScheme = schemes.ByName(testingSchemeName)
 func genDescriptor(require *require.Assertions, idx int, isGatewayNode, isServiceNode bool) *MixDescriptor {
 	d := new(MixDescriptor)
 	d.Name = fmt.Sprintf("gen%d.example.net", idx)
-	d.Addresses = map[Transport][]string{
+	d.Addresses = map[string][]string{
 		TransportTCPv4: []string{fmt.Sprintf("192.0.2.%d:4242", idx)},
 	}
 	d.IsGatewayNode = isGatewayNode

--- a/minclient/client.go
+++ b/minclient/client.go
@@ -108,7 +108,7 @@ type ClientConfig struct {
 
 	// PreferedTransports is a list of the transports will be used to make
 	// outgoing network connections, with the most prefered first.
-	PreferedTransports []cpki.Transport
+	PreferedTransports []string
 
 	// MessagePollInterval is the interval at which the server will be
 	// polled for new messages if the queue is belived to be empty.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -155,7 +155,7 @@ func (sCfg *Server) validate() error {
 
 	for k, v := range sCfg.AltAddresses {
 		lowkey := strings.ToLower(k)
-		switch pki.Transport(lowkey) {
+		switch lowkey {
 		case pki.TransportTCP:
 			for _, a := range v {
 				h, p, err := net.SplitHostPort(a)
@@ -617,7 +617,7 @@ func (pCfg *Gateway) validate() error {
 		if internalTransports[kLower] {
 			return fmt.Errorf("config: Provider: AltAddress is overriding internal transport: %v", kLower)
 		}
-		switch pki.Transport(kLower) {
+		switch kLower {
 		case pki.TransportTCP:
 			for _, a := range v {
 				h, p, err := net.SplitHostPort(a)

--- a/server/internal/decoy/decoy_test.go
+++ b/server/internal/decoy/decoy_test.go
@@ -228,8 +228,8 @@ func generateNodes(isGatewayNode, isServiceNode bool, num int, epoch uint64) ([]
 			IdentityKey: blob,
 			LinkKey:     linkKeyBlob,
 			MixKeys:     mixKeys,
-			Addresses: map[pki.Transport][]string{
-				pki.Transport("tcp4"): []string{fmt.Sprintf("127.0.0.1:%d", i+1)},
+			Addresses: map[string][]string{
+				"tcp4": []string{fmt.Sprintf("127.0.0.1:%d", i+1)},
 			},
 			Kaetzchen:     nil,
 			IsServiceNode: isServiceNode,

--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -61,7 +61,7 @@ type pki struct {
 	log  *logging.Logger
 
 	impl               cpki.Client
-	descAddrMap        map[cpki.Transport][]string
+	descAddrMap        map[string][]string
 	docs               map[uint64]*pkicache.Entry
 	rawDocs            map[uint64][]byte
 	failedFetches      map[uint64]error
@@ -686,7 +686,7 @@ func New(glue glue.Glue) (glue.PKI, error) {
 
 	var err error
 	if glue.Config().Server.OnlyAdvertiseAltAddresses {
-		p.descAddrMap = make(map[cpki.Transport][]string)
+		p.descAddrMap = make(map[string][]string)
 	} else {
 		if p.descAddrMap, err = makeDescAddrMap(glue.Config().Server.Addresses); err != nil {
 			return nil, err
@@ -698,7 +698,7 @@ func New(glue glue.Glue) (glue.PKI, error) {
 		if len(v) == 0 {
 			continue
 		}
-		kTransport := cpki.Transport(strings.ToLower(k))
+		kTransport := string(strings.ToLower(k))
 		if _, ok := p.descAddrMap[kTransport]; ok {
 			return nil, fmt.Errorf("BUG: pki: AltAddresses overrides existing transport: '%v'", k)
 		}
@@ -735,8 +735,8 @@ func New(glue glue.Glue) (glue.PKI, error) {
 	return p, nil
 }
 
-func makeDescAddrMap(addrs []string) (map[cpki.Transport][]string, error) {
-	m := make(map[cpki.Transport][]string)
+func makeDescAddrMap(addrs []string) (map[string][]string, error) {
+	m := make(map[string][]string)
 	for _, addr := range addrs {
 		h, p, err := net.SplitHostPort(addr)
 		if err != nil {
@@ -746,7 +746,7 @@ func makeDescAddrMap(addrs []string) (map[cpki.Transport][]string, error) {
 			return nil, err
 		}
 
-		var t cpki.Transport
+		var t string
 		ip := net.ParseIP(h)
 		if ip == nil {
 			return nil, fmt.Errorf("address '%v' is not an IP", h)


### PR DESCRIPTION
The goal is to get rid of the golang type alias within core/pki. The pki Transport type alias is really just a string however using this type alias complicates a lot of client code. Changing this back to string will be a welcome change.