### PR TITLE
fix 673 sigint

### DIFF
--- a/catshadow/client_docker_test.go
+++ b/catshadow/client_docker_test.go
@@ -846,7 +846,10 @@ loop4a:
 	err = a.RenameContact("b", "b2")
 	require.NoError(err)
 
+	// XXX: a.conversations["b"] - panics with bad map state
+	a.conversationsMutex.Lock()
 	c := a.conversations["b"]
+	a.conversationsMutex.Unlock()
 	require.Equal(len(c), 0)
 
 	// verify that contact data is gone

--- a/client2/Makefile
+++ b/client2/Makefile
@@ -23,6 +23,7 @@ coverage-html:
 
 
 dockerdockertest:
+	cd ../docker && make $(distro)_base.stamp
 	$(docker) run -w /go/katzenpost/client2 ${docker_args} $(image) \
 		go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 1h -run TestAllClient2Tests
 

--- a/client2/Makefile
+++ b/client2/Makefile
@@ -7,7 +7,7 @@ docker=$(shell if which podman|grep -q .; then echo podman; else echo docker; fi
 distro=alpine
 image=localhost/katzenpost-$(distro)_base
 cache_dir=$(shell readlink -f ../docker)/cache
-docker_args=--init --user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost --network=host --rm -v $(cache_dir)/go:/go/ -v $(cache_dir)/root_cache:/root/.cache -e GORACE=history_size=7
+docker_args=--init -it --user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost --network=host --rm -v $(cache_dir)/go:/go/ -v $(cache_dir)/root_cache:/root/.cache -e GORACE=history_size=7
 
 test:
 	go test -v -race -timeout 0 -ldflags ${ldflags} .

--- a/client2/Makefile
+++ b/client2/Makefile
@@ -7,7 +7,7 @@ docker=$(shell if which podman|grep -q .; then echo podman; else echo docker; fi
 distro=alpine
 image=katzenpost-$(distro)_base
 cache_dir=$(shell readlink -f ../docker)/cache
-docker_args=--user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost --network=host --rm -v $(cache_dir)/go:/go/ -v $(cache_dir)/root_cache:/root/.cache
+docker_args=--init --user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost --network=host --rm -v $(cache_dir)/go:/go/ -v $(cache_dir)/root_cache:/root/.cache -e GORACE=history_size=7
 
 test:
 	go test -v -race -timeout 0 -ldflags ${ldflags} .
@@ -23,8 +23,8 @@ coverage-html:
 
 
 dockerdockertest:
-	$(docker) run ${docker_args} $(image) \
-		sh -c 'cd /go/katzenpost/client2/; GORACE=history_size=7 go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 1h -run TestAllClient2Tests'
+	$(docker) run -w /go/katzenpost/client2 ${docker_args} $(image) \
+		go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 1h -run TestAllClient2Tests
 
 warpedclientdaemon:
 	cd cmd/kpclientd; go build -ldflags ${ldflags}

--- a/client2/Makefile
+++ b/client2/Makefile
@@ -5,7 +5,7 @@ gid=$(shell [ "$$SUDO_GID" != "" ] && echo "$$SUDO_GID" || id -g)
 docker_user?=$(shell if echo ${docker}|grep -q podman; then echo 0:0; else echo ${uid}:${gid}; fi)
 docker=$(shell if which podman|grep -q .; then echo podman; else echo docker; fi)
 distro=alpine
-image=katzenpost-$(distro)_base
+image=localhost/katzenpost-$(distro)_base
 cache_dir=$(shell readlink -f ../docker)/cache
 docker_args=--init --user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost --network=host --rm -v $(cache_dir)/go:/go/ -v $(cache_dir)/root_cache:/root/.cache -e GORACE=history_size=7
 

--- a/client2/client_docker_test.go
+++ b/client2/client_docker_test.go
@@ -24,6 +24,10 @@ import (
 	_ "net/http/pprof"
 )
 
+var (
+	shutdownCh chan interface{}
+)
+
 func TestAllClient2Tests(t *testing.T) {
 	d, err := setupDaemon()
 	require.NoError(t, err)
@@ -32,10 +36,12 @@ func TestAllClient2Tests(t *testing.T) {
 		d.Shutdown()
 	})
 
-	haltCh := make(chan os.Signal)
+	haltCh := make(chan os.Signal, 1)
 	signal.Notify(haltCh, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-haltCh
+		close(shutdownCh)
+		t.Log("Interrupt caught. Shutdown")
 		d.Shutdown()
 	}()
 
@@ -71,9 +77,17 @@ func sendAndWait(t *testing.T, client *thin.ThinClient, message []byte, nodeID *
 	err := client.SendMessage(surbID, message, nodeID, queueID)
 	require.NoError(t, err)
 
-Loop:
 	for {
-		event := <-eventSink
+		var event thin.Event
+		select {
+		case event = <-eventSink:
+		case <-shutdownCh: // exit if halted
+			// interrupt caught, shutdown client
+			t.Log("Interrupt caught - shutting down client")
+			client.Halt()
+			return nil
+		}
+
 		switch v := event.(type) {
 		case *thin.MessageIDGarbageCollected:
 			t.Log("MessageIDGarbageCollected")
@@ -90,7 +104,6 @@ Loop:
 			t.Log("MessageReplyEvent")
 			require.Equal(t, surbID[:], v.SURBID[:])
 			return v.Payload
-			break Loop
 		default:
 			panic("impossible event type")
 		}
@@ -257,6 +270,7 @@ func testDockerClientSendReceive(t *testing.T) {
 	t.Log("BEFORE sendAndWait")
 	reply := sendAndWait(t, thin, message1, &nodeIdKey, []byte("testdest"))
 	t.Log("AFTER sendAndWait")
+	require.Equal(t, len(message1), len(reply))
 	require.Equal(t, message1, reply[:len(message1)])
 
 	/*
@@ -281,6 +295,7 @@ func testDockerClientSendReceive(t *testing.T) {
 }
 
 func init() {
+	shutdownCh = make(chan interface{})
 	go func() {
 		http.ListenAndServe("localhost:9090", nil)
 	}()

--- a/client2/client_docker_test.go
+++ b/client2/client_docker_test.go
@@ -66,10 +66,10 @@ func setupDaemon() *Daemon {
 
 func sendAndWait(t *testing.T, client *thin.ThinClient, message []byte, nodeID *[32]byte, queueID []byte) []byte {
 	surbID := client.NewSURBID()
+	eventSink := client.EventSink()
 	err := client.SendMessage(surbID, message, nodeID, queueID)
 	require.NoError(t, err)
 
-	eventSink := client.EventSink()
 Loop:
 	for {
 		event := <-eventSink

--- a/client2/client_docker_test.go
+++ b/client2/client_docker_test.go
@@ -8,6 +8,7 @@ package client2
 import (
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"testing"
 	"time"
@@ -18,6 +19,9 @@ import (
 	"github.com/katzenpost/katzenpost/client2/config"
 	"github.com/katzenpost/katzenpost/client2/thin"
 	cpki "github.com/katzenpost/katzenpost/core/pki"
+
+	"net/http"
+	_ "net/http/pprof"
 )
 
 func TestAllClient2Tests(t *testing.T) {
@@ -273,4 +277,12 @@ func testDockerClientSendReceive(t *testing.T) {
 
 	err = thin.Close()
 	require.NoError(t, err)
+}
+
+func init() {
+	go func() {
+		http.ListenAndServe("localhost:9090", nil)
+	}()
+	runtime.SetMutexProfileFraction(1)
+	runtime.SetBlockProfileRate(1)
 }

--- a/client2/client_docker_test.go
+++ b/client2/client_docker_test.go
@@ -8,7 +8,6 @@ package client2
 import (
 	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
 	"testing"
 	"time"
@@ -19,9 +18,6 @@ import (
 	"github.com/katzenpost/katzenpost/client2/config"
 	"github.com/katzenpost/katzenpost/client2/thin"
 	cpki "github.com/katzenpost/katzenpost/core/pki"
-
-	"net/http"
-	_ "net/http/pprof"
 )
 
 var (
@@ -296,9 +292,4 @@ func testDockerClientSendReceive(t *testing.T) {
 
 func init() {
 	shutdownCh = make(chan interface{})
-	go func() {
-		http.ListenAndServe("localhost:4242", nil)
-	}()
-	runtime.SetMutexProfileFraction(1)
-	runtime.SetBlockProfileRate(1)
 }

--- a/client2/client_docker_test.go
+++ b/client2/client_docker_test.go
@@ -297,7 +297,7 @@ func testDockerClientSendReceive(t *testing.T) {
 func init() {
 	shutdownCh = make(chan interface{})
 	go func() {
-		http.ListenAndServe("localhost:9090", nil)
+		http.ListenAndServe("localhost:4242", nil)
 	}()
 	runtime.SetMutexProfileFraction(1)
 	runtime.SetBlockProfileRate(1)

--- a/client2/connection.go
+++ b/client2/connection.go
@@ -822,10 +822,11 @@ func (c *connection) GetConsensus(ctx context.Context, epoch uint64) (*commands.
 	// NOTREACHED
 }
 
-func (c *connection) halt() {
+func (c *connection) Shutdown() {
 	c.isShutdown = true
-	c.Worker.Halt()
-	c = nil
+	c.Halt()
+	close(c.fetchCh)
+	close(c.sendCh)
 }
 
 func (c *connection) start() {

--- a/client2/listener.go
+++ b/client2/listener.go
@@ -251,6 +251,9 @@ func NewListener(client *Client, rates *Rates, egressCh chan *Request, logBacken
 			return nil, err
 		}
 		l.listener, err = net.ListenTCP(network, tcpAddr)
+		if err != nil {
+			return nil, err
+		}
 	case "unix":
 		fallthrough
 	case "unixgram":

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -24,17 +24,17 @@ serviceNodes=1
 
 # Parameters
 sr=0
-mu=0.0005
-muMax=2000
-lP=0.0005
-lPMax=2000
+mu=0.005
+muMax=1000
+lP=0.001
+lPMax=1000
 lL=0.0005
-lLMax=2000
+lLMax=1000
 lD=0.0005
-lDMax=2000
+lDMax=3000
 lM=0.0005
-lMMax=2000
-lGMax=5000
+lMMax=100
+lGMax=1000
 
 UserForwardPayloadLength=2000
 


### PR DESCRIPTION
This PR resolves #673 and fixes some bugs in client2 shutdown path

- **DEBUG: add pprof http listener**
- **client2.NewListener: return err from net.ListenTCP**
- **call EventSink() before SendMessage**
- **client2: client_docker_test: shutdown cleanly on os.Interrupt**
- **client2/client_docker_test: do not listen on prometheus default listening port**
- **client2/Makefile: do not run go test in subshell**
- **do not remotely resolve missing images**
- **client2/Makefile: ensure target image exists**
- **client2/Makefile: allocate tty to pass sigint to container**
- **Revert "DEBUG: add pprof http listener"**
