### PR TITLE
docker: make compatible with docker v2

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -71,9 +71,13 @@ replace_name=$(shell if echo ${docker}|grep -q podman; then echo " --replace --n
 i_if_podman=$(shell if echo ${docker}|grep -q podman; then echo " -i"; else echo; fi)
 mount_net_name=-v `pwd`/$(net_name):/$(net_name)
 
-docker_compose?= $(shell if echo ${docker}|grep -q podman; then echo DOCKER_HOST="unix://$$XDG_RUNTIME_DIR/podman/podman.sock" docker-compose; else echo docker-compose; fi)
+docker_compose_v1_or_v2?= $(shell [ -e /usr/libexec/docker/cli-plugins/docker-compose ] && echo /usr/libexec/docker/cli-plugins/docker-compose || echo docker-compose)
+docker_compose?= $(shell if which podman|grep -q .; then echo DOCKER_HOST="unix://$$XDG_RUNTIME_DIR/podman/podman.sock" $(docker_compose_v1_or_v2); else echo $(docker_compose_v1_or_v2); fi)
 
 make_args=--no-print-directory net_name=$(net_name) docker=$(docker) distro=$(distro) warped=$(warped) docker_user=$(docker_user)
+
+$(net_name):
+	mkdir -p $(net_name)
 
 $(docker_compose_yml): ../genconfig/main.go $(distro)_go_mod.stamp
 	mkdir -p $(net_name)
@@ -204,7 +208,7 @@ run-ping: $(net_name)/ping.$(distro) $(net_name)/running.stamp
 	$(docker) run --network=host ${docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_go_mod \
         /$(net_name)/ping.$(distro) -c /go/katzenpost/docker/$(net_name)/client/client.toml -s echo -printDiff -n 1
 
-shell: $(distro)_go_mod.stamp
+shell: $(distro)_go_mod.stamp $(net_name)
 	$(docker) run --network=host ${docker_args} $(mount_net_name) -w /go/katzenpost/docker/$(net_name) --rm -it katzenpost-$(distro)_go_mod $(sh)
 
 # this is for running with docker, where we are root outside and (except for

--- a/docker/README.rst
+++ b/docker/README.rst
@@ -10,7 +10,7 @@ mix network components as part of the core Katzenpost developer work flow.
 0. Requirements
 
 * Podman or Docker
-* docker-compose (tested with 1.29.2, among other versions)
+* either docker-compose (v1) or docker compose v2
 * GNU Make
 
 1. Run a test network


### PR DESCRIPTION
on systems with a new enough version of the Python requests module it is no longer possible to use the (deprecated) standalone docker-compose v1.

with this commit we will now use docker compose v2 (the "compose" subcommand to docker) if it is installed. we are calling its executable directly, which can drive either podman or docker.

this commit also makes the shell target create the network directory if it does not exist. (note that we still run mkdir -p in the docker_compose_yml target separately rather than depending on the target that creates it because depending on that causes the config to be regenerated every time the directory is modified.)