### PR TITLE
client2: gate the time tests with a build tag

### DIFF
--- a/client2/exponential_test.go
+++ b/client2/exponential_test.go
@@ -1,3 +1,5 @@
+//go:build time_test
+
 // SPDX-FileCopyrightText: Copyright (C) 2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only
 

--- a/client2/timer_queue_test.go
+++ b/client2/timer_queue_test.go
@@ -1,3 +1,5 @@
+//go:build time_test
+
 // SPDX-FileCopyrightText: © 2023 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only
 


### PR DESCRIPTION
prevent client2's time related unit tests from running by build tag; the time_test build tag is required to run those tests. The github CI has intermittent failures on all time related tests; this should reduce those failures and make our CI more reliable.