### PR TITLE
mixserver: increase authentication failure log verbosity

### DIFF
--- a/server/internal/gateway/gateway.go
+++ b/server/internal/gateway/gateway.go
@@ -13,7 +13,6 @@ import (
 
 	"gopkg.in/op/go-logging.v1"
 
-	"github.com/katzenpost/hpqc/hash"
 	"github.com/katzenpost/hpqc/kem/schemes"
 
 	"github.com/katzenpost/katzenpost/core/epochtime"
@@ -77,14 +76,9 @@ func (p *gateway) UserDB() userdb.UserDB {
 func (p *gateway) AuthenticateClient(c *wire.PeerCredentials) bool {
 	isValid := p.userDB.IsValid(c.AdditionalData, c.PublicKey)
 	if !isValid {
-		blob, err := c.PublicKey.MarshalBinary()
+		_, err := c.PublicKey.MarshalBinary()
 		if err != nil {
 			panic(err)
-		}
-		if len(c.AdditionalData) == sConstants.NodeIDLength {
-			p.log.Errorf("Authentication failed: User: '%x', Key: '%x' (Probably a peer)", c.AdditionalData, hash.Sum256(blob))
-		} else {
-			p.log.Errorf("Authentication failed: User: '%x', Key: '%x'", c.AdditionalData, hash.Sum256(blob))
 		}
 	}
 	return isValid

--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -538,14 +538,8 @@ func (p *pki) documentsForAuthentication() ([]*pkicache.Entry, *pkicache.Entry, 
 func (p *pki) AuthenticateConnection(c *wire.PeerCredentials, isOutgoing bool) (desc *cpki.MixDescriptor, canSend, isValid bool) {
 	var earlySendSlack = epochtime.Period / 8
 
-	dirStr := "Incoming"
-	if isOutgoing {
-		dirStr = "Outgoing"
-	}
-
 	// Ensure the additional data is valid.
 	if len(c.AdditionalData) != sConstants.NodeIDLength {
-		p.log.Debugf("%v: '%x' AD not an IdentityKey?.", dirStr, c.AdditionalData)
 		return nil, false, false
 	}
 	var nodeID [sConstants.NodeIDLength]byte
@@ -578,7 +572,6 @@ func (p *pki) AuthenticateConnection(c *wire.PeerCredentials, isOutgoing bool) (
 		}
 		if !hmac.Equal(m.LinkKey, blob) {
 			if desc == m || !hmac.Equal(m.LinkKey, blob) {
-				p.log.Warningf("%v: '%x' Public Key mismatch: '%x'", dirStr, c.AdditionalData, hash.Sum256(blob))
 				continue
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -336,12 +336,7 @@ func New(cfg *config.Config) (*Server, error) {
 	}
 
 	s.linkKey = linkPrivateKey
-	blob, err := linkPublicKey.MarshalBinary()
-	if err != nil {
-		panic(err)
-	}
-	linkPubKeyHash := hash.Sum256(blob)
-	s.log.Noticef("Server link public key hash is: %x", linkPubKeyHash[:])
+	s.log.Noticef("Server link public key is: %s", pemkem.ToPublicPEMString(linkPublicKey))
 
 	if s.cfg.Debug.GenerateOnly {
 		return nil, ErrGenerateOnly
@@ -459,7 +454,7 @@ func New(cfg *config.Config) (*Server, error) {
 	}
 	// Bring the listener(s) online.
 	s.listeners = make([]glue.Listener, 0, len(addresses))
-	for i, addr := range addresses  {
+	for i, addr := range addresses {
 		l, err := incoming.New(goo, s.inboundPackets, i, addr)
 		if err != nil {
 			s.log.Errorf("Failed to spawn listener on address: %v (%v).", addr, err)


### PR DESCRIPTION
* mix server: print link pub key upon startup
* remove error and warning log lines that were printed for trial authentications: meaning that if they fail the authentication can still succeed at a later stage... therefore do not print such log lines since they are probably just noise
* mix server: increase log error verbosity for incoming and outgoing authentication failures