### PR TITLE
dockerdockertest: various improvements

### DIFF
--- a/catshadow/Makefile
+++ b/catshadow/Makefile
@@ -7,12 +7,13 @@ docker=$(shell if which podman|grep -q .; then echo podman; else echo docker; fi
 distro=alpine
 image=katzenpost-$(distro)_base
 cache_dir=$(shell readlink -f ../docker)/cache
-docker_args=--user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost --network=host --rm -v $(cache_dir)/go:/go/ -v $(cache_dir)/root_cache:/root/.cache
-run_docker_test=$(docker) run ${docker_args} $(image) sh -c 'cd /go/katzenpost/catshadow/; GORACE=history_size=7 go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 0 -failfast -run '
+docker_args=--init -it --user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost --network=host --rm -v $(cache_dir)/go:/go/ -v $(cache_dir)/root_cache:/root/.cache -e GORACE=history_size=7 -w /go/katzenpost/catshadow
+run_docker_test=$(docker) run ${docker_args} $(image) go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 1h -failfast -run 
 
 test_version=v30
 
 dockerdockertest:
+	cd ../docker && make $(distro)_base.stamp
 	$(run_docker_test)Docker
 
 upgrade_test_use_saved:

--- a/client/Makefile
+++ b/client/Makefile
@@ -7,7 +7,7 @@ docker=$(shell if which podman|grep -q .; then echo podman; else echo docker; fi
 distro=alpine
 image=katzenpost-$(distro)_base
 cache_dir=$(shell readlink -f ../docker)/cache
-docker_args=--user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost --network=host --rm -v $(cache_dir)/go:/go/ -v $(cache_dir)/root_cache:/root/.cache
+docker_args=--init -it --user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost --network=host --rm -v $(cache_dir)/go:/go/ -v $(cache_dir)/root_cache:/root/.cache -e GORACE=history_size=7 -w /go/katzenpost/client
 
 test:
 	go test -v -race -timeout 0 -ldflags ${ldflags} .
@@ -23,5 +23,6 @@ coverage-html:
 
 
 dockerdockertest:
+	cd ../docker && make $(distro)_base.stamp
 	$(docker) run ${docker_args} $(image) \
-		sh -c 'cd /go/katzenpost/client/; GORACE=history_size=7 go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 1h -run Docker'
+		go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 1h -run Docker

--- a/memspool/Makefile
+++ b/memspool/Makefile
@@ -7,8 +7,9 @@ docker=$(shell if which podman|grep -q .; then echo podman; else echo docker; fi
 distro=alpine
 image=katzenpost-$(distro)_base
 cache_dir=$(shell readlink -f ../docker)/cache
-docker_args=--user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost --network=host --rm -v $(cache_dir)/go:/go/ -v $(cache_dir)/root_cache:/root/.cache
+docker_args=--init -it --user ${docker_user} -v $(shell readlink -f ..):/go/katzenpost --network=host --rm -v $(cache_dir)/go:/go/ -v $(cache_dir)/root_cache:/root/.cache -e GORACE=history_size=7 -w /go/katzenpost/memspool/client
 
 dockerdockertest:
+	cd ../docker && make $(distro)_base.stamp
 	$(docker) run ${docker_args} $(image) \
-		sh -c 'cd /go/katzenpost/memspool/client; GORACE=history_size=7 go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 0 -failfast -run Docker'
+		go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 1h -failfast -run Docker


### PR DESCRIPTION
This refactors the make "dockerdockertest" target in memspool, client, and catshadow packages.

- catch sigint and exit
- verify docker image exists
- remove subshell, call go test directly
