### PR TITLE
github-ci: remove codecov

### DIFF
--- a/.github/workflows/docker-mixnet.yml
+++ b/.github/workflows/docker-mixnet.yml
@@ -159,6 +159,3 @@ jobs:
       - name: Stop the mixnet
         run: |
           cd docker && sudo -E make stop
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4


### PR DESCRIPTION
this removes codecov. we should add a github action that adds the go tooling coverage statements to our PR's without using a 3rd party.
codecov now requires an API key, and I removed the application from the org because I couldn't find the control panel anywhere and when I went to re-add the application it wants to disclose all of the group members emails to codecov, so this PR just removes this noise.
