### PR TITLE
fix client2 dockerdockertest

### DIFF
--- a/client2/client.go
+++ b/client2/client.go
@@ -49,7 +49,6 @@ type Client struct {
 // Shutdown cleanly shuts down a given Client instance.
 func (c *Client) Shutdown() {
 	c.log.Info("Starting graceful shutdown.")
-	c.Halt()
 
 	if c.conn != nil {
 		c.conn.Shutdown()
@@ -60,6 +59,7 @@ func (c *Client) Shutdown() {
 		c.pki.Halt()
 		c.log.Info("waiting for stopped PKI worker to exit")
 	}
+	c.Halt()
 	c.log.Info("Shutdown complete.")
 }
 

--- a/client2/client_docker_test.go
+++ b/client2/client_docker_test.go
@@ -147,10 +147,10 @@ func testDockerMultiplexClients(t *testing.T) {
 	message1 := []byte("hello alice, this is bob.")
 	nodeIdKey := hash.Sum256(pingTargets[0].IdentityKey)
 
-	reply := sendAndWait(t, thin1, message1, &nodeIdKey, []byte("echo"))
+	reply := sendAndWait(t, thin1, message1, &nodeIdKey, []byte("+echo"))
 	require.Equal(t, message1, reply[:len(message1)])
 
-	reply = sendAndWait(t, thin2, message1, &nodeIdKey, []byte("echo"))
+	reply = sendAndWait(t, thin2, message1, &nodeIdKey, []byte("+echo"))
 	require.Equal(t, message1, reply[:len(message1)])
 
 	err = thin1.Close()
@@ -274,19 +274,19 @@ func testDockerClientSendReceive(t *testing.T) {
 	require.Equal(t, message1, reply[:len(message1)])
 
 	/*
-		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("testdest"))
+		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
 		require.Equal(t, message1, reply[:len(message1)])
 
-		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("testdest"))
+		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
 		require.Equal(t, message1, reply[:len(message1)])
 
-		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("testdest"))
+		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
 		require.Equal(t, message1, reply[:len(message1)])
 
-		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("testdest"))
+		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
 		require.Equal(t, message1, reply[:len(message1)])
 
-		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("testdest"))
+		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
 		require.Equal(t, message1, reply[:len(message1)])
 	*/
 

--- a/client2/client_docker_test.go
+++ b/client2/client_docker_test.go
@@ -194,37 +194,37 @@ func testDockerClientARQSendReceive(t *testing.T) {
 	id3 := thin.NewMessageID()
 	id4 := thin.NewMessageID()
 
-	message3, err := thin.BlockingSendReliableMessage(id1, message1, &nodeIdKey, []byte("echo"))
+	message3, err := thin.BlockingSendReliableMessage(id1, message1, &nodeIdKey, []byte("+echo"))
 	require.NoError(t, err)
 	require.NotEqual(t, message3, []byte{})
 	require.Equal(t, message1, message3[:len(message1)])
 
-	message3, err = thin.BlockingSendReliableMessage(id2, message1, &nodeIdKey, []byte("echo"))
+	message3, err = thin.BlockingSendReliableMessage(id2, message1, &nodeIdKey, []byte("+echo"))
 	require.NoError(t, err)
 	require.NotEqual(t, message3, []byte{})
 	require.Equal(t, message1, message3[:len(message1)])
 
-	message3, err = thin.BlockingSendReliableMessage(id3, message1, &nodeIdKey, []byte("echo"))
+	message3, err = thin.BlockingSendReliableMessage(id3, message1, &nodeIdKey, []byte("+echo"))
 	require.NoError(t, err)
 	require.NotEqual(t, message3, []byte{})
 	require.Equal(t, message1, message3[:len(message1)])
 
-	message3, err = thin.BlockingSendReliableMessage(id4, message1, &nodeIdKey, []byte("echo"))
+	message3, err = thin.BlockingSendReliableMessage(id4, message1, &nodeIdKey, []byte("+echo"))
 	require.NoError(t, err)
 	require.NotEqual(t, message3, []byte{})
 	require.Equal(t, message1, message3[:len(message1)])
 
-	message3, err = thin.BlockingSendReliableMessage(id4, message1, &nodeIdKey, []byte("echo"))
+	message3, err = thin.BlockingSendReliableMessage(id4, message1, &nodeIdKey, []byte("+echo"))
 	require.NoError(t, err)
 	require.NotEqual(t, message3, []byte{})
 	require.Equal(t, message1, message3[:len(message1)])
 
-	message3, err = thin.BlockingSendReliableMessage(id4, message1, &nodeIdKey, []byte("echo"))
+	message3, err = thin.BlockingSendReliableMessage(id4, message1, &nodeIdKey, []byte("+echo"))
 	require.NoError(t, err)
 	require.NotEqual(t, message3, []byte{})
 	require.Equal(t, message1, message3[:len(message1)])
 
-	message3, err = thin.BlockingSendReliableMessage(id4, message1, &nodeIdKey, []byte("echo"))
+	message3, err = thin.BlockingSendReliableMessage(id4, message1, &nodeIdKey, []byte("+echo"))
 	require.NoError(t, err)
 	require.NotEqual(t, message3, []byte{})
 	require.Equal(t, message1, message3[:len(message1)])
@@ -272,22 +272,20 @@ func testDockerClientSendReceive(t *testing.T) {
 	t.Log("AFTER sendAndWait")
 	require.Equal(t, message1, reply[:len(message1)])
 
-	/*
-		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
-		require.Equal(t, message1, reply[:len(message1)])
+	reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
+	require.Equal(t, message1, reply[:len(message1)])
 
-		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
-		require.Equal(t, message1, reply[:len(message1)])
+	reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
+	require.Equal(t, message1, reply[:len(message1)])
 
-		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
-		require.Equal(t, message1, reply[:len(message1)])
+	reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
+	require.Equal(t, message1, reply[:len(message1)])
 
-		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
-		require.Equal(t, message1, reply[:len(message1)])
+	reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
+	require.Equal(t, message1, reply[:len(message1)])
 
-		reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
-		require.Equal(t, message1, reply[:len(message1)])
-	*/
+	reply = sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
+	require.Equal(t, message1, reply[:len(message1)])
 
 	err = thin.Close()
 	require.NoError(t, err)

--- a/client2/client_docker_test.go
+++ b/client2/client_docker_test.go
@@ -45,8 +45,8 @@ func TestAllClient2Tests(t *testing.T) {
 		d.Shutdown()
 	}()
 
-	//t.Run("TestDockerMultiplexClients", testDockerMultiplexClients)
-	//t.Run("TestDockerClientARQSendReceive", testDockerClientARQSendReceive)
+	t.Run("TestDockerMultiplexClients", testDockerMultiplexClients)
+	t.Run("TestDockerClientARQSendReceive", testDockerClientARQSendReceive)
 	t.Run("TestDockerClientSendReceive", testDockerClientSendReceive)
 }
 

--- a/client2/client_docker_test.go
+++ b/client2/client_docker_test.go
@@ -270,7 +270,6 @@ func testDockerClientSendReceive(t *testing.T) {
 	t.Log("BEFORE sendAndWait")
 	reply := sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
 	t.Log("AFTER sendAndWait")
-	require.Equal(t, len(message1), len(reply))
 	require.Equal(t, message1, reply[:len(message1)])
 
 	/*

--- a/client2/client_docker_test.go
+++ b/client2/client_docker_test.go
@@ -268,7 +268,7 @@ func testDockerClientSendReceive(t *testing.T) {
 	nodeIdKey := hash.Sum256(pingTargets[0].IdentityKey)
 
 	t.Log("BEFORE sendAndWait")
-	reply := sendAndWait(t, thin, message1, &nodeIdKey, []byte("testdest"))
+	reply := sendAndWait(t, thin, message1, &nodeIdKey, []byte("+testdest"))
 	t.Log("AFTER sendAndWait")
 	require.Equal(t, len(message1), len(reply))
 	require.Equal(t, message1, reply[:len(message1)])

--- a/client2/client_docker_test.go
+++ b/client2/client_docker_test.go
@@ -8,6 +8,7 @@ package client2
 import (
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"testing"
 	"time"
@@ -18,6 +19,9 @@ import (
 	"github.com/katzenpost/katzenpost/client2/config"
 	"github.com/katzenpost/katzenpost/client2/thin"
 	cpki "github.com/katzenpost/katzenpost/core/pki"
+
+	"net/http"
+	_ "net/http/pprof"
 )
 
 var (
@@ -292,4 +296,9 @@ func testDockerClientSendReceive(t *testing.T) {
 
 func init() {
 	shutdownCh = make(chan interface{})
+	go func() {
+		http.ListenAndServe("localhost:4242", nil)
+	}()
+	runtime.SetMutexProfileFraction(1)
+	runtime.SetBlockProfileRate(1)
 }

--- a/client2/connection.go
+++ b/client2/connection.go
@@ -493,7 +493,7 @@ func (c *connection) onWireConn(w *wire.Session) {
 		if deltaT := sendAt.Sub(selectAt); deltaT < fetchDelay {
 			fetchDelay = fetchDelay - deltaT
 		} else {
-			fetchDelay = time.Second * 3
+			fetchDelay = 0 // fetch immediately
 		}
 	}
 	var seq uint32

--- a/client2/connection.go
+++ b/client2/connection.go
@@ -438,7 +438,7 @@ func (c *connection) onWireConn(w *wire.Session) {
 
 	// Start the peer reader.
 	cmdCh := make(chan interface{})
-	go func() {
+	c.Go(func() {
 		defer close(cmdCh)
 		for {
 			rawCmd, err := w.RecvCommand()
@@ -459,7 +459,7 @@ func (c *connection) onWireConn(w *wire.Session) {
 				return
 			}
 		}
-	}()
+	})
 
 	dispatchOnEmpty := func() error {
 		if c.client.cfg.Callbacks.OnEmptyFn != nil {

--- a/client2/connection.go
+++ b/client2/connection.go
@@ -226,13 +226,13 @@ func (c *connection) connectWorker() {
 	defer c.log.Debugf("Terminating connect worker.")
 
 	dialCtx, cancelFn := context.WithCancel(context.Background())
-	go func() {
+	c.Go(func() {
 		select {
 		case <-c.HaltCh():
 			cancelFn()
 		case <-dialCtx.Done():
 		}
-	}()
+	})
 
 	for {
 		select {
@@ -464,13 +464,13 @@ func (c *connection) onWireConn(w *wire.Session) {
 	dispatchOnEmpty := func() error {
 		if c.client.cfg.Callbacks.OnEmptyFn != nil {
 			cbWg.Add(1)
-			go func() {
+			c.Go(func() {
 				defer cbWg.Done()
 				if err := c.client.cfg.Callbacks.OnEmptyFn(); err != nil {
 					c.log.Debugf("Caller failed to handle MessageEmpty: %v", err)
 					forceCloseConn(err)
 				}
-			}()
+			})
 		}
 		return nil
 	}

--- a/client2/daemon.go
+++ b/client2/daemon.go
@@ -199,6 +199,9 @@ func (d *Daemon) Start() error {
 }
 
 func (d *Daemon) onDocument(doc *cpki.Document) {
+	slopFactor := 0.8
+	pollProviderMsec := time.Duration((1.0 / (doc.LambdaP + doc.LambdaL)) * slopFactor * float64(time.Millisecond))
+	d.client.SetPollInterval(pollProviderMsec)
 	d.listener.updateFromPKIDoc(doc)
 }
 
@@ -358,7 +361,11 @@ func (d *Daemon) send(request *Request) {
 
 	if request.WithSURB {
 		now = time.Now()
-		duration := rtt
+		// XXX  this is too aggressive, and must be at least the fetchInterval + rtt + some slopfactor to account for path delays
+	
+		fetchInterval := d.client.GetPollInterval()
+		slop := time.Second
+		duration := rtt + fetchInterval + slop
 		replyArrivalTime := now.Add(duration)
 
 		d.timerQueue.Push(uint64(replyArrivalTime.UnixNano()), request.SURBID)

--- a/client2/daemon.go
+++ b/client2/daemon.go
@@ -119,7 +119,8 @@ func (d *Daemon) Shutdown() {
 }
 
 func (d *Daemon) halt() {
-	d.Halt() // shutdown ingressWorker and egressWorker
+	d.log.Debug("Stopping thin client listener")
+	d.listener.Shutdown()
 	d.log.Debug("Stopping timerQueue")
 	d.timerQueue.Halt()
 	d.log.Debug("Stopping gcTimerQueue")
@@ -127,11 +128,9 @@ func (d *Daemon) halt() {
 	d.log.Debug("Stopping arqTimerQueue")
 	d.arqTimerQueue.Halt()
 
-	d.log.Debug("Stopping thin client listener")
-	d.listener.Halt()
-
 	d.log.Debug("Stopping client")
 	d.client.Shutdown()
+	d.Halt() // shutdown ingressWorker and egressWorker
 }
 
 func (d *Daemon) Start() error {

--- a/client2/exponential.go
+++ b/client2/exponential.go
@@ -46,15 +46,19 @@ func (e *ExpDist) OutCh() <-chan struct{} {
 }
 
 func (e *ExpDist) UpdateRate(averageRate uint64, maxDelay uint64) {
-	e.opCh <- opExpNewRate{
+	select {
+	case <-e.HaltCh():
+	case e.opCh <- opExpNewRate{
 		averageRate: averageRate,
 		maxDelay:    maxDelay,
+	}:
 	}
 }
 
 func (e *ExpDist) UpdateConnectionStatus(isConnected bool) {
-	e.opCh <- opConnStatusChanged{
-		isConnected: isConnected,
+	select {
+	case <-e.HaltCh():
+	case e.opCh <- opConnStatusChanged{isConnected: isConnected}:
 	}
 }
 

--- a/client2/exponential.go
+++ b/client2/exponential.go
@@ -45,10 +45,6 @@ func (e *ExpDist) OutCh() <-chan struct{} {
 	return e.outCh
 }
 
-func (e *ExpDist) Stop() {
-	e.Halt()
-}
-
 func (e *ExpDist) UpdateRate(averageRate uint64, maxDelay uint64) {
 	e.opCh <- opExpNewRate{
 		averageRate: averageRate,

--- a/client2/incoming_conn.go
+++ b/client2/incoming_conn.go
@@ -87,7 +87,7 @@ func (c *incomingConn) sendPKIDoc(doc []byte) error {
 	}
 	select {
 	case c.sendToClientCh <- message:
-	case <-c.listener.closeAllCh:
+	case <-c.listener.HaltCh():
 		return errors.New("shutting down")
 	}
 	return nil
@@ -102,7 +102,7 @@ func (c *incomingConn) updateConnectionStatus(status error) {
 	}
 	select {
 	case c.sendToClientCh <- message:
-	case <-c.listener.closeAllCh:
+	case <-c.listener.HaltCh():
 		return
 	}
 }
@@ -193,7 +193,7 @@ func (c *incomingConn) worker() {
 		var ok bool
 
 		select {
-		case <-c.listener.closeAllCh:
+		case <-c.listener.HaltCh():
 			return
 		case rawReq, ok = <-requestCh:
 			if !ok {
@@ -206,7 +206,7 @@ func (c *incomingConn) worker() {
 			c.log.Infof("Received Request from peer application.")
 			select {
 			case c.listener.ingressCh <- rawReq:
-			case <-c.listener.closeAllCh:
+			case <-c.listener.HaltCh():
 				return
 			}
 		}

--- a/client2/incoming_conn.go
+++ b/client2/incoming_conn.go
@@ -172,10 +172,10 @@ func (c *incomingConn) worker() {
 		}
 	}()
 
-	go func() {
+	c.listener.Go(func() {
 		for {
 			select {
-			case <-c.listener.closeAllCh:
+			case <-c.listener.HaltCh():
 				return
 			case message := <-c.sendToClientCh:
 				c.log.Debug("SEND TO THIN CLIENT THREAD")
@@ -186,7 +186,7 @@ func (c *incomingConn) worker() {
 				}
 			}
 		}
-	}()
+	})
 
 	for {
 		var rawReq *Request

--- a/client2/incoming_conn.go
+++ b/client2/incoming_conn.go
@@ -139,7 +139,7 @@ func (c *incomingConn) sendResponse(r *Response) error {
 
 func (c *incomingConn) start() {
 	c.log.Debug("STARTING incomingConn")
-	go c.worker()
+	c.listener.Go(c.worker)
 }
 
 func (c *incomingConn) worker() {
@@ -153,7 +153,7 @@ func (c *incomingConn) worker() {
 	requestCh := make(chan *Request)
 	requestCloseCh := make(chan interface{})
 	defer close(requestCloseCh)
-	go func() {
+	c.listener.Go(func() {
 		defer close(requestCh)
 		for {
 			rawCmd, err := c.recvRequest()
@@ -170,7 +170,7 @@ func (c *incomingConn) worker() {
 				return
 			}
 		}
-	}()
+	})
 
 	c.listener.Go(func() {
 		for {

--- a/client2/listener.go
+++ b/client2/listener.go
@@ -41,18 +41,12 @@ type listener struct {
 }
 
 func (l *listener) Shutdown() {
+	// stop the decoy Sender
 	l.decoySender.Halt()
 	// Close the listener, wait for worker() to return.
 	l.listener.Close()
-
 	// stop listener, and stop Accepting connections
 	l.Halt()
-
-// Close all connections belonging to the listener.
-	//
-	// Note: Worst case this can take up to the handshake timeout to
-	// actually complete, since the channel isn't checked mid-handshake.
-
 }
 
 func (l *listener) updateFromPKIDoc(doc *cpki.Document) {

--- a/client2/listener.go
+++ b/client2/listener.go
@@ -42,7 +42,6 @@ type listener struct {
 
 func (l *listener) Halt() {
 	l.decoySender.Halt()
-	l.decoySender.Wait()
 	// Close the listener, wait for worker() to return.
 	l.listener.Close()
 	l.Worker.Halt()

--- a/client2/listener.go
+++ b/client2/listener.go
@@ -40,17 +40,19 @@ type listener struct {
 	updateStatusCh chan error
 }
 
-func (l *listener) Halt() {
+func (l *listener) Shutdown() {
 	l.decoySender.Halt()
 	// Close the listener, wait for worker() to return.
 	l.listener.Close()
-	l.Worker.Halt()
-	// Close all connections belonging to the listener.
+
+	// stop listener, and stop Accepting connections
+	l.Halt()
+
+// Close all connections belonging to the listener.
 	//
 	// Note: Worst case this can take up to the handshake timeout to
 	// actually complete, since the channel isn't checked mid-handshake.
-	close(l.closeAllCh)
-	l.closeAllWg.Wait()
+
 }
 
 func (l *listener) updateFromPKIDoc(doc *cpki.Document) {

--- a/client2/listener.go
+++ b/client2/listener.go
@@ -38,12 +38,12 @@ type listener struct {
 }
 
 func (l *listener) Shutdown() {
-	// stop the decoy Sender
-	l.decoySender.Halt()
 	// Close the listener, wait for worker() to return.
 	l.listener.Close()
 	// stop listener, and stop Accepting connections
 	l.Halt()
+	// stop the decoy Sender
+	l.decoySender.Halt()
 }
 
 func (l *listener) updateFromPKIDoc(doc *cpki.Document) {

--- a/client2/pki.go
+++ b/client2/pki.go
@@ -207,14 +207,14 @@ func (p *pki) worker() {
 
 func (p *pki) updateDocument(epoch uint64) error {
 	pkiCtx, cancelFn := context.WithCancel(context.Background())
-	go func() {
+	p.Go(func() {
 		select {
 		case <-p.HaltCh():
 			p.log.Debugf("Terminating gracefully.")
 			cancelFn()
 		case <-pkiCtx.Done():
 		}
-	}()
+	})
 
 	docBlob, d, err := p.getDocument(pkiCtx, epoch)
 	cancelFn()

--- a/client2/thin/thin.go
+++ b/client2/thin/thin.go
@@ -280,6 +280,8 @@ func (t *ThinClient) worker() {
 		if err != nil {
 			t.log.Errorf("thin client ReceiveMessage failed: %v", err)
 			if err == io.EOF {
+				// XXX: should we halt ThinClient on EOF??
+				go t.Halt()
 				return
 			}
 			continue

--- a/client2/timer_queue.go
+++ b/client2/timer_queue.go
@@ -64,9 +64,12 @@ func (t *TimerQueue) Len() int {
 }
 
 func (t *TimerQueue) Push(priority uint64, value interface{}) {
-	t.pushCh <- &pushedItem{
+	select {
+	case t.pushCh <- &pushedItem{
 		priority: priority,
 		value:    value,
+	}:
+	case <-t.HaltCh():
 	}
 }
 
@@ -88,7 +91,9 @@ func (t *TimerQueue) worker() {
 			t.queue.Pop()
 			t.mutex.Unlock()
 			if m != nil {
-				t.action(m.Value)
+				t.Go(func() {
+					t.action(m.Value)
+				})
 			}
 		case item := <-t.pushCh:
 			t.mutex.Lock()

--- a/client2/timer_queue.go
+++ b/client2/timer_queue.go
@@ -41,10 +41,6 @@ func NewTimerQueue(action func(interface{})) *TimerQueue {
 	}
 }
 
-func (t *TimerQueue) Halt() {
-	t.Worker.Halt()
-}
-
 func (t *TimerQueue) Start() {
 	t.Go(t.worker)
 }

--- a/genconfig/main.go
+++ b/genconfig/main.go
@@ -116,7 +116,7 @@ func (s *katzenpost) genClient2Cfg() error {
 	cfg.VotingAuthority = &cConfig2.VotingAuthority{Peers: peers}
 
 	// Debug section
-	cfg.Debug = &cConfig2.Debug{DisableDecoyTraffic: false}
+	cfg.Debug = &cConfig2.Debug{DisableDecoyTraffic: s.debugConfig.DisableDecoyTraffic}
 
 	log.Print("before gathering providers")
 	gateways := make([]*cConfig2.Gateway, 0)
@@ -644,7 +644,7 @@ func main() {
 		log.Fatalf("%s", err)
 	}
 
-	err = s.genClient2Cfg()
+	err = s.genClient2Cfg() // depends on genClientCfg()
 	if err != nil {
 		log.Fatalf("%s", err)
 	}

--- a/genconfig/main.go
+++ b/genconfig/main.go
@@ -65,6 +65,7 @@ type katzenpost struct {
 	serviceNodeIdx int
 	hasPanda       bool
 	hasProxy       bool
+	noMixDecoy     bool
 	debugConfig    *cConfig.Debug
 }
 
@@ -246,7 +247,7 @@ func (s *katzenpost) genNodeConfig(isGateway, isServiceNode bool, isVoting bool)
 
 	// Debug section.
 	cfg.Debug = new(sConfig.Debug)
-	cfg.Debug.SendDecoyTraffic = true
+	cfg.Debug.SendDecoyTraffic = !s.noMixDecoy
 
 	// PKI section.
 	if isVoting {
@@ -464,6 +465,7 @@ func main() {
 	UserForwardPayloadLength := flag.Int("UserForwardPayloadLength", 2000, "UserForwardPayloadLength")
 	pkiSignatureScheme := flag.String("pkiScheme", "Ed25519", "PKI Signature Scheme to be used")
 	noDecoy := flag.Bool("noDecoy", false, "Disable decoy traffic for the client")
+	noMixDecoy := flag.Bool("noMixDecoy", false, "Disable decoy traffic for the mixes")
 	dialTimeout := flag.Int("dialTimeout", 0, "Session dial timeout")
 	maxPKIDelay := flag.Int("maxPKIDelay", 0, "Initial maximum PKI retrieval delay")
 	pollingIntvl := flag.Int("pollingIntvl", 0, "Polling interval")
@@ -535,6 +537,7 @@ func main() {
 		InitialMaxPKIRetrievalDelay: *maxPKIDelay,
 		PollingInterval:             *pollingIntvl,
 	}
+	s.noMixDecoy = *noMixDecoy
 
 	nrHops := *nrLayers + 2
 


### PR DESCRIPTION
this collection of commits fixes issues found while debugging the client2 dockerdockertest make target.

in particular there were several issues with blocked routines at shutdown, a missing "+" required for addressing kaetzchen endpoints, misbehaving fetchInterval loop and aggressive garbage collection timeout resulted in SURB Replies being dropped.

- **Reapply "DEBUG: add pprof http listener"**
- **add -noMixDecoy to genconfig**
- **genconfig: disable client2 decoy traffic with -noDecoy**
- **client2: fix testtest endpoint**
- **client2: connection: run peer reader with worker.Go**
- **client2: listener: eliminate redundant Wait()**
- **client2: Shutdown conn and pki worker before halting client worker**
- **client2: incoming_conn, connection: start workers with worker.Go()**
- **client2/daemon: shutdown listener first**
- **client2/client_docker_test: fix other endpoints**
- **client2/exponential: do not block opCh at shutdown**
- **client2/connection, client2/daemon: update fetchDelay from pki Document**
- **client2/listener: fix comment**
- **client2/client_docker_test: remove invalid constraint**
