### PR TITLE
catshadow: use TimeUnixMicro for better than 1s resolution

### DIFF
--- a/catshadow/client.go
+++ b/catshadow/client.go
@@ -64,6 +64,8 @@ var (
 	ErrAlreadyHaveKeyExchange = errors.New("Already created KeyExchange with contact")
 	ErrHalted                 = errors.New("Halted")
 	pandaBlobSize             = 1000
+	encWithTimeMicro          cbor.EncMode
+	roundTimestampsBy         = 200 * time.Millisecond
 )
 
 const EventChannelSize = 1000
@@ -918,11 +920,11 @@ func (c *Client) doSendMessage(convoMesgID MessageID, nickname string, message [
 	}
 	outMessage := Message{
 		Plaintext: message,
-		Timestamp: time.Now(),
+		Timestamp: time.Now().Round(roundTimestampsBy),
 		Outbound:  true,
 	}
 
-	serialized, err := cbor.Marshal(outMessage)
+	serialized, err := encWithTimeMicro.Marshal(outMessage)
 	if err != nil {
 		c.eventCh <- &MessageNotSentEvent{
 			Nickname:  nickname,
@@ -1496,4 +1498,10 @@ func (c *Client) goOffline() error {
 	c.online = false
 	c.session = nil
 	return nil
+}
+
+func init() {
+	opts := cbor.CanonicalEncOptions()
+	opts.Time = cbor.TimeUnixMicro
+	encWithTimeMicro, _ = opts.EncMode()
 }


### PR DESCRIPTION
catshadow sorts messages by Timestamp. This workaround tells the cbor library to use the option TimeMicroUnix instead of TimeUnix.
Because messages are encrypted with the senders timestamp before queuing for transmission, it's easily possible for a user to send more than 1 message per second, which is the default timestamp resolution, and results in unstable sort order of messages.
