### PR TITLE
core/pki: fix MixDescriptor, remove omitempty as name

### DIFF
--- a/core/pki/descriptor.go
+++ b/core/pki/descriptor.go
@@ -124,7 +124,7 @@ type MixDescriptor struct {
 
 	// Kaetzchen is the map of provider autoresponder agents by capability
 	// to parameters.
-	Kaetzchen map[string]map[string]interface{} `cbor:"omitempty"`
+	Kaetzchen map[string]map[string]interface{}
 
 	// KaetzchenAdvertizedData is used by the operator to advertize
 	// additional information about specific services. This is different


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove `omitempty` tag from `Kaetzchen` field in `MixDescriptor`


___

### **Changes diagram**

```mermaid
flowchart LR
  A["MixDescriptor struct"] --> B["Kaetzchen field"] 
  B -- "remove omitempty tag" --> C["Fixed serialization"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>descriptor.go</strong><dd><code>Remove omitempty tag from Kaetzchen field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/pki/descriptor.go

<li>Remove <code>omitempty</code> CBOR tag from <code>Kaetzchen</code> field in <code>MixDescriptor</code> struct


</details>


  </td>
  <td><a href="https://github.com/katzenpost/katzenpost/pull/874/files#diff-bc6ad40ba5a4b3ce8119eebd09fa61d2582298f4fa2fcb250d4d6850aaa3d88a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>