### PR TITLE
BUG FIX: Remove prometheus goroutines for monitoring buf chans

### DIFF
--- a/server/internal/gateway/gateway.go
+++ b/server/internal/gateway/gateway.go
@@ -311,9 +311,6 @@ func New(glue glue.Glue) (glue.Gateway, error) {
 		p.Go(p.worker)
 	}
 
-	// monitor channel length
-	instrument.MonitorChannelLen("server.gateway.ch", p.HaltCh(), p.ch)
-
 	isOk = true
 	return p, nil
 }

--- a/server/internal/instrument/prometheus.go
+++ b/server/internal/instrument/prometheus.go
@@ -6,7 +6,6 @@ package instrument
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/katzenpost/katzenpost/core/wire/commands"
 	"github.com/katzenpost/katzenpost/server/internal/glue"
@@ -167,23 +166,6 @@ var (
 		[]string{"channel_name"},
 	)
 )
-
-func MonitorChannelLen(name string, haltCh <-chan interface{}, ch chan interface{}) {
-	go doMonitorChannelLen(name, haltCh, ch)
-}
-
-func doMonitorChannelLen(name string, haltCh <-chan interface{}, ch chan interface{}) {
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-haltCh:
-			return
-		case <-ticker.C:
-			channelUsage.With(prometheus.Labels{"channel_name": name}).Set(float64(len(ch)))
-		}
-	}
-}
 
 // StartPrometheusListener starts the Prometheus metrics TCP/HTTP Listener
 func StartPrometheusListener(glue glue.Glue) {

--- a/server/internal/scheduler/scheduler.go
+++ b/server/internal/scheduler/scheduler.go
@@ -238,9 +238,6 @@ func New(glue glue.Glue) (glue.Scheduler, error) {
 		sch.q = newMemoryQueue(glue, sch.log)
 	}
 
-	// monitor channel length
-	instrument.MonitorChannelLen("server.scheduler.inCh", sch.HaltCh(), sch.inCh)
-
 	sch.Go(sch.pipeWorker)
 	sch.Go(sch.worker)
 	return sch, nil

--- a/server/internal/service/kaetzchen/kaetzchen.go
+++ b/server/internal/service/kaetzchen/kaetzchen.go
@@ -290,8 +290,5 @@ func New(glue glue.Glue) (*KaetzchenWorker, error) {
 		kaetzchenWorker.Go(kaetzchenWorker.worker)
 	}
 
-	// monitor channel length
-	instrument.MonitorChannelLen("server.kaetzchen.ch", kaetzchenWorker.HaltCh(), kaetzchenWorker.ch)
-
 	return &kaetzchenWorker, nil
 }

--- a/server/internal/service/service.go
+++ b/server/internal/service/service.go
@@ -166,9 +166,6 @@ func New(glue glue.Glue) (glue.ServiceNode, error) {
 		p.Go(p.worker)
 	}
 
-	// monitor channel length
-	instrument.MonitorChannelLen("server.service.ch", p.HaltCh(), p.ch)
-
 	isOk = true
 	return p, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -425,9 +425,6 @@ func New(cfg *config.Config) (*Server, error) {
 	// Start the periodic 1 Hz utility timer.
 	s.periodic = newPeriodicTimer(s)
 
-	// monitor channel length
-	instrument.MonitorChannelLen("server.inboundPackets", s.haltedCh, s.inboundPackets)
-
 	isOk = true
 	return s, nil
 }


### PR DESCRIPTION
The extra goroutines used for the Prometheus gauges of buffered channel usage are causing high mix server load.