### PR TITLE
docker/Makefile: fix no_decoy and no_mixdecoy options

### DIFF
--- a/.github/workflows/docker-mixnet.yml
+++ b/.github/workflows/docker-mixnet.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Build and start the mixnet
         run: |
-          cd docker && make log_level=DEBUG start wait
+          cd docker && make no_decoy=false no_mixdecoy=false log_level=DEBUG start wait
 
       - name: run ping
         run: cd docker && make run-ping

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -60,17 +60,16 @@ sh=$(shell if echo ${distro}|grep -q alpine; then echo sh; else echo bash; fi)
 cache_dir=cache
 
 # no_decoy and no_mixdecoy control enabling dockerized mixnets with or without decoy traffic
-noMixDecoy=$(shell if [[ $no_mixdecoy ]]; then echo -noMixDecoy; fi)
-noDecoy=$(shell if [[ $no_decoy ]]; then echo -noDecoy; fi)
+ifeq ($(no_mixdecoy),true)
+  noMixDecoy=-noMixDecoy
+endif
+
+ifeq ($(no_decoy),true)
+  noDecoy=-noDecoy
+endif
 
 # log_level can be DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL
 log_level=INFO
-
-no_decoy?=false
-no_mixdecoy?=false
-
-noDecoy=$(shell if [[ $no_decoy ]]; then echo -noDecoy; fi)
-noMixDecoy=$(shell if [[ $no_mixdecoy ]]; then echo -noMixDecoy; fi)
 
 docker=$(shell if which podman|grep -q .; then echo podman; else echo docker; fi)
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -119,7 +119,7 @@ $(net_name)/running.stamp:
 	make $(make_args) start
 
 start: $(docker_compose_yml) testnet_binaries
-	cd $(net_name); $(docker_compose) up --remove-orphans -d; $(docker_compose) top
+	cd $(net_name); $(docker_compose) up --remove-orphans -d; $(docker_compose) ps
 	touch $(net_name)/running.stamp
 
 stop:


### PR DESCRIPTION
This makes it possible to pass `no_decoy=false no_mixdecoy=false` to `make` to enable cover traffic in the containerized testnet.