### PR TITLE
Change transport endpoint to "quic"

### DIFF
--- a/authority/voting/server/server.go
+++ b/authority/voting/server/server.go
@@ -393,7 +393,7 @@ func New(cfg *config.Config) (*Server, error) {
 				s.state.Go(func() {
 					s.listenWorker(l)
 				})
-			case "http":
+			case "quic":
 				l, err := quic.ListenAddr(u.Host, common.GenerateTLSConfig(), nil)
 				if err != nil {
 					s.log.Errorf("Failed to start listener '%v': %v", v, err)

--- a/authority/voting/server/server.go
+++ b/authority/voting/server/server.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/quic-go/quic-go"
 	"gopkg.in/op/go-logging.v1"
 
 	"github.com/katzenpost/hpqc/hash"
@@ -43,7 +44,6 @@ import (
 	"github.com/katzenpost/katzenpost/core/sphinx/geo"
 	"github.com/katzenpost/katzenpost/core/utils"
 	"github.com/katzenpost/katzenpost/http/common"
-	"github.com/quic-go/quic-go"
 )
 
 // ErrGenerateOnly is the error returned when the server initialization

--- a/core/pki/descriptor.go
+++ b/core/pki/descriptor.go
@@ -227,7 +227,7 @@ func IsDescriptorWellFormed(d *MixDescriptor, epoch uint64) error {
 			expectedIPVer = 4
 		case TransportTCPv6:
 			expectedIPVer = 6
-		case TransportHTTP:
+		case TransportQUIC:
 		case TransportTCP:
 			// Ignore transports that don't have validation logic.
 			continue
@@ -246,7 +246,7 @@ func IsDescriptorWellFormed(d *MixDescriptor, epoch uint64) error {
 				return err
 			}
 			switch u.Scheme {
-			case TransportWS, TransportTCP, TransportTCPv4, TransportTCPv6, TransportHTTP:
+			case TransportWS, TransportTCP, TransportTCPv4, TransportTCPv6, TransportQUIC:
 			default:
 				return fmt.Errorf("Unsupported listener scheme '%v': %v", v, u.Scheme)
 			}

--- a/core/pki/document.go
+++ b/core/pki/document.go
@@ -383,17 +383,17 @@ var (
 	// TransportTCPv6 is TCP over IPv6.
 	TransportTCPv6 string = "tcp6"
 
-	// TransportHTTP is QUIC, with the IP version determined by the results
+	// TransportQUIC is QUIC, with the IP version determined by the results
 	// of a name server lookup
-	TransportHTTP string = "http"
+	TransportQUIC string = "quic"
 
 	// InternalTransports is the list of transports used for non-client related
 	// communications.
-	InternalTransports = []string{TransportTCPv4, TransportTCPv6, TransportHTTP}
+	InternalTransports = []string{TransportTCPv4, TransportTCPv6, TransportQUIC}
 
 	// ClientTransports is the list of transports used by default for client
 	// to provider communication.
-	ClientTransports = []string{TransportTCP, TransportTCPv4, TransportTCPv6, TransportHTTP, TransportWS}
+	ClientTransports = []string{TransportTCP, TransportTCPv4, TransportTCPv6, TransportQUIC, TransportWS}
 )
 
 // FromPayload deserializes, then verifies a Document, and returns the Document or error.

--- a/genconfig/main.go
+++ b/genconfig/main.go
@@ -158,10 +158,10 @@ func (s *katzenpost) genNodeConfig(isGateway, isServiceNode bool, isVoting bool)
 	cfg.Server.PKISignatureScheme = s.pkiSignatureScheme.Name()
 	cfg.Server.Identifier = n
 	if isGateway {
-		cfg.Server.Addresses = []string{fmt.Sprintf("http://127.0.0.1:%d", s.lastPort), fmt.Sprintf("tcp://127.0.0.1:%d", s.lastPort+1)}
+		cfg.Server.Addresses = []string{fmt.Sprintf("tcp://127.0.0.1:%d", s.lastPort), fmt.Sprintf("tcp://127.0.0.1:%d", s.lastPort+1)}
 		s.lastPort += 2
 	} else {
-		cfg.Server.Addresses = []string{fmt.Sprintf("http://127.0.0.1:%d", s.lastPort)}
+		cfg.Server.Addresses = []string{fmt.Sprintf("tcp://127.0.0.1:%d", s.lastPort)}
 		s.lastPort += 1
 	}
 	cfg.Server.DataDir = filepath.Join(s.baseDir, n)
@@ -302,7 +302,7 @@ func (s *katzenpost) genVotingAuthoritiesCfg(numAuthorities int, parameters *vCo
 			WireKEMScheme:      s.wireKEMScheme,
 			PKISignatureScheme: s.pkiSignatureScheme.Name(),
 			Identifier:         fmt.Sprintf("auth%d", i),
-			Addresses:          []string{fmt.Sprintf("http://127.0.0.1:%d", s.lastPort)},
+			Addresses:          []string{fmt.Sprintf("tcp://127.0.0.1:%d", s.lastPort)},
 			DataDir:            filepath.Join(s.baseDir, fmt.Sprintf("auth%d", i)),
 		}
 		os.Mkdir(filepath.Join(s.outDir, cfg.Server.Identifier), 0700)

--- a/http/common/quic.go
+++ b/http/common/quic.go
@@ -146,7 +146,7 @@ func DialURL(u *url.URL, ctx context.Context, dialFn func(ctx context.Context, n
 		} else {
 			return conn, nil
 		}
-	case "http":
+	case "quic":
 		// http/3 quic connector
 		// XXX: will need to add the TLS certificate
 		// fingerprint to the authority configuration

--- a/http/proxy/client/main.go
+++ b/http/proxy/client/main.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	cfgFile  = flag.String("cfg", "proxy.toml", "config file")
-	epName   = flag.String("ep", "http", "endpoint name")
+	epName   = flag.String("ep", "quic", "endpoint name")
 	logLevel = flag.String("log_level", "DEBUG", "logging level could be set to: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL")
 	port     = flag.Int("port", 8080, "listener address")
 	retry    = flag.Int("retry", -1, "limit number of reconnection attempts")

--- a/server/internal/incoming/listener.go
+++ b/server/internal/incoming/listener.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-
 	"github.com/katzenpost/hpqc/kem/schemes"
 	signSchemes "github.com/katzenpost/hpqc/sign/schemes"
 
@@ -238,7 +237,7 @@ func New(glue glue.Glue, incomingCh chan<- interface{}, id int, addr string) (gl
 				l.log.Errorf("Failed to start listener '%v': %v", addr, err)
 				return nil, err
 			}
-		case "http":
+		case "quic":
 			ql, err := quic.ListenAddr(u.Host, common.GenerateTLSConfig(), nil)
 			if err != nil {
 				l.log.Errorf("Failed to start listener '%v': %v", addr, err)

--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -743,8 +743,8 @@ func makeDescAddrMap(addrs []string) (map[string][]string, error) {
 			return nil, err
 		}
 		switch u.Scheme {
-		case string(cpki.TransportHTTP):
-			m[cpki.TransportHTTP] = append(m[cpki.TransportHTTP], addr)
+		case string(cpki.TransportQUIC):
+			m[cpki.TransportQUIC] = append(m[cpki.TransportQUIC], addr)
 		case string(cpki.TransportTCP):
 			// See if the URL contains an IP
 			var ips = []net.IP{}


### PR DESCRIPTION
* Rename internally used transport endpoint; call it "quic" instead of "http".
* Remove quic listener code duplication from authority/voting/server/server.go
* Make genconfig default to using TCP instead of QUIC