### PR TITLE
Fixup thinclient2

### DIFF
--- a/client2/connection.go
+++ b/client2/connection.go
@@ -321,8 +321,6 @@ func (c *connection) doConnect(dialCtx context.Context) {
 			return
 		}
 
-		c.log.Debug("doConnect, before for loop")
-
 		for _, addr := range dstAddrs {
 			select {
 			case <-time.After(time.Duration(atomic.LoadInt64(&c.retryDelay))):
@@ -421,7 +419,6 @@ func (c *connection) onNetConn(conn net.Conn) {
 	defer w.Close()
 
 	// Bind the session to the conn, handshake, authenticate.
-	c.log.Debug("onTCPConn: before handshake")
 	conn.SetDeadline(time.Now().Add(handshakeTimeout))
 	if err = w.Initialize(conn); err != nil {
 		c.log.Errorf("Handshake failed: %v", err)

--- a/client2/connection.go
+++ b/client2/connection.go
@@ -151,7 +151,6 @@ func (c *Client) ForceFetch() {
 // ForceFetchPKI attempts to force client's pkiclient to wake and fetch
 // consensus documents immediately.
 func (c *Client) ForceFetchPKI() {
-	c.log.Debug("ForceFetchPKI()")
 	select {
 	case c.pki.forceUpdateCh <- true:
 	default:
@@ -159,8 +158,6 @@ func (c *Client) ForceFetchPKI() {
 }
 
 func (c *connection) getDescriptor() error {
-	c.log.Debug("getDescriptor")
-
 	ok := false
 	defer func() {
 		if !ok {
@@ -238,8 +235,6 @@ func (c *connection) getDescriptor() error {
 }
 
 func (c *connection) connectWorker() {
-	c.log.Debug("connectWorker begin")
-
 	defer c.log.Debugf("Terminating connect worker.")
 
 	dialCtx, cancelFn := context.WithCancel(context.Background())
@@ -263,7 +258,6 @@ func (c *connection) connectWorker() {
 }
 
 func (c *connection) doConnect(dialCtx context.Context) {
-	c.log.Debug("doConnect begin")
 	const (
 		retryIncrement = 15 * time.Second
 		maxRetryDelay  = 2 * time.Minute
@@ -287,8 +281,6 @@ func (c *connection) doConnect(dialCtx context.Context) {
 				c.isShutdownLock.RUnlock()
 				if !isShutdown {
 					c.client.cfg.Callbacks.OnConnFn(connErr)
-				} else {
-					c.log.Debug("already shutting down, skipping OnConnFn callback")
 				}
 			}
 		}
@@ -376,7 +368,6 @@ func (c *connection) doConnect(dialCtx context.Context) {
 }
 
 func (c *connection) onNetConn(conn net.Conn) {
-	c.log.Debug("onNetConn begin")
 	const handshakeTimeout = 1 * time.Minute
 	var err error
 
@@ -384,8 +375,6 @@ func (c *connection) onNetConn(conn net.Conn) {
 		c.log.Debugf("connection closed.")
 		conn.Close()
 	}()
-
-	c.log.Debug("onNetConn: GenerateKeypair")
 	_, linkKey, err := c.client.wireKEMScheme.GenerateKeyPair()
 	if err != nil {
 		panic(err)
@@ -407,7 +396,6 @@ func (c *connection) onNetConn(conn net.Conn) {
 		AuthenticationKey: linkKey,
 		RandomReader:      rand.Reader,
 	}
-	c.log.Debug("onNetConn: NewSession")
 	w, err := wire.NewSession(cfg, true)
 	if err != nil {
 		c.log.Errorf("Failed to allocate session: %v", err)
@@ -431,12 +419,10 @@ func (c *connection) onNetConn(conn net.Conn) {
 	conn.SetDeadline(time.Time{})
 	c.client.pki.setClockSkew(int64(w.ClockSkew().Seconds()))
 
-	c.log.Debug("onNetConn end")
 	c.onWireConn(w)
 }
 
 func (c *connection) onWireConn(w *wire.Session) {
-	c.log.Debug("onWireConn")
 	c.onConnStatusChange(nil)
 
 	var wireErr error
@@ -916,7 +902,6 @@ func (c *connection) Shutdown() {
 }
 
 func (c *connection) start() {
-	c.log.Debug("start")
 	c.Go(c.connectWorker)
 }
 
@@ -924,7 +909,6 @@ func newConnection(c *Client) *connection {
 	k := new(connection)
 	k.client = c
 	k.log = c.logbackend.GetLogger("client2/conn")
-	k.log.Debug("newConnection")
 	k.fetchCh = make(chan interface{}, 1)
 	k.sendCh = make(chan *connSendCtx)
 	k.getConsensusCh = make(chan *getConsensusCtx, 1)

--- a/client2/courier_docker_test.go
+++ b/client2/courier_docker_test.go
@@ -185,10 +185,10 @@ func TestDockerCourierServiceNewThinclientAPI(t *testing.T) {
 	// Bob reads message using the helper function
 	t.Log("Bob: Reading message")
 	messageID := bobThinClient.NewMessageID()
-	readPayload, _, err := bobThinClient.ReadChannel(ctx, bobChannelID, messageID)
+	readPayload, _, replyIndex, err := bobThinClient.ReadChannel(ctx, bobChannelID, messageID, nil)
 	require.NoError(t, err)
 	require.NotNil(t, readPayload)
-	t.Logf("Bob: Generated read payload (%d bytes)", len(readPayload))
+	t.Logf("Bob: Generated read payload (%d bytes), replyIndex: %v", len(readPayload), replyIndex)
 
 	// Bob sends read query and waits for reply using helper
 	t.Log("Bob: Sending read query and waiting for reply...")

--- a/client2/courier_docker_test.go
+++ b/client2/courier_docker_test.go
@@ -196,4 +196,12 @@ func TestDockerCourierServiceNewThinclientAPI(t *testing.T) {
 	require.NotNil(t, receivedPayload, "Bob: Received nil payload")
 
 	require.Equal(t, originalMessage, receivedPayload, "Bob should receive the original message")
+
+	aliceThinClient.CloseChannel(ctx, channelID)
+	bobThinClient.CloseChannel(ctx, bobChannelID)
+
+	err = aliceThinClient.Close()
+	require.NoError(t, err)
+	err = bobThinClient.Close()
+	require.NoError(t, err)
 }

--- a/client2/courier_docker_test.go
+++ b/client2/courier_docker_test.go
@@ -199,9 +199,4 @@ func TestDockerCourierServiceNewThinclientAPI(t *testing.T) {
 
 	aliceThinClient.CloseChannel(ctx, channelID)
 	bobThinClient.CloseChannel(ctx, bobChannelID)
-
-	err = aliceThinClient.Close()
-	require.NoError(t, err)
-	err = bobThinClient.Close()
-	require.NoError(t, err)
 }

--- a/client2/daemon.go
+++ b/client2/daemon.go
@@ -274,12 +274,10 @@ func (d *Daemon) Start() error {
 	})
 	d.timerQueue.Start()
 	d.arqTimerQueue = NewTimerQueue(func(rawSurbID interface{}) {
-		d.log.Info("ARQ TimerQueue callback!")
 		surbID, ok := rawSurbID.(*[sphinxConstants.SURBIDLength]byte)
 		if !ok {
 			panic("wtf, failed type assertion!")
 		}
-		d.log.Warning("BEFORE ARQ resend")
 		// Use a timeout to prevent blocking during shutdown
 		go func() {
 			select {
@@ -292,7 +290,6 @@ func (d *Daemon) Start() error {
 				d.arqResend(surbID)
 			}
 		}()
-		d.log.Warning("AFTER ARQ resend")
 	})
 	d.arqTimerQueue.Start()
 	d.gcTimerQueue = NewTimerQueue(func(rawGCReply interface{}) {

--- a/client2/listener.go
+++ b/client2/listener.go
@@ -93,7 +93,6 @@ func (l *listener) updatePKIDocWorker() {
 }
 
 func (l *listener) worker() {
-	l.log.Debug("Listener worker begin")
 	addr := l.listener.Addr()
 	l.log.Infof("Listening on: %v", addr)
 	defer func() {
@@ -121,7 +120,6 @@ func (l *listener) worker() {
 }
 
 func (l *listener) onNewConn(conn net.Conn) {
-	l.log.Debug("onNewConn begin")
 	// make sure we can serve a document before anything else
 	docBlob, doc := l.client.CurrentDocument()
 	if doc == nil {
@@ -139,16 +137,9 @@ func (l *listener) onNewConn(conn net.Conn) {
 	l.conns[*c.appID] = c
 	l.connsLock.Unlock()
 
-	l.log.Debug("get connection status")
 	status := l.getConnectionStatus()
-	l.log.Debug("send connection status")
 	c.updateConnectionStatus(status)
-	l.log.Debug("getting current pki doc")
-
-	l.log.Debug("send pki doc")
 	c.sendPKIDoc(docBlob)
-
-	l.log.Debug("onNewConn end")
 }
 
 func (l *listener) onClosedConn(c *incomingConn) {

--- a/client2/pigeonhole.go
+++ b/client2/pigeonhole.go
@@ -18,6 +18,7 @@ import (
 	"github.com/katzenpost/katzenpost/client2/constants"
 	"github.com/katzenpost/katzenpost/client2/thin"
 	cpki "github.com/katzenpost/katzenpost/core/pki"
+	sphinxConstants "github.com/katzenpost/katzenpost/core/sphinx/constants"
 	"github.com/katzenpost/katzenpost/pigeonhole"
 	pigeonholeGeo "github.com/katzenpost/katzenpost/pigeonhole/geo"
 	replicaCommon "github.com/katzenpost/katzenpost/replica/common"
@@ -94,7 +95,7 @@ func NewPigeonholeChannel() (*bacap.StatefulWriter, *bacap.ReadCap, *bacap.Write
 }
 
 // createEnvelopeFromMessage creates a CourierEnvelope from a ReplicaInnerMessage
-func createEnvelopeFromMessage(msg *pigeonhole.ReplicaInnerMessage, doc *cpki.Document, isRead bool) (*pigeonhole.CourierEnvelope, nike.PrivateKey, error) {
+func createEnvelopeFromMessage(msg *pigeonhole.ReplicaInnerMessage, doc *cpki.Document, isRead bool, replyIndex uint8) (*pigeonhole.CourierEnvelope, nike.PrivateKey, error) {
 	intermediateReplicas, replicaPubKeys, err := pigeonhole.GetRandomIntermediateReplicas(doc)
 	if err != nil {
 		return nil, nil, err
@@ -120,7 +121,7 @@ func createEnvelopeFromMessage(msg *pigeonhole.ReplicaInnerMessage, doc *cpki.Do
 		IntermediateReplicas: intermediateReplicas,
 		Dek1:                 dek1,
 		Dek2:                 dek2,
-		ReplyIndex:           0,
+		ReplyIndex:           replyIndex,
 		Epoch:                doc.Epoch,
 		SenderPubkeyLen:      uint16(len(senderPubkeyBytes)),
 		SenderPubkey:         senderPubkeyBytes,
@@ -175,7 +176,7 @@ func CreateChannelWriteRequest(
 		WriteMsg:    writeRequest,
 	}
 
-	return createEnvelopeFromMessage(msg, doc, false)
+	return createEnvelopeFromMessage(msg, doc, false, 0)
 }
 
 // CreateChannelWriteRequestPrepareOnly prepares a write request WITHOUT advancing StatefulWriter state.
@@ -220,7 +221,7 @@ func CreateChannelWriteRequestPrepareOnly(
 		WriteMsg:    writeRequest,
 	}
 
-	return createEnvelopeFromMessage(msg, doc, false)
+	return createEnvelopeFromMessage(msg, doc, false, 0)
 }
 
 func CreateChannelReadRequest(channelID [thin.ChannelIDLength]byte,
@@ -251,7 +252,7 @@ func CreateChannelReadRequestWithBoxID(channelID [thin.ChannelIDLength]byte,
 	}
 
 	fmt.Printf("BOB MKEM ENCRYPT: Starting encryption with message size %d bytes\n", len(msg.Bytes()))
-	envelope, mkemPrivateKey, err := createEnvelopeFromMessage(msg, doc, true)
+	envelope, mkemPrivateKey, err := createEnvelopeFromMessage(msg, doc, true, 0)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -689,7 +690,13 @@ func (d *Daemon) readChannel(request *Request) {
 		},
 	}
 
-	courierEnvelope, envelopePrivateKey, err := createEnvelopeFromMessage(msg, doc, true)
+	// Use the ReplyIndex from the request, defaulting to 0 if not specified
+	replyIndex := uint8(0)
+	if request.ReadChannel.ReplyIndex != nil {
+		replyIndex = *request.ReadChannel.ReplyIndex
+	}
+
+	courierEnvelope, envelopePrivateKey, err := createEnvelopeFromMessage(msg, doc, true, replyIndex)
 	if err != nil {
 		d.log.Errorf("readChannel failure: failed to create envelope: %s", err)
 		d.sendReadChannelError(request, thin.ThinClientErrorInternalError)
@@ -723,7 +730,40 @@ func (d *Daemon) readChannel(request *Request) {
 			ChannelID:          channelID,
 			SendMessagePayload: courierQuery.Bytes(),
 			NextMessageIndex:   nextMessageIndex,
+			ReplyIndex:         request.ReadChannel.ReplyIndex,
 			ErrorCode:          thin.ThinClientSuccess,
 		},
 	})
+}
+
+// closeChannel closes a pigeonhole channel and cleans up its resources
+func (d *Daemon) closeChannel(request *Request) {
+	channelID := request.CloseChannel.ChannelID
+
+	d.newChannelMapLock.Lock()
+	_, ok := d.newChannelMap[channelID]
+	if ok {
+		delete(d.newChannelMap, channelID)
+	}
+	d.newChannelMapLock.Unlock()
+
+	if !ok {
+		d.log.Debugf("closeChannel: channel %d not found (already closed or never existed)", channelID)
+		return
+	}
+
+	// Clean up any stored SURB ID mappings for this channel
+	d.newSurbIDToChannelMapLock.Lock()
+	toDelete := make([][sphinxConstants.SURBIDLength]byte, 0)
+	for surbID, mappedChannelID := range d.newSurbIDToChannelMap {
+		if mappedChannelID == channelID {
+			toDelete = append(toDelete, surbID)
+		}
+	}
+	for _, surbID := range toDelete {
+		delete(d.newSurbIDToChannelMap, surbID)
+	}
+	d.newSurbIDToChannelMapLock.Unlock()
+
+	d.log.Infof("closeChannel: successfully closed channel %d", channelID)
 }

--- a/client2/thin/thin_messages.go
+++ b/client2/thin/thin_messages.go
@@ -176,7 +176,11 @@ type ReadChannel struct {
 	// MessageID is used for correlating the read request with its response.
 	// This allows the client to match responses to specific read operations.
 	// This field is required.
-	MessageID *[MessageIDLength]byte `cbor:"id,omitempty"`
+	MessageID *[MessageIDLength]byte `cbor:"message_id"`
+
+	// ReplyIndex is the index of the reply to return. It is optional and
+	// a default of zero will be used if not specified.
+	ReplyIndex *uint8 `cbor:"reply_index,omitempty"`
 }
 
 // String returns a string representation of the ReadChannel request.
@@ -185,7 +189,20 @@ func (r *ReadChannel) String() string {
 	if r.MessageID != nil {
 		msgIDStr = fmt.Sprintf("%x", r.MessageID[:8]) // First 8 bytes for brevity
 	}
-	return fmt.Sprintf("ReadChannel: channel=%d msgID=%s", r.ChannelID, msgIDStr)
+	replyIndexStr := ""
+	if r.ReplyIndex != nil {
+		replyIndexStr = fmt.Sprintf(" replyIndex=%d", *r.ReplyIndex)
+	}
+	return fmt.Sprintf("ReadChannel: channel=%d msgID=%s%s", r.ChannelID, msgIDStr, replyIndexStr)
+}
+
+// CloseChannel requests closing a pigeonhole channel.
+type CloseChannel struct {
+	ChannelID uint16 `cbor:"channel_id"`
+}
+
+func (c *CloseChannel) String() string {
+	return fmt.Sprintf("CloseChannel: channel=%d", c.ChannelID)
 }
 
 type SendMessage struct {
@@ -286,6 +303,9 @@ type Request struct {
 
 	// ReadChannel is used to read from a Pigeonhole channel.
 	ReadChannel *ReadChannel `cbor:"read_channel"`
+
+	// CloseChannel is used to close a Pigeonhole channel.
+	CloseChannel *CloseChannel `cbor:"close_channel"`
 
 	// SendMessage is used to send a message through the mix network.
 	SendMessage *SendMessage `cbor:"send_message"`

--- a/client2/thin_messages.go
+++ b/client2/thin_messages.go
@@ -53,6 +53,7 @@ func FromThinRequest(r *thin.Request, appid *[AppIDLength]byte) *Request {
 		CreateReadChannel:  r.CreateReadChannel,
 		WriteChannel:       r.WriteChannel,
 		ReadChannel:        r.ReadChannel,
+		CloseChannel:       r.CloseChannel,
 
 		SendMessage:    r.SendMessage,
 		SendARQMessage: r.SendARQMessage,
@@ -70,6 +71,8 @@ type Request struct {
 	WriteChannel *thin.WriteChannel
 
 	ReadChannel *thin.ReadChannel
+
+	CloseChannel *thin.CloseChannel
 
 	SendMessage *thin.SendMessage
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix reply index handling in courier and thinclient APIs

- Add channel close functionality for resource cleanup

- Update API signatures to return reply index information

- Improve error handling with proper reply index propagation


___

### **Changes diagram**

```mermaid
flowchart LR
  A["ThinClient ReadChannel"] --> B["Daemon readChannel"]
  B --> C["createEnvelopeFromMessage"]
  C --> D["Courier handleMessage"]
  D --> E["CourierQueryReply with ReplyIndex"]
  E --> F["MessageReplyEvent with ReplyIndex"]
  G["CloseChannel Request"] --> H["closeChannel handler"]
  H --> I["Resource cleanup"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>courier_docker_test.go</strong><dd><code>Update test to handle new ReadChannel signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/katzenpost/katzenpost/pull/878/files#diff-4d114fa4a8b87669f2af14b476a75370bdfcc0f08e29784c6cc16f147497f1f4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>daemon.go</strong><dd><code>Add reply index handling and channel close support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/katzenpost/katzenpost/pull/878/files#diff-6f61192532263d5304d0a061f9c4a3f976917a0353aa88b2ccc1abd50a06ac62">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>thin.go</strong><dd><code>Update ReadChannel API and add CloseChannel method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/katzenpost/katzenpost/pull/878/files#diff-c869be44db09f934ee91886d5feae9b5eb53ec02b1df27824ac120492569c93f">+28/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>thin_events.go</strong><dd><code>Add reply index field to event structures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/katzenpost/katzenpost/pull/878/files#diff-0537d199efc45d1582c174df0f79e7d32ca5663a2a369275b8471b05d11246b8">+20/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>thin_messages.go</strong><dd><code>Add reply index and close channel message types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/katzenpost/katzenpost/pull/878/files#diff-290f338a93987bf88dc673f03ef6407f398f5bfff70fbccc3754d4c9ce4d5b10">+22/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>thin_messages.go</strong><dd><code>Add CloseChannel field to request structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/katzenpost/katzenpost/pull/878/files#diff-4bf7479276e4b7abe42fbb59a05c88fd9144f8236848b05e8ece98a924216a32">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>pigeonhole.go</strong><dd><code>Fix reply index parameter in envelope creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/katzenpost/katzenpost/pull/878/files#diff-858b9ada5b5d3edfcdec23a0ee8bc74e92b250adf525c79cd632c16403bf40eb">+46/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plugin.go</strong><dd><code>Fix reply index usage in error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/katzenpost/katzenpost/pull/878/files#diff-601aa415b618672f009966007205e4720d8b2afe3245950ba6da97a0e918383e">+12/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>