### PR TITLE
fix TestKeyExchangeWithSerialization

### DIFF
--- a/panda/crypto/panda_test.go
+++ b/panda/crypto/panda_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"crypto/rand"
 	"errors"
+	"sync"
+	"testing"
+
 	"github.com/katzenpost/katzenpost/core/log"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/op/go-logging.v1"
-	"sync"
-	"testing"
 )
 
 const paddingSize = 1 << 16


### PR DESCRIPTION
This PR resolves the deadlock issue in https://github.com/katzenpost/katzenpost/actions/runs/9216037360/job/25356619537?pr=588

```
panic: test timed out after 30m0s
running tests:
	TestKeyExchangeWithSerialization (30m0s)
```

The error is probably happening because no other part of the application is producing data to  `pandaChan`, due to a tight loop, adding select/default makes it non-blocking.