### PR TITLE
ratchet_test.go: use NOBS_CSIDH512X25519

### DIFF
--- a/doubleratchet/ratchet_test.go
+++ b/doubleratchet/ratchet_test.go
@@ -15,7 +15,7 @@ import (
 
 //var nikeScheme = ecdh.Scheme(rand.Reader)
 
-var nikeScheme = hybrid.CTIDH1024X25519
+var nikeScheme = hybrid.NOBS_CSIDH512X25519
 
 func pairedRatchet(t *testing.T) (aRatchet, bRatchet *Ratchet) {
 	var err error

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/protobuf v1.5.3
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/katzenpost/chacha20poly1305 v0.0.0-20211026103954-7b6fb2fc0129
-	github.com/katzenpost/hpqc v0.0.35
+	github.com/katzenpost/hpqc v0.0.36-0.20240616193325-5391979eb54b
 	github.com/katzenpost/nyquist v0.0.10
 	github.com/prometheus/client_golang v1.18.0
 	github.com/stretchr/testify v1.8.4

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/protobuf v1.5.3
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/katzenpost/chacha20poly1305 v0.0.0-20211026103954-7b6fb2fc0129
-	github.com/katzenpost/hpqc v0.0.36-0.20240616193325-5391979eb54b
+	github.com/katzenpost/hpqc v0.0.36
 	github.com/katzenpost/nyquist v0.0.10
 	github.com/prometheus/client_golang v1.18.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/katzenpost/circl v1.3.9-0.20240222183521-1cd9a34e9a0c h1:FYy03rLIjdyj
 github.com/katzenpost/circl v1.3.9-0.20240222183521-1cd9a34e9a0c/go.mod h1:+EBrwiGYs9S+qZqaqxujN1CReTNCMAG6p+31KkEDeeA=
 github.com/katzenpost/hpqc v0.0.35 h1:5o6KC2lCG2t7QUOpLloQn4sdSEZ8CH8HdWrdRw5LrLI=
 github.com/katzenpost/hpqc v0.0.35/go.mod h1:QxsoI3+qXXmDAzAy7FkPZtVAUR4/KiG2bkdt+/9t42Y=
+github.com/katzenpost/hpqc v0.0.36-0.20240616193325-5391979eb54b h1:2MM0TAQFBVb4HbAvIXv5Wj0Jx06vV+/Pp50CksZNUp8=
+github.com/katzenpost/hpqc v0.0.36-0.20240616193325-5391979eb54b/go.mod h1:QxsoI3+qXXmDAzAy7FkPZtVAUR4/KiG2bkdt+/9t42Y=
 github.com/katzenpost/nyquist v0.0.10 h1:rh9TCEXCsutsg+cvbV6ASVFnzSAYBisWQ3fnwQSPa34=
 github.com/katzenpost/nyquist v0.0.10/go.mod h1:tyK92JiCptgsaE0iUAMlt5W2v2Rdw6mnUpIdIidIGHo=
 github.com/katzenpost/sntrup4591761 v0.0.0-20231024131303-8755eb1986b8 h1:TsKxH0x2RUwf5rBw67k15bqVM3oVbexA9oaTZQLIy3Y=

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/katzenpost/hpqc v0.0.35 h1:5o6KC2lCG2t7QUOpLloQn4sdSEZ8CH8HdWrdRw5LrL
 github.com/katzenpost/hpqc v0.0.35/go.mod h1:QxsoI3+qXXmDAzAy7FkPZtVAUR4/KiG2bkdt+/9t42Y=
 github.com/katzenpost/hpqc v0.0.36-0.20240616193325-5391979eb54b h1:2MM0TAQFBVb4HbAvIXv5Wj0Jx06vV+/Pp50CksZNUp8=
 github.com/katzenpost/hpqc v0.0.36-0.20240616193325-5391979eb54b/go.mod h1:QxsoI3+qXXmDAzAy7FkPZtVAUR4/KiG2bkdt+/9t42Y=
+github.com/katzenpost/hpqc v0.0.36 h1:ZdVSX1aMmy6fjZUk3f5TCQr36L/ynJwEo/IimU/Udbs=
+github.com/katzenpost/hpqc v0.0.36/go.mod h1:QxsoI3+qXXmDAzAy7FkPZtVAUR4/KiG2bkdt+/9t42Y=
 github.com/katzenpost/nyquist v0.0.10 h1:rh9TCEXCsutsg+cvbV6ASVFnzSAYBisWQ3fnwQSPa34=
 github.com/katzenpost/nyquist v0.0.10/go.mod h1:tyK92JiCptgsaE0iUAMlt5W2v2Rdw6mnUpIdIidIGHo=
 github.com/katzenpost/sntrup4591761 v0.0.0-20231024131303-8755eb1986b8 h1:TsKxH0x2RUwf5rBw67k15bqVM3oVbexA9oaTZQLIy3Y=


### PR DESCRIPTION
This changes the doubleratchet test's nike to NOBS_CSIDH512X25519, and upgrades to the latest hpqc with https://github.com/katzenpost/hpqc/pull/30 which fixes the bug which made doubleratchet unable to use it.