### PR TITLE
make client2 TimerQueue worker do action in goroutine consistently

### DIFF
--- a/client2/timer_queue.go
+++ b/client2/timer_queue.go
@@ -126,7 +126,9 @@ func (t *TimerQueue) worker() {
 			if timeLeft < 0 || m.Priority < uint64(time.Now().UnixNano()) {
 				t.queue.Pop()
 				t.mutex.Unlock()
-				t.action(m.Value)
+				t.Go(func() {
+					t.action(m.Value)
+				})
 				continue
 			} else {
 				timer.Reset(time.Duration(timeLeft))


### PR DESCRIPTION
action should be run in another routine so that it does not block the TimerQueue worker from waking consitently
