### PR TITLE
docker, genconfig: add client2 kpclientd to testnet services

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -92,7 +92,7 @@ make_args=--no-print-directory net_name=$(net_name) docker=$(docker) distro=$(di
 
 docker_run_sh=$(docker) run ${docker_args} $(mount_net_name) --rm katzenpost-$(distro)_base $(sh) -c
 
-testnet_binaries: $(net_name)/server.$(distro) $(net_name)/proxy_server.$(distro) $(net_name)/proxy_client.$(distro) $(net_name)/memspool.$(distro) $(net_name)/pigeonhole.$(distro) $(net_name)/panda_server.$(distro) $(net_name)/echo_server.$(distro) $(net_name)/dirauth.$(distro) | $(net_name) $(cache_dir)
+testnet_binaries: $(net_name)/server.$(distro) $(net_name)/proxy_server.$(distro) $(net_name)/proxy_client.$(distro) $(net_name)/memspool.$(distro) $(net_name)/pigeonhole.$(distro) $(net_name)/panda_server.$(distro) $(net_name)/echo_server.$(distro) $(net_name)/dirauth.$(distro) $(net_name)/kpclientd.$(distro) | $(net_name) $(cache_dir)
 
 $(net_name):
 	mkdir -vp $(net_name)
@@ -197,6 +197,10 @@ $(net_name)/dirauth.$(distro): $(distro)_base.stamp $(docker_compose_yml) | $(ne
 $(net_name)/ping.$(distro): $(distro)_base.stamp | $(net_name) $(cache_dir)
 		$(docker_run_sh) 'cd ping && go mod verify && go build -ldflags ${ldflags} && \
 			mv ping /$(net_name)/ping.$(distro)'
+
+$(net_name)/kpclientd.$(distro): $(distro)_base.stamp | $(net_name) $(cache_dir)
+		$(docker_run_sh) 'cd client2/cmd/kpclientd && go mod verify && go build -ldflags ${ldflags} && \
+			mv kpclientd /$(net_name)/kpclientd.$(distro)'
 
 clean-images: stop
 	@-for distro in $(DISTROS); do \

--- a/genconfig/main.go
+++ b/genconfig/main.go
@@ -924,5 +924,14 @@ services:
     network_mode: host
 `, "metrics", "docker.io/prom/prometheus", s.baseDir, s.baseDir)
 
+	write(f, `
+  kpclientd:
+    restart: "no"
+    image: %s
+    volumes:
+      - ./:%s
+    command: %s/kpclientd%s -c %s/client2/client.toml
+    network_mode: host
+`, dockerImage, s.baseDir, s.baseDir, s.binSuffix, s.baseDir)
 	return nil
 }


### PR DESCRIPTION
This adds client2's kpclientd as a service to the dockerized testnet infrastucture
