### PR TITLE
fix client timer queue

### DIFF
--- a/client/timer_queue.go
+++ b/client/timer_queue.go
@@ -83,9 +83,11 @@ func (a *TimerQueue) forward() {
 		return
 	}
 	item := m.(*queue.Entry).Value.(Item)
-	if err := a.NextQ.Push(item); err != nil {
-		panic(err)
-	}
+	a.Go(func() {
+		if err := a.NextQ.Push(item); err != nil {
+			panic(err)
+		}
+	})
 }
 
 func (a *TimerQueue) worker() {

--- a/client/timer_queue_test.go
+++ b/client/timer_queue_test.go
@@ -100,7 +100,6 @@ func TestTimerQueueOrder(t *testing.T) {
 		m.ID[0] = uint8(i)
 		t.Logf("Inserting: %x : %d", m.ID[0], m.Priority())
 		a.Push(m)
-		<-time.After(10 * time.Millisecond)
 	}
 
 	t.Logf("\n")


### PR DESCRIPTION
- **client/timer_queue: run Push method in goroutine**
- **fix timer_queue_test: do not sleep longer than the replyETA**

fixes deadlock in timer_queue
