### PR TITLE
add -noMixDecoy to genconfig

### DIFF
--- a/genconfig/main.go
+++ b/genconfig/main.go
@@ -77,6 +77,7 @@ type katzenpost struct {
 	serviceNodeIdx int
 	hasPanda       bool
 	hasProxy       bool
+	noMixDecoy     bool
 	debugConfig    *cConfig.Debug
 }
 
@@ -180,7 +181,7 @@ func (s *katzenpost) genNodeConfig(isGateway, isServiceNode bool, isVoting bool)
 
 	// Debug section.
 	cfg.Debug = new(sConfig.Debug)
-	cfg.Debug.SendDecoyTraffic = false
+	cfg.Debug.SendDecoyTraffic = !s.noMixDecoy
 
 	// PKI section.
 	if isVoting {
@@ -391,6 +392,7 @@ func main() {
 	UserForwardPayloadLength := flag.Int("UserForwardPayloadLength", 2000, "UserForwardPayloadLength")
 	pkiSignatureScheme := flag.String("pkiScheme", "Ed25519", "PKI Signature Scheme to be used")
 	noDecoy := flag.Bool("noDecoy", false, "Disable decoy traffic for the client")
+	noMixDecoy := flag.Bool("noMixDecoy", false, "Disable decoy traffic for the mixes")
 	dialTimeout := flag.Int("dialTimeout", 0, "Session dial timeout")
 	maxPKIDelay := flag.Int("maxPKIDelay", 0, "Initial maximum PKI retrieval delay")
 	pollingIntvl := flag.Int("pollingIntvl", 0, "Polling interval")
@@ -462,6 +464,7 @@ func main() {
 		InitialMaxPKIRetrievalDelay: *maxPKIDelay,
 		PollingInterval:             *pollingIntvl,
 	}
+	s.noMixDecoy = *noMixDecoy
 
 	nrHops := *nrLayers + 2
 


### PR DESCRIPTION
this adds -noMixDecoy flag to genconfig

This produces a mixnet configuration that doesn't send decoy messages
