### PR TITLE
Use latest hpqc with bacap bug fix

### DIFF
--- a/client2/pigeonhole.go
+++ b/client2/pigeonhole.go
@@ -112,11 +112,6 @@ func createEnvelopeFromMessage(msg *pigeonhole.ReplicaInnerMessage, doc *cpki.Do
 
 	senderPubkeyBytes := mkemPublicKey.Bytes()
 
-	var isReadFlag uint8 = 0
-	if isRead {
-		isReadFlag = 1
-	}
-
 	envelope := &pigeonhole.CourierEnvelope{
 		IntermediateReplicas: intermediateReplicas,
 		Dek1:                 dek1,
@@ -127,7 +122,6 @@ func createEnvelopeFromMessage(msg *pigeonhole.ReplicaInnerMessage, doc *cpki.Do
 		SenderPubkey:         senderPubkeyBytes,
 		CiphertextLen:        uint32(len(mkemCiphertext.Envelope)),
 		Ciphertext:           mkemCiphertext.Envelope,
-		IsRead:               isReadFlag,
 	}
 	return envelope, mkemPrivateKey, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ toolchain go1.23.6
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/carlmjohnson/versioninfo v0.22.5
+	github.com/charmbracelet/colorprofile v0.3.0
 	github.com/charmbracelet/fang v0.2.0
+	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta1
 	github.com/fxamacker/cbor/v2 v2.8.0
 	github.com/grafana/pyroscope-go v1.2.2
 	github.com/jackc/pgx v3.6.2+incompatible
@@ -39,8 +41,6 @@ require (
 	github.com/agl/gcmsiv v0.0.0-20190418185415-e8dcd2f151dc // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/charmbracelet/colorprofile v0.3.0 // indirect
-	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta1 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250603201427-c31516f43444 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grafana/pyroscope-go v1.2.2
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/katzenpost/circl v1.3.9-0.20240222183521-1cd9a34e9a0c
-	github.com/katzenpost/hpqc v0.0.66
+	github.com/katzenpost/hpqc v0.0.67
 	github.com/katzenpost/nyquist v0.0.10
 	github.com/linxGnu/grocksdb v1.10.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/katzenpost/circl v1.3.9-0.20240222183521-1cd9a34e9a0c h1:FYy03rLIjdyj
 github.com/katzenpost/circl v1.3.9-0.20240222183521-1cd9a34e9a0c/go.mod h1:+EBrwiGYs9S+qZqaqxujN1CReTNCMAG6p+31KkEDeeA=
 github.com/katzenpost/hpqc v0.0.66 h1:cIrmXDrvOopmGbEX8De+WQOLyo2Utx7uJQqrDMRAJi0=
 github.com/katzenpost/hpqc v0.0.66/go.mod h1:yaVqoZyKeBmgiKnGBpgLNf+nfO4ll81f54RAnaL6OpI=
+github.com/katzenpost/hpqc v0.0.67 h1:hlpSFkFmK6sMzq2gcscsejfUs8uqoxUpLdBWOTpwQ1g=
+github.com/katzenpost/hpqc v0.0.67/go.mod h1:yaVqoZyKeBmgiKnGBpgLNf+nfO4ll81f54RAnaL6OpI=
 github.com/katzenpost/nyquist v0.0.10 h1:rh9TCEXCsutsg+cvbV6ASVFnzSAYBisWQ3fnwQSPa34=
 github.com/katzenpost/nyquist v0.0.10/go.mod h1:tyK92JiCptgsaE0iUAMlt5W2v2Rdw6mnUpIdIidIGHo=
 github.com/katzenpost/sntrup4591761 v0.0.0-20231024131303-8755eb1986b8 h1:TsKxH0x2RUwf5rBw67k15bqVM3oVbexA9oaTZQLIy3Y=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/charmbracelet/colorprofile v0.3.0 h1:KtLh9uuu1RCt+Hml4s6Hz+kB1PfV3wi+
 github.com/charmbracelet/colorprofile v0.3.0/go.mod h1:oHJ340RS2nmG1zRGPmhJKJ/jf4FPNNk0P39/wBPA1G0=
 github.com/charmbracelet/fang v0.2.0 h1:F2sK2Zjy9kRYz/xUSF1o89DNj2BHKpxVKT7TA21KZi0=
 github.com/charmbracelet/fang v0.2.0/go.mod h1:TPpME1GkB6/4uR4wXmPnugTCkqRLgZkWSH+aMds6454=
-github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1 h1:D9AJJuYTN5pvz6mpIGO1ijLKpfTYSHOtKGgwoTQ4Gog=
-github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1/go.mod h1:tRlx/Hu0lo/j9viunCN2H+Ze6JrmdjQlXUQvvArgaOc=
 github.com/charmbracelet/lipgloss/v2 v2.0.0-beta1 h1:SOylT6+BQzPHEjn15TIzawBPVD0QmhKXbcb3jY0ZIKU=
 github.com/charmbracelet/lipgloss/v2 v2.0.0-beta1/go.mod h1:tRlx/Hu0lo/j9viunCN2H+Ze6JrmdjQlXUQvvArgaOc=
 github.com/charmbracelet/x/ansi v0.8.0 h1:9GTq3xq9caJW8ZrBTe0LIe2fvfLR/bYXKTx2llXn7xE=
@@ -71,8 +69,6 @@ github.com/katzenpost/chacha20poly1305 v0.0.1 h1:yFPxgu/VSWsoCNQ2x15az8xBKKc/9GD
 github.com/katzenpost/chacha20poly1305 v0.0.1/go.mod h1:5sv//C8pWaXrnnP3CNiJXqAlA1/yfUZOl1tR9xsL9bI=
 github.com/katzenpost/circl v1.3.9-0.20240222183521-1cd9a34e9a0c h1:FYy03rLIjdyjklBOI6YSCb3q7OubTx0dVDWYOgDsvA8=
 github.com/katzenpost/circl v1.3.9-0.20240222183521-1cd9a34e9a0c/go.mod h1:+EBrwiGYs9S+qZqaqxujN1CReTNCMAG6p+31KkEDeeA=
-github.com/katzenpost/hpqc v0.0.66 h1:cIrmXDrvOopmGbEX8De+WQOLyo2Utx7uJQqrDMRAJi0=
-github.com/katzenpost/hpqc v0.0.66/go.mod h1:yaVqoZyKeBmgiKnGBpgLNf+nfO4ll81f54RAnaL6OpI=
 github.com/katzenpost/hpqc v0.0.67 h1:hlpSFkFmK6sMzq2gcscsejfUs8uqoxUpLdBWOTpwQ1g=
 github.com/katzenpost/hpqc v0.0.67/go.mod h1:yaVqoZyKeBmgiKnGBpgLNf+nfO4ll81f54RAnaL6OpI=
 github.com/katzenpost/nyquist v0.0.10 h1:rh9TCEXCsutsg+cvbV6ASVFnzSAYBisWQ3fnwQSPa34=

--- a/pigeonhole/geo/geometry.go
+++ b/pigeonhole/geo/geometry.go
@@ -87,10 +87,9 @@ func calculateCourierEnvelopeOverhead(_ int, senderPubkeySize int) int {
 	const epochSize = 8                // uint64
 	const senderPubkeyLenSize = 2      // uint16
 	const ciphertextLenSize = 4        // uint32
-	const isReadSize = 1               // uint8
 
 	courierEnvelopeFixedOverhead := intermediateReplicasSize + dek1Size + dek2Size +
-		replyIndexSize + epochSize + senderPubkeyLenSize + ciphertextLenSize + isReadSize
+		replyIndexSize + epochSize + senderPubkeyLenSize + ciphertextLenSize
 
 	return courierEnvelopeFixedOverhead + senderPubkeySize
 }

--- a/pigeonhole/geo/geometry_test.go
+++ b/pigeonhole/geo/geometry_test.go
@@ -236,7 +236,6 @@ func TestGeometryPrecisePredictions(t *testing.T) {
 			SenderPubkey:         senderPubkeyBytes,
 			CiphertextLen:        uint32(len(mkemCiphertext.Envelope)),
 			Ciphertext:           mkemCiphertext.Envelope,
-			IsRead:               0, // 0 = write, 1 = read
 		}
 
 		// Create CourierQuery like integration tests
@@ -281,10 +280,9 @@ func TestGeometryPrecisePredictions(t *testing.T) {
 		const epochSize = 8                // uint64
 		const senderPubkeyLenSize = 2      // uint16
 		const ciphertextLenSize = 4        // uint32
-		const isReadSize = 1               // uint8
 
 		expectedFixedOverhead := intermediateReplicasSize + dek1Size + dek2Size +
-			replyIndexSize + epochSize + senderPubkeyLenSize + ciphertextLenSize + isReadSize
+			replyIndexSize + epochSize + senderPubkeyLenSize + ciphertextLenSize
 		expectedTotalOverhead := expectedFixedOverhead + senderPubkeySize
 
 		t.Logf("Sender pubkey size: %d", senderPubkeySize)
@@ -388,7 +386,6 @@ func TestGeometryPrecisePredictions(t *testing.T) {
 			SenderPubkey:         senderPubkeyBytes,
 			CiphertextLen:        uint32(len(mkemCiphertext.Envelope)),
 			Ciphertext:           mkemCiphertext.Envelope,
-			IsRead:               0,
 		}
 
 		envelopeBytes := envelope.Bytes()
@@ -402,10 +399,9 @@ func TestGeometryPrecisePredictions(t *testing.T) {
 		const epochSize = 8                // uint64
 		const senderPubkeyLenSize = 2      // uint16
 		const ciphertextLenSize = 4        // uint32
-		const isReadSize = 1               // uint8
 
 		expectedCourierEnvelopeOverhead := intermediateReplicasSize + dek1Size + dek2Size +
-			replyIndexSize + epochSize + senderPubkeyLenSize + ciphertextLenSize + isReadSize + len(senderPubkeyBytes)
+			replyIndexSize + epochSize + senderPubkeyLenSize + ciphertextLenSize + len(senderPubkeyBytes)
 
 		t.Logf("Layer 5 - CourierEnvelope:")
 		t.Logf("  MKEM ciphertext: %d bytes", len(mkemCiphertext.Envelope))
@@ -471,7 +467,7 @@ func TestGeometryPrecisePredictions(t *testing.T) {
 
 		// Step 5: CourierEnvelope
 		senderPubkeySize := nikeScheme.PublicKeySize()
-		courierEnvelopeFixedOverhead := 2 + 60 + 60 + 1 + 8 + 2 + 4 + 1 // All fixed fields
+		courierEnvelopeFixedOverhead := 2 + 60 + 60 + 1 + 8 + 2 + 4 // All fixed fields
 		courierEnvelopeOverhead := courierEnvelopeFixedOverhead + senderPubkeySize
 		courierEnvelopeSize := courierEnvelopeOverhead + mkemCiphertextSize
 		t.Logf("Step 5 - CourierEnvelope: (%d + %d) + %d = %d", courierEnvelopeFixedOverhead, senderPubkeySize, mkemCiphertextSize, courierEnvelopeSize)

--- a/pigeonhole/message_types_test.go
+++ b/pigeonhole/message_types_test.go
@@ -61,7 +61,6 @@ func TestCourierEnvelopeEncodeDecode(t *testing.T) {
 		SenderPubkey:         senderPubkey,
 		CiphertextLen:        uint32(len(ciphertext)),
 		Ciphertext:           ciphertext,
-		IsRead:               1,
 	}
 
 	// Encode
@@ -104,9 +103,6 @@ func TestCourierEnvelopeEncodeDecode(t *testing.T) {
 	}
 	if !bytes.Equal(decoded.Ciphertext, original.Ciphertext) {
 		t.Errorf("Ciphertext mismatch")
-	}
-	if decoded.IsRead != original.IsRead {
-		t.Errorf("IsRead mismatch: got %d, want %d", decoded.IsRead, original.IsRead)
 	}
 }
 
@@ -520,7 +516,6 @@ func TestEmptyPayloads(t *testing.T) {
 		SenderPubkey:         []uint8{},
 		CiphertextLen:        0,
 		Ciphertext:           []uint8{},
-		IsRead:               0,
 	}
 
 	encoded, err := original.MarshalBinary()
@@ -558,7 +553,6 @@ func TestMaxValues(t *testing.T) {
 		SenderPubkey:         maxSenderPubkey,
 		CiphertextLen:        uint32(len(maxCiphertext)),
 		Ciphertext:           maxCiphertext,
-		IsRead:               255,
 	}
 
 	// Fill arrays with max values

--- a/pigeonhole/pigeonhole_messages.trunnel
+++ b/pigeonhole/pigeonhole_messages.trunnel
@@ -33,9 +33,6 @@ struct courier_envelope {
     // Encrypted payload (variable length)
     u32 ciphertext_len;
     u8 ciphertext[ciphertext_len];
-
-    // Read/Write flag
-    u8 is_read;
 }
 
 // CourierEnvelopeReply - reply envelope structure

--- a/pigeonhole/trunnel_messages.go
+++ b/pigeonhole/trunnel_messages.go
@@ -17,7 +17,6 @@ type CourierEnvelope struct {
 	SenderPubkey         []uint8
 	CiphertextLen        uint32
 	Ciphertext           []uint8
-	IsRead               uint8
 }
 
 func (c *CourierEnvelope) Parse(data []byte) ([]byte, error) {
@@ -97,13 +96,6 @@ func (c *CourierEnvelope) Parse(data []byte) ([]byte, error) {
 			cur = cur[1:]
 		}
 	}
-	{
-		if len(cur) < 1 {
-			return nil, errors.New("data too short")
-		}
-		c.IsRead = cur[0]
-		cur = cur[1:]
-	}
 	return cur, nil
 }
 
@@ -149,7 +141,6 @@ func (c *CourierEnvelope) encodeBinary() []byte {
 	for idx := 0; idx < int(c.CiphertextLen); idx++ {
 		buf = append(buf, byte(c.Ciphertext[idx]))
 	}
-	buf = append(buf, byte(c.IsRead))
 	return buf
 }
 

--- a/replica/cryptography_model_tests/client_courier_test.go
+++ b/replica/cryptography_model_tests/client_courier_test.go
@@ -327,7 +327,6 @@ func (c *ClientWriter) ComposeSendNextMessage(message []byte) *pigeonhole.Courie
 		SenderPubkey:         senderPubkey,
 		CiphertextLen:        uint32(len(mkemCiphertext.Envelope)),
 		Ciphertext:           mkemCiphertext.Envelope,
-		IsRead:               0, // 0 = write
 	}
 	return envelope
 }
@@ -382,7 +381,6 @@ func (c *ClientReader) ComposeReadNextMessage() (nike.PrivateKey, *pigeonhole.Co
 		SenderPubkey:         senderPubkey,
 		CiphertextLen:        uint32(len(mkemCiphertext.Envelope)),
 		Ciphertext:           mkemCiphertext.Envelope,
-		IsRead:               1, // 1 = read
 	}
 	return mkemPrivateKey, envelope
 }

--- a/replica/integration_tests/courier_replica_integration_test.go
+++ b/replica/integration_tests/courier_replica_integration_test.go
@@ -114,20 +114,12 @@ func createMKEMEnvelope(t *testing.T, sharding *shardingResult, innerMessage *pi
 	mkemPublicKey := mkemPrivateKey.Public()
 	replicaEpoch, _, _ := replicaCommon.ReplicaNow()
 
-	var isReadUint8 uint8
-	if isRead {
-		isReadUint8 = 1
-	} else {
-		isReadUint8 = 0
-	}
-
 	return &pigeonhole.CourierEnvelope{
 		SenderPubkey:         mkemPublicKey.Bytes(),
 		IntermediateReplicas: sharding.ReplicaIndices,
 		Dek1:                 *mkemCiphertext.DEKCiphertexts[0],
 		Dek2:                 *mkemCiphertext.DEKCiphertexts[1],
 		Ciphertext:           mkemCiphertext.Envelope,
-		IsRead:               isReadUint8,
 		Epoch:                replicaEpoch,
 	}
 }
@@ -791,7 +783,6 @@ func aliceComposesNextMessageWithIsLast(t *testing.T, message []byte, env *testE
 		SenderPubkey:         senderPubkeyBytes,
 		CiphertextLen:        uint32(len(mkemCiphertext.Envelope)),
 		Ciphertext:           mkemCiphertext.Envelope,
-		IsRead:               0, // 0 = write, 1 = read
 	}
 }
 
@@ -1057,7 +1048,6 @@ func composeReadRequest(t *testing.T, env *testEnvironment, reader *bacap.Statef
 		SenderPubkey:         senderPubkeyBytes,
 		CiphertextLen:        uint32(len(mkemCiphertext.Envelope)),
 		Ciphertext:           mkemCiphertext.Envelope,
-		IsRead:               1, // 1 = read, 0 = write
 	}, mkemPrivateKey
 }
 

--- a/vendor/github.com/katzenpost/hpqc/bacap/bacap.go
+++ b/vendor/github.com/katzenpost/hpqc/bacap/bacap.go
@@ -270,7 +270,7 @@ func (m *MessageBoxIndex) VerifyBox(box [BoxIDSize]byte, ciphertext []byte, sig 
 	if err = boxPk.FromBytes(box[:]); err != nil {
 		return
 	}
-	if false == boxPk.Verify(sig, ciphertext) {
+	if !boxPk.Verify(sig, ciphertext) {
 		return false, errors.New("signature verification failed")
 	}
 	return true, nil
@@ -303,7 +303,7 @@ func (m *MessageBoxIndex) DecryptForContext(box [BoxIDSize]byte, ctx []byte, cip
 	if err = boxPk.FromBytes(box[:]); err != nil {
 		return
 	}
-	if false == boxPk.Verify(sig, ciphertext) {
+	if !boxPk.Verify(sig, ciphertext) {
 		return nil, errors.New("signature verification failed")
 	}
 	eICtx := m.deriveEForContext(ctx)
@@ -453,13 +453,13 @@ func (o *WriteCap) UnmarshalBinary(data []byte) error {
 		return errors.New("invalid BoxOwnerCap binary size")
 	}
 	o.rootPrivateKey = new(ed25519.PrivateKey)
-	err := o.rootPrivateKey.FromBytes(data[:64])
+	err := o.rootPrivateKey.FromBytes(data[:ed25519.PrivateKeySize])
 	if err != nil {
 		return err
 	}
 	o.rootPublicKey = o.rootPrivateKey.PublicKey()
 	o.firstMessageBoxIndex = &MessageBoxIndex{}
-	if err := o.firstMessageBoxIndex.UnmarshalBinary(data[64:]); err != nil {
+	if err := o.firstMessageBoxIndex.UnmarshalBinary(data[ed25519.PrivateKeySize:]); err != nil {
 		return err
 	}
 	return nil
@@ -517,12 +517,12 @@ func (u *ReadCap) UnmarshalBinary(data []byte) error {
 		return errors.New("invalid ReadCap binary size")
 	}
 	u.rootPublicKey = new(ed25519.PublicKey)
-	err := u.rootPublicKey.FromBytes(data[:32])
+	err := u.rootPublicKey.FromBytes(data[:ed25519.PublicKeySize])
 	if err != nil {
 		return err
 	}
 	u.firstMessageBoxIndex = &MessageBoxIndex{}
-	if err := u.firstMessageBoxIndex.UnmarshalBinary(data[32:]); err != nil {
+	if err := u.firstMessageBoxIndex.UnmarshalBinary(data[ed25519.PublicKeySize:]); err != nil {
 		return err
 	}
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -146,7 +146,7 @@ github.com/katzenpost/circl/sign/ed448
 github.com/katzenpost/circl/sign/eddilithium2
 github.com/katzenpost/circl/sign/eddilithium3
 github.com/katzenpost/circl/simd/keccakf1600
-# github.com/katzenpost/hpqc v0.0.66
+# github.com/katzenpost/hpqc v0.0.67
 ## explicit; go 1.23.0
 github.com/katzenpost/hpqc/bacap
 github.com/katzenpost/hpqc/hash


### PR DESCRIPTION
Use latest hpqc with bacap bug fix.
Teach courier to cache all reads and writes.
Update pigeonhole geometry and related tests
to account for not having an IsRead field.