### PR TITLE
after WaitForDocument, call currentDocument to get the document

### DIFF
--- a/client2/pki_test.go
+++ b/client2/pki_test.go
@@ -208,6 +208,7 @@ func TestPKIWaitForDocument(t *testing.T) {
 	_, currentDoc := p.currentDocument()
 	require.Nil(t, currentDoc)
 	c.WaitForCurrentDocument()
+	_, currentDoc = p.currentDocument()
 	require.NotNil(t, currentDoc)
 	require.Equal(t, currentDoc, testDoc)
 }


### PR DESCRIPTION
this fixes TestPKIWaitForDocument in pki_test.go
