### PR TITLE
Fix Signing bug + genconfig: default to dilithium

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -97,7 +97,7 @@ var (
 	)
 )
 
-var testSignatureScheme = signSchemes.ByName("Ed25519")
+var testSignatureScheme = signSchemes.ByName("Ed448-Dilithium3")
 
 func getClientCfg(f string) *config.Config {
 	cfg, err := config.LoadFile(f)

--- a/core/cert/cert.go
+++ b/core/cert/cert.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/katzenpost/hpqc/hash"
 	"github.com/katzenpost/hpqc/sign"
+
 	"github.com/katzenpost/katzenpost/core/epochtime"
 )
 
@@ -190,10 +191,7 @@ func Sign(signer sign.PrivateKey, verifier sign.PublicKey, data []byte, expirati
 		return nil, err
 	}
 	cert.Signatures = make(map[[32]byte]Signature)
-	sig, err := signer.Sign(nil, mesg, nil)
-	if err != nil {
-		return nil, err
-	}
+	sig := signer.Scheme().Sign(signer, mesg, nil)
 	cert.Signatures[hash.Sum256From(verifier)] = Signature{
 		PublicKeySum256: hash.Sum256From(verifier),
 		Payload:         sig,
@@ -294,10 +292,7 @@ func SignMulti(signer sign.PrivateKey, verifier sign.PublicKey, rawCert []byte) 
 	if err != nil {
 		return nil, err
 	}
-	sig, err := signer.Sign(nil, mesg, nil)
-	if err != nil {
-		return nil, err
-	}
+	sig := signer.Scheme().Sign(signer, mesg, nil)
 	signature := Signature{
 		PublicKeySum256: hash.Sum256From(verifier),
 		Payload:         sig,

--- a/genconfig/main.go
+++ b/genconfig/main.go
@@ -492,7 +492,7 @@ func main() {
 	nike := flag.String("nike", "x25519", "Name of the NIKE Scheme to be used with Sphinx")
 	ratchetNike := flag.String("ratchetNike", "CTIDH512-X25519", "Name of the NIKE Scheme to be used with the doubleratchet")
 	UserForwardPayloadLength := flag.Int("UserForwardPayloadLength", 2000, "UserForwardPayloadLength")
-	pkiSignatureScheme := flag.String("pkiScheme", "Ed25519", "PKI Signature Scheme to be used")
+	pkiSignatureScheme := flag.String("pkiScheme", "Ed448-Dilithium3", "PKI Signature Scheme to be used")
 	noDecoy := flag.Bool("noDecoy", true, "Disable decoy traffic for the client")
 	noMixDecoy := flag.Bool("noMixDecoy", true, "Disable decoy traffic for the mixes")
 	dialTimeout := flag.Int("dialTimeout", 0, "Session dial timeout")


### PR DESCRIPTION
Here we fix a signing bug that prevented us from using some of the signature schemes made available in hpqc, namely it lets us use the Signature schemes from our fork `circl` library if we've specifically made them available.