### PR TITLE
wire: reverse initiator/responder

### DIFF
--- a/authority/voting/client/client.go
+++ b/authority/voting/client/client.go
@@ -180,7 +180,11 @@ func (p *connector) initSession(ctx context.Context, doneCh <-chan interface{}, 
 		AuthenticationKey:  linkKey,
 		RandomReader:       rand.Reader,
 	}
-	s, err := wire.NewPKISession(cfg, true)
+
+	// was previously s, err := wire.NewPKISession(cfg, true)
+	// where true indicates initiator
+	// see ticket https://github.com/katzenpost/katzenpost/issues/630
+	s, err := wire.NewPKISession(cfg, false)
 	if err != nil {
 		return nil, err
 	}

--- a/authority/voting/client/client_test.go
+++ b/authority/voting/client/client_test.go
@@ -294,7 +294,10 @@ func (d *mockDialer) mockServer(address string, linkPrivateKey kem.PrivateKey, i
 		AuthenticationKey: linkPrivateKey,
 		RandomReader:      rand.Reader,
 	}
-	session, err := wire.NewSession(cfg, false)
+
+	// was previously session, err := wire.NewSession(cfg, false)
+	// see ticket https://github.com/katzenpost/katzenpost/issues/630
+	session, err := wire.NewSession(cfg, true)
 	if err != nil {
 		d.log.Errorf("mockServer NewSession failure: %s", err)
 		return

--- a/authority/voting/server/state.go
+++ b/authority/voting/server/state.go
@@ -735,7 +735,9 @@ func (s *state) sendCommandToPeer(peer *config.Authority, cmd commands.Command) 
 		AuthenticationKey: s.s.linkKey,
 		RandomReader:      rand.Reader,
 	}
-	session, err := wire.NewPKISession(cfg, true)
+	// previously session, err := wire.NewPKISession(cfg, true)
+	// see ticket https://github.com/katzenpost/katzenpost/issues/630
+	session, err := wire.NewPKISession(cfg, false)
 	if err != nil {
 		return nil, err
 	}

--- a/authority/voting/server/wire_handler.go
+++ b/authority/voting/server/wire_handler.go
@@ -65,7 +65,11 @@ func (s *Server) onConn(conn net.Conn) {
 		AuthenticationKey:  s.linkKey,
 		RandomReader:       rand.Reader,
 	}
-	wireConn, err := wire.NewPKISession(cfg, false)
+
+	// was preivously wireConn, err := wire.NewPKISession(cfg, false)
+	// where false indicates responder
+	// see ticket https://github.com/katzenpost/katzenpost/issues/630
+	wireConn, err := wire.NewPKISession(cfg, true)
 	if err != nil {
 		s.log.Debugf("Peer %v: Failed to initialize session: %v", rAddr, err)
 		return

--- a/client/send.go
+++ b/client/send.go
@@ -54,7 +54,7 @@ func (s *Session) sendNext() {
 
 func (s *Session) doRetransmit(msg *Message) {
 	msg.Retransmissions++
-	msgIdStr := fmt.Sprintf("[%v]", hex.EncodeToString(msg.ID[:]))
+	msgIdStr := fmt.Sprintf("[%s]", hex.EncodeToString(msg.ID[:]))
 	s.log.Debugf("doRetransmit: %d for %s", msg.Retransmissions, msgIdStr)
 	s.egressQueue.Push(msg)
 }

--- a/core/wire/session.go
+++ b/core/wire/session.go
@@ -548,8 +548,10 @@ func (s *Session) PeerCredentials() (*PeerCredentials, error) {
 // from a session that has successfully completed Initialize(), and the peer is
 // the responder.
 func (s *Session) ClockSkew() time.Duration {
-	if !s.isInitiator {
-		panic("wire/session: ClockSkew() call by responder")
+	// was previously if !s.isInitiator {
+	// see ticket https://github.com/katzenpost/katzenpost/issues/630
+	if s.isInitiator {
+		panic("wire/session: ClockSkew() call by initiator")
 	}
 	if atomic.LoadUint32(&s.state) != stateEstablished {
 		panic("wire/session: ClockSkew() call in invalid state")

--- a/core/wire/session_test.go
+++ b/core/wire/session_test.go
@@ -106,7 +106,8 @@ func TestSessionIntegration(t *testing.T) {
 		AuthenticationKey: authKEMKeyAlice,
 		RandomReader:      rand.Reader,
 	}
-	sAlice, err := NewSession(cfgAlice, true)
+	// was previously sAlice, err := NewSession(cfgAlice, true)
+	sAlice, err := NewSession(cfgAlice, false)
 	require.NoError(err, "Integration: Alice NewSession()")
 
 	// Bob's session setup.
@@ -118,7 +119,8 @@ func TestSessionIntegration(t *testing.T) {
 		AuthenticationKey: authKEMKeyBob,
 		RandomReader:      rand.Reader,
 	}
-	sBob, err := NewSession(cfgBob, false)
+	// was previously sBob, err := NewSession(cfgBob, false)
+	sBob, err := NewSession(cfgBob, true)
 	require.NoError(err, "Integration: Bob NewSession()")
 
 	t.Log("before Pipe")

--- a/docs/specs/wire-protocol.md
+++ b/docs/specs/wire-protocol.md
@@ -61,11 +61,44 @@ Noise_pqXX_Xwing_ChaChaPoly_BLAKE2b
 ```
 
 The protocol string is a very condensed description of our protocol.
-We use the pqXX two way Noise pattern which is described as follows:
+We use the pqXX two way Noise pattern which is described as follows
+using the algebraic token system from the PQ Noise paper that very
+closely resembles the Noise algebraic token system:
 
 ```
-pqXX: -> e <- ekem, s -> skem, s <- skem
+-> e
+<- ekem, s
+-> skem, s
+<- skem
 ```
+
+However let us remark that usually `e` is first sent over by the
+client. However in our case the serer is the Noise protocol initiator
+after the connection is made via the client initiating the connection.
+To be clear, clients connec to servers as usually, and then the client
+waits for a message, while the server sends the first PQ Noise
+message. The reason for this modification is so that the server authenticates itself to the client first
+just like classical Noise XX pattern.
+
+Classical Noise XX pattern:
+
+```
+  -> e
+  <- e, ee, s, es
+  -> s, se
+```
+
+Therefore our solution is to annotate the pqXX pattern differently than the expected interpretation:
+
+```
+server: -> e
+client: <- ekem, s
+server: -> skem, s
+client: <- skem
+```
+
+Thus, the client initiates the TCP or QUIC connection to the server, however once connected,
+the client waits for a PQ Noise message and the server immediately sends the first PQ Noise message.
 
 The next part of the protocol string specifies the KEM,
 `Xwing` which is a hybrid KEM where the share

--- a/docs/specs/wire-protocol.md
+++ b/docs/specs/wire-protocol.md
@@ -73,12 +73,13 @@ closely resembles the Noise algebraic token system:
 ```
 
 However let us remark that usually `e` is first sent over by the
-client. However in our case the serer is the Noise protocol initiator
-after the connection is made via the client initiating the connection.
-To be clear, clients connec to servers as usually, and then the client
-waits for a message, while the server sends the first PQ Noise
-message. The reason for this modification is so that the server authenticates itself to the client first
-just like classical Noise XX pattern.
+client. However in our case the server is the Noise protocol initiator
+after the connection is made via the client initiating the underlying
+TCP or QUIC connection. To be clear, clients connect to servers as
+usual, and then the client waits for a message, while the server sends
+the first PQ Noise message. The reason for this modification is so
+that the server authenticates itself to the client first just like
+classical Noise XX pattern.
 
 Classical Noise XX pattern:
 

--- a/minclient/connection.go
+++ b/minclient/connection.go
@@ -383,7 +383,11 @@ func (c *connection) onTCPConn(conn net.Conn) {
 		AuthenticationKey:  c.c.cfg.LinkKey,
 		RandomReader:       rand.Reader,
 	}
-	w, err := wire.NewSession(cfg, true)
+
+	// was previously true for initiator
+	// w, err := wire.NewSession(cfg, true)
+	// see ticket https://github.com/katzenpost/katzenpost/issues/630
+	w, err := wire.NewSession(cfg, false)
 	if err != nil {
 		c.log.Errorf("Failed to allocate session: %v", err)
 		if c.c.cfg.OnConnFn != nil {

--- a/server/internal/incoming/incoming_conn.go
+++ b/server/internal/incoming/incoming_conn.go
@@ -180,7 +180,10 @@ func (c *incomingConn) worker() {
 	}
 	var err error
 	c.l.Lock()
-	c.w, err = wire.NewSession(cfg, false)
+	// was previously false for responder
+	// c.w, err = wire.NewSession(cfg, false)
+	// see ticket https://github.com/katzenpost/katzenpost/issues/630
+	c.w, err = wire.NewSession(cfg, true)
 	c.l.Unlock()
 	if err != nil {
 		c.log.Errorf("Failed to allocate session: %v", err)

--- a/server/internal/outgoing/outgoing_conn.go
+++ b/server/internal/outgoing/outgoing_conn.go
@@ -259,7 +259,11 @@ func (c *outgoingConn) onConnEstablished(conn net.Conn, closeCh <-chan struct{})
 		AuthenticationKey: c.co.glue.LinkKey(),
 		RandomReader:      rand.Reader,
 	}
-	w, err := wire.NewSession(cfg, true)
+
+	// was previously true for initiator:
+	// w, err := wire.NewSession(cfg, true)
+	// see ticket https://github.com/katzenpost/katzenpost/issues/630
+	w, err := wire.NewSession(cfg, false)
 	if err != nil {
 		c.log.Errorf("Failed to allocate session: %v", err)
 		return


### PR DESCRIPTION
This breaks wire protocol backwards compatibility in order to make our PQ Noise based wire protocol more correct. This doesn't actually fix a security vulnerability per se however it does change the ordering of authentication between client and server HOWEVER it does NOT change the handshake pattern. Specifically, this change ensures that the client authenticates the server before the server authenticates the client, as is obviously most appropriate for an anonymous communications network. No changes to the Noise / PQ Noise protocol is made. Zero changes to our fork of nyquist.

## details

```
Noise_pqXX_Xwing_ChaChaPoly_BLAKE2b
```

The protocol string is a very condensed description of our protocol.
We use the pqXX two way Noise pattern which is described as follows
using the algebraic token system from the PQ Noise paper that very
closely resembles the Noise algebraic token system:

```
-> e
<- ekem, s
-> skem, s
<- skem
```

However let us remark that usually `e` is first sent over by the
client. However in our case the server is the Noise protocol initiator
after the connection is made via the client initiating the connection.
To be clear, clients connect to servers as usually, and then the client
waits for a message, while the server sends the first PQ Noise
message. The reason for this modification is so that the server authenticates itself to the client first
just like classical Noise XX pattern.

Classical Noise XX pattern:

```
  -> e
  <- e, ee, s, es
  -> s, se
```
Which by default, everyone presumes will be used as follows:

```
client:  -> e
server:  <- e, ee, s, es
client:  -> s, se
```

Therefore the XX handshake pattern has the client authenticating the
server as soon as it receives "e, ee, s, es" from the server in the
second handshake message. Only AFTER that does the server authenticate
the client when it receives "s, se" from the client in the last
handshake message.

The default interpretation of the pqXX pattern is as follows:

```
client: -> e
server: <- ekem, s
client: -> skem, s
server: <- skem
```

The very last pqXX message is used to authenticate the server to the client. The second to last message
authenticates the client to the server. Wrong ordering!

Therefore our solution is to have the client connect to the server as usual, however the client would then
await a Noise message instead of sending one. And the server would immediately send the first PQ Noise message
upon receiving a client connection, like this:

```
server: -> e
client: <- ekem, s
server: -> skem, s
client: <- skem
```

Thus, the above implies that the client connect via TCP or QUIC to the server which accepts the connection.
The client awaits a message, and the server sends the first PQ Noise message, "e". Once the clients receives
the "e" message it responds with "ekem, s"; which means that the client uses the server's ephemeral key to encrypt
it's static key and sends that ciphertext to the server. The server response with "skem, s". Since the client has the
corresponding private key, it's able to decrypt skem and retreive the encapsulated "s" within. The client then uses that
public key "s" from the server to send "skem" to the server, proving that the client was able to decrypt the previous
KEM ciphertext, thus proving ownership of the client's static key.


