### PR TITLE
core/wire: increase max noise message len to 400MB

### DIFF
--- a/core/wire/constants/constants.go
+++ b/core/wire/constants/constants.go
@@ -4,4 +4,4 @@
 package constants
 
 // MaxMsgLen is the maximum we're willing to send in one message.
-const MaxMsgLen = 1300000
+const MaxMsgLen = 400000000


### PR DESCRIPTION
this does not change the noise message size. instead it changes the bounds checking for noise messages... and this change here helps us use ANY of the KEMs in hpqc for Sphinx or our Noise wire protocol.