### PR TITLE
fix client blocking send

### DIFF
--- a/client/send.go
+++ b/client/send.go
@@ -269,6 +269,7 @@ func (s *Session) BlockingSendUnreliableMessageWithContext(ctx context.Context, 
 	case <-s.HaltCh():
 		return nil, ErrHalted
 	case <-ctx.Done():
+		s.log.Debugf("ctx.Done(): %v", ctx.Err())
 		return nil, ctx.Err()
 	}
 	// unreachable

--- a/client/send.go
+++ b/client/send.go
@@ -113,15 +113,9 @@ func (s *Session) doSend(msg *Message) {
 			}
 			sentWaitChan := sentWaitChanRaw.(chan *Message)
 			if err == nil {
-				// do not block writing to the receiver if this is a retransmission
-				select {
-				case sentWaitChan <- msg:
-				default:
-				}
-
-			} else {
-				close(sentWaitChan)
+				sentWaitChan <- msg
 			}
+			close(sentWaitChan)
 			return
 		}
 	}
@@ -232,7 +226,7 @@ func (s *Session) BlockingSendUnreliableMessageWithContext(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	sentWaitChan := make(chan *Message)
+	sentWaitChan := make(chan *Message, 1)
 	s.sentWaitChanMap.Store(*msg.ID, sentWaitChan)
 	defer s.sentWaitChanMap.Delete(*msg.ID)
 
@@ -281,7 +275,7 @@ func (s *Session) BlockingSendReliableMessage(recipient, provider string, messag
 		return nil, err
 	}
 	msg.Reliable = true
-	sentWaitChan := make(chan *Message)
+	sentWaitChan := make(chan *Message, 1)
 	s.sentWaitChanMap.Store(*msg.ID, sentWaitChan)
 	defer s.sentWaitChanMap.Delete(*msg.ID)
 

--- a/client/send.go
+++ b/client/send.go
@@ -238,7 +238,6 @@ func (s *Session) BlockingSendUnreliableMessageWithContext(ctx context.Context, 
 
 	replyWaitChan := make(chan []byte)
 	s.replyWaitChanMap.Store(*msg.ID, replyWaitChan)
-	defer s.replyWaitChanMap.Delete(*msg.ID)
 
 	err = s.egressQueue.Push(msg)
 	if err != nil {
@@ -265,6 +264,7 @@ func (s *Session) BlockingSendUnreliableMessageWithContext(ctx context.Context, 
 	// wait for reply or round trip timeout
 	select {
 	case reply := <-replyWaitChan:
+		defer s.replyWaitChanMap.Delete(*msg.ID)
 		return reply, nil
 	case <-s.HaltCh():
 		return nil, ErrHalted

--- a/client/session.go
+++ b/client/session.go
@@ -341,13 +341,7 @@ func (s *Session) onACK(surbID *[sConstants.SURBIDLength]byte, ciphertext []byte
 			return nil
 		}
 		replyWaitChan := replyWaitChanRaw.(chan []byte)
-		// do not block the worker if the receiver timed out!
-		select {
-		case replyWaitChan <- plaintext:
-		default:
-			s.log.Warningf("Failed to respond to a blocking message")
-			close(replyWaitChan)
-		}
+		replyWaitChan <- plaintext
 	} else {
 		s.eventCh <- &MessageReplyEvent{
 			MessageID: msg.ID,

--- a/client/session.go
+++ b/client/session.go
@@ -411,8 +411,8 @@ func (s *Session) ForceFetchPKI() {
 }
 
 func (s *Session) Shutdown() {
-	s.Halt()
 	s.timerQ.Halt()
 	s.minclient.Shutdown()
+	s.Halt()
 	s.minclient.Wait()
 }

--- a/client/session.go
+++ b/client/session.go
@@ -316,6 +316,7 @@ func (s *Session) onACK(surbID *[sConstants.SURBIDLength]byte, ciphertext []byte
 	}
 	s.surbIDMap.Delete(*surbID)
 	msg := rawMessage.(*Message)
+	midStr := fmt.Sprintf("[%v]", hex.EncodeToString(msg.ID[:]))
 	plaintext, err := s.sphinx.DecryptSURBPayload(ciphertext, msg.Key)
 	if err != nil {
 		s.log.Infof("Discarding SURB Reply, decryption failure: %s", err)
@@ -329,13 +330,14 @@ func (s *Session) onACK(surbID *[sConstants.SURBIDLength]byte, ciphertext []byte
 		s.decrementDecoyLoopTally()
 		return nil
 	}
-
+	s.log.Debugf("SURB-ACK: %v response to %v", idStr, midStr)
 	if msg.IsBlocking {
 		replyWaitChanRaw, ok := s.replyWaitChanMap.Load(*msg.ID)
 		if !ok {
 			//XXX: this can happen if a SURB-ACK arrives after a call to BlockingSendUnreliableMessage has timed-out
 			// because the session.surbIDMap has not been deleted or garbage collected
-			s.log.Warningf("Discarding surb %v for blocking message %x : caller likely timed-out", idStr, msg.ID)
+			s.log.Debugf("Did not find a replyChan for blocking message %v", midStr)
+			s.log.Warningf("Discarding surb %v response to %v : caller likely timed-out", idStr, midStr)
 			return nil
 		}
 		replyWaitChan := replyWaitChanRaw.(chan []byte)

--- a/minclient/connection.go
+++ b/minclient/connection.go
@@ -751,7 +751,10 @@ func (c *connection) sendPacket(pkt []byte) error {
 	case c.sendCh <- &connSendCtx{
 		pkt: pkt,
 		doneFn: func(err error) {
-			errCh <- err
+			select {
+			case errCh <- err:
+			case <-c.HaltCh():
+			}
 		},
 	}:
 	case <-c.HaltCh():


### PR DESCRIPTION
- **client/send: BlockingSendUnreliableMessageWithContext: do not block on sendWaitChan at Halt**
- **client/session: improve debug logging**
- **client/send: log reason for context.Done**
- **client/session: halt workers before self**
- **client/send: don't delete the reply channel if a response was not received**
- **client/send: do not block writing to abandoned replyWaitChan**
- **client/send: use buffered sentWaitChan, always close sentWaitChan when done**

fixes deadlock in client when worker is unable to write response
