### PR TITLE
Fixup client2 thin client protocol

### DIFF
--- a/authority/voting/server/state.go
+++ b/authority/voting/server/state.go
@@ -188,7 +188,7 @@ func (s *state) fsm() <-chan time.Time {
 	case stateAcceptDescriptor:
 		signed, err := s.getVote(s.votingEpoch)
 		if err == nil {
-			serialized, err := signed.MarshalBinary()
+			serialized, err := signed.MarshalCertificate()
 			if err == nil {
 				s.sendVoteToAuthorities(serialized, s.votingEpoch)
 			} else {
@@ -209,7 +209,7 @@ func (s *state) fsm() <-chan time.Time {
 	case stateAcceptReveal:
 		signed, err := s.getCertificate(s.votingEpoch)
 		if err == nil {
-			serialized, err := signed.MarshalBinary()
+			serialized, err := signed.MarshalCertificate()
 			if err == nil {
 				s.sendCertToAuthorities(serialized, s.votingEpoch)
 			} else {
@@ -462,7 +462,7 @@ func (s *state) getThresholdConsensus(epoch uint64) (*pki.Document, error) {
 		}
 	}
 	// now see if we managed to get a threshold number of signatures
-	signedConsensus, err := ourConsensus.MarshalBinary()
+	signedConsensus, err := ourConsensus.MarshalCertificate()
 	if err != nil {
 		return nil, err
 	}
@@ -1699,7 +1699,7 @@ func (s *state) documentForEpoch(epoch uint64) ([]byte, error) {
 	// If we have a serialized document, return it.
 	if d, ok := s.documents[epoch]; ok {
 		// XXX We should cache this
-		return d.MarshalBinary()
+		return d.MarshalCertificate()
 	}
 
 	// Otherwise, return an error based on the time.

--- a/authority/voting/server/state_test.go
+++ b/authority/voting/server/state_test.go
@@ -314,7 +314,7 @@ func TestVote(t *testing.T) {
 		require.Equal(len(myVote.Signatures), 1)
 		require.NoError(err)
 		require.NotNil(myVote)
-		raw, err := myVote.MarshalBinary()
+		raw, err := myVote.MarshalCertificate()
 		require.NoError(err)
 		_, err = pki.ParseDocument(raw)
 		require.NoError(err)

--- a/client2/incoming_conn.go
+++ b/client2/incoming_conn.go
@@ -57,7 +57,7 @@ func (c *incomingConn) recvRequest() (*Request, error) {
 	c.log.Debug("before Unmarshal")
 	err = cbor.Unmarshal(blob[:count], &req)
 	if err != nil {
-		fmt.Printf("error decoding cbor from client: %s\n", err)
+		c.log.Infof("error decoding cbor from client: %s\n", err)
 		return nil, err
 	}
 	c.log.Debug("after Unmarshal")

--- a/client2/incoming_conn.go
+++ b/client2/incoming_conn.go
@@ -32,50 +32,35 @@ type incomingConn struct {
 }
 
 func (c *incomingConn) recvRequest() (*Request, error) {
-
 	req := new(thin.Request)
-	if c.listener.isTCP {
-		c.log.Debug("recvRequest TCP")
-		const prefixLength = 4
-		lenPrefix := [prefixLength]byte{}
-		count, err := io.ReadFull(c.conn, lenPrefix[:])
-		if err != nil {
-			return nil, err
-		}
-		c.log.Debug("read length prefix")
-		if count != prefixLength {
-			return nil, errors.New("failed to read length prefix")
-		}
-		blobLen := binary.BigEndian.Uint32(lenPrefix[:])
-		c.log.Debugf("length prefix is %d", blobLen)
-		blob := make([]byte, blobLen)
-		if count, err = io.ReadFull(c.conn, blob); err != nil {
-			return nil, err
-		}
-		c.log.Debug("after blob read")
-		if uint32(count) != blobLen {
-			return nil, errors.New("failed to read blob")
-		}
-		c.log.Debug("before Unmarshal")
-		err = cbor.Unmarshal(blob[:count], &req)
-		if err != nil {
-			fmt.Printf("error decoding cbor from client: %s\n", err)
-			return nil, err
-		}
-		c.log.Debug("after Unmarshal")
-	} else {
-		c.log.Debug("recvRequest UNIX socket")
-		buff := make([]byte, 65536)
-		reqLen, _, _, _, err := c.conn.(*net.UnixConn).ReadMsgUnix(buff, nil)
-		if err != nil {
-			return nil, err
-		}
-		err = cbor.Unmarshal(buff[:reqLen], &req)
-		if err != nil {
-			fmt.Printf("error decoding cbor from client: %s\n", err)
-			return nil, err
-		}
+	c.log.Debug("recvRequest TCP")
+	const prefixLength = 4
+	lenPrefix := [prefixLength]byte{}
+	count, err := io.ReadFull(c.conn, lenPrefix[:])
+	if err != nil {
+		return nil, err
 	}
+	c.log.Debug("read length prefix")
+	if count != prefixLength {
+		return nil, errors.New("failed to read length prefix")
+	}
+	blobLen := binary.BigEndian.Uint32(lenPrefix[:])
+	c.log.Debugf("length prefix is %d", blobLen)
+	blob := make([]byte, blobLen)
+	if count, err = io.ReadFull(c.conn, blob); err != nil {
+		return nil, err
+	}
+	c.log.Debug("after blob read")
+	if uint32(count) != blobLen {
+		return nil, errors.New("failed to read blob")
+	}
+	c.log.Debug("before Unmarshal")
+	err = cbor.Unmarshal(blob[:count], &req)
+	if err != nil {
+		fmt.Printf("error decoding cbor from client: %s\n", err)
+		return nil, err
+	}
+	c.log.Debug("after Unmarshal")
 	return FromThinRequest(req, c.appID), nil
 }
 
@@ -115,15 +100,10 @@ func (c *incomingConn) sendResponse(r *Response) error {
 	}
 
 	var toSend []byte
-	if c.listener.isTCP {
-		const blobPrefixLen = 4
-		prefix := [blobPrefixLen]byte{}
-		binary.BigEndian.PutUint32(prefix[:], uint32(len(blob)))
-
-		toSend = append(prefix[:], blob...)
-	} else {
-		toSend = blob
-	}
+	const blobPrefixLen = 4
+	prefix := [blobPrefixLen]byte{}
+	binary.BigEndian.PutUint32(prefix[:], uint32(len(blob)))
+	toSend = append(prefix[:], blob...)
 
 	c.log.Debug("sendResponse BEFORE conn.Write")
 	count, err := c.conn.Write(toSend)

--- a/client2/pki.go
+++ b/client2/pki.go
@@ -11,12 +11,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fxamacker/cbor/v2"
+	"gopkg.in/op/go-logging.v1"
+
 	vServer "github.com/katzenpost/katzenpost/authority/voting/server"
 	"github.com/katzenpost/katzenpost/core/epochtime"
 	cpki "github.com/katzenpost/katzenpost/core/pki"
 	"github.com/katzenpost/katzenpost/core/wire/commands"
 	"github.com/katzenpost/katzenpost/core/worker"
-	"gopkg.in/op/go-logging.v1"
 )
 
 var (
@@ -268,8 +270,14 @@ func (p *pki) getDocument(ctx context.Context, epoch uint64) ([]byte, *cpki.Docu
 		p.log.Errorf("BUG: Provider returned document for incorrect epoch: %v", d.Epoch)
 		return nil, nil, fmt.Errorf("BUG: Provider returned document for incorrect epoch: %v", d.Epoch)
 	}
+	d.Signatures = nil
+	docBlob, err := cbor.Marshal(d)
+	if err != nil {
+		p.log.Errorf("BUG: failed to cbor marshal pki doc: %v", err)
+		return nil, nil, err
+	}
 
-	return resp.Payload, d, err
+	return docBlob, d, err
 }
 
 func (p *pki) pruneDocuments(now uint64) {

--- a/core/pki/document_test.go
+++ b/core/pki/document_test.go
@@ -157,7 +157,7 @@ func TestDocument(t *testing.T) {
 		tmpDoc, err := ParseDocument(tmpDocBytes)
 		require.Equal(nil, err)
 		require.Equal(ddoc, tmpDoc)
-		tmpDocBytes, err := tmpDoc.MarshalBinary()
+		tmpDocBytes, err := tmpDoc.MarshalCertificate()
 		require.Equal(nil, err)
 		require.Equal(signed, tmpDocBytes)
 	}

--- a/genconfig/main.go
+++ b/genconfig/main.go
@@ -108,9 +108,16 @@ func (s *katzenpost) genClient2Cfg() error {
 	os.Mkdir(filepath.Join(s.outDir, "client2"), 0700)
 	cfg := new(cConfig2.Config)
 
-	//cfg.ListenNetwork = "unixpacket"
+	// abstract unix domain sockets only work on linux,
+	//cfg.ListenNetwork = "unix"
 	//cfg.ListenAddress = "@katzenpost"
+	// therefore if unix sockets are requires on non-linux platforms
+	// the solution is to specify a unix socket file path instead of
+	// and abstract unix socket name:
+	//cfg.ListenNetwork = "unix"
+	//cfg.ListenAddress = "/tmp/katzenzpost.socket"
 
+	// Use TCP by default so that the CI tests pass on all platforms
 	cfg.ListenNetwork = "tcp"
 	cfg.ListenAddress = "localhost:64331"
 
@@ -243,7 +250,7 @@ func (s *katzenpost) genNodeConfig(isGateway, isServiceNode bool, isVoting bool)
 	cfg.Server.Identifier = n
 	if isGateway {
 		cfg.Server.Addresses = []string{fmt.Sprintf("tcp://127.0.0.1:%d", s.lastPort), fmt.Sprintf("quic://[::1]:%d", s.lastPort+1),
-		fmt.Sprintf("onion://thisisjustatestoniontoverifythatconfigandpkiworkproperly.onion:4242")}
+			fmt.Sprintf("onion://thisisjustatestoniontoverifythatconfigandpkiworkproperly.onion:4242")}
 		cfg.Server.BindAddresses = []string{fmt.Sprintf("tcp://127.0.0.1:%d", s.lastPort), fmt.Sprintf("quic://[::1]:%d", s.lastPort+1)}
 		s.lastPort += 2
 	} else {


### PR DESCRIPTION
* The goal here is to serialize the pki Document with CBOR and send that to Thin Client apps with the signatures removed to save bandwidth because the client daemon has checked the signatures already. This turned out to be very difficult.
* The other main goal is to fix the thin client protocol so that it always uses the length prefixing whereas previously it only used length prefixing for tcp.

One of the reasons it's problematic to have the methods for binary marshaler/unmarshaler on the pki Document type is because our actual implementation is a complete lie and does not actually unmarshal the PKI Document type and instead unmarshals the Certificate struct type which contains public keys and signatures.

The other reason it's problematic is because it prevents use from using the cbor library directly to manually marshal/unmarshal the pki Document type. It has previously forced us to deal only with the serialization of the Certification struct type.
