### PR TITLE
client: fatalErr watcher should not WARN at close of fatalErrCh

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -114,9 +114,11 @@ func New(cfg *config.Config) (*Client, error) {
 func (c *Client) fatalErr() {
 	select {
 	case <-c.HaltCh():
-	case err := <-c.fatalErrCh:
-		c.log.Warningf("Shutting down due to error: %v", err)
-		c.Shutdown()
+	case err, ok := <-c.fatalErrCh:
+		if ok {
+			c.log.Warningf("Shutting down due to error: %v", err)
+			c.Shutdown()
+		}
 	}
 }
 


### PR DESCRIPTION
when client is Shutdown gracefully, the fatalErrCh should not WARN
