### PR TITLE
Add DisableDecoyTraffic to courier and replica configs

### DIFF
--- a/client2/listener_test.go
+++ b/client2/listener_test.go
@@ -26,7 +26,7 @@ func TestListenerBasic(t *testing.T) {
 	}
 
 	rates := &Rates{
-		messageOrDrop: 555,
+		messageOrLoop: 555,
 	}
 
 	egressSize := 123
@@ -47,7 +47,7 @@ func TestListenerBasic(t *testing.T) {
 
 	doc1 := &cpki.Document{
 		Epoch:   epoch,
-		LambdaP: rates.messageOrDrop,
+		LambdaP: rates.messageOrLoop,
 	}
 
 	listener.doUpdateFromPKIDoc(doc1)
@@ -55,11 +55,6 @@ func TestListenerBasic(t *testing.T) {
 
 	listener.doUpdateConnectionStatus(nil)
 	require.Nil(t, listener.getConnectionStatus())
-
-	//listener.connectionStatus = errors.New("fail")
-	//listener.updateConnectionStatus(nil)
-	//time.Sleep(1 * time.Second)
-	//require.Nil(t, listener.getConnectionStatus())
 
 	listener.Shutdown()
 }

--- a/client2/rates.go
+++ b/client2/rates.go
@@ -6,23 +6,13 @@ package client2
 import cpki "github.com/katzenpost/katzenpost/core/pki"
 
 type Rates struct {
-	messageOrDrop         float64
-	messageOrDropMaxDelay uint64
-
-	loop         float64
-	loopMaxDelay uint64
-
-	drop         float64
-	dropMaxDelay uint64
+	messageOrLoop         float64
+	messageOrLoopMaxDelay uint64
 }
 
 func ratesFromPKIDoc(doc *cpki.Document) *Rates {
 	return &Rates{
-		messageOrDrop:         doc.LambdaP,
-		messageOrDropMaxDelay: doc.LambdaPMaxDelay,
-		loop:                  doc.LambdaL,
-		loopMaxDelay:          doc.LambdaLMaxDelay,
-		drop:                  doc.LambdaD,
-		dropMaxDelay:          doc.LambdaDMaxDelay,
+		messageOrLoop:         doc.LambdaP,
+		messageOrLoopMaxDelay: doc.LambdaPMaxDelay,
 	}
 }

--- a/client2/sender.go
+++ b/client2/sender.go
@@ -76,7 +76,11 @@ func (s *sender) UpdateConnectionStatus(isConnected bool) {
 }
 
 func (s *sender) UpdateRates(rates *Rates) {
-	s.sendMessageOrLoop.UpdateRate(uint64(1/rates.messageOrDrop), rates.messageOrDropMaxDelay)
+	if rates.messageOrLoop <= 0 {
+		s.log.Warning("Invalid messageOrDrop rate, using default")
+		return
+	}
+	s.sendMessageOrLoop.UpdateRate(uint64(1/rates.messageOrLoop), rates.messageOrLoopMaxDelay)
 }
 
 func newLoopDecoy() *Request {

--- a/client2/sender_test.go
+++ b/client2/sender_test.go
@@ -4,8 +4,9 @@
 package client2
 
 import (
-	"github.com/katzenpost/katzenpost/core/log"
 	"testing"
+
+	"github.com/katzenpost/katzenpost/core/log"
 )
 
 func TestSender(t *testing.T) {
@@ -31,7 +32,7 @@ func TestSender(t *testing.T) {
 	s.UpdateConnectionStatus(true)
 	s.UpdateRates(rates)
 
-	n := 40
+	n := 10
 	for i := 0; i < n; i++ {
 		go func() {
 			in <- &Request{}

--- a/client2/sender_test.go
+++ b/client2/sender_test.go
@@ -11,12 +11,8 @@ import (
 
 func TestSender(t *testing.T) {
 	rates := &Rates{
-		messageOrDrop:         0.001,
-		messageOrDropMaxDelay: 1000,
-		loop:                  0.0005,
-		loopMaxDelay:          1000,
-		drop:                  0.0005,
-		dropMaxDelay:          3000,
+		messageOrLoop:         0.001,
+		messageOrLoopMaxDelay: 1000,
 	}
 
 	in := make(chan *Request)

--- a/client2/thin_messages.go
+++ b/client2/thin_messages.go
@@ -95,6 +95,8 @@ type Request struct {
 	// that is sending this Request.
 	AppID *[AppIDLength]byte
 
+	// Channel API
+
 	CreateWriteChannel *thin.CreateWriteChannel
 
 	CreateReadChannel *thin.CreateReadChannel
@@ -113,17 +115,21 @@ type Request struct {
 
 	CloseChannel *thin.CloseChannel
 
+	SendChannelQuery *thin.SendChannelQuery
+
+	// Core functionality
+
 	ThinClose *thin.ThinClose
 
-	SendChannelQuery *thin.SendChannelQuery
+	// Decoys
+
+	SendLoopDecoy *SendLoopDecoy
+
+	SendDropDecoy *SendDropDecoy
 
 	// Legacy API
 
 	SendMessage *thin.SendMessage
 
 	SendARQMessage *thin.SendARQMessage
-
-	SendLoopDecoy *SendLoopDecoy
-
-	SendDropDecoy *SendDropDecoy
 }

--- a/courier/server/config/config.go
+++ b/courier/server/config/config.go
@@ -61,6 +61,9 @@ type Config struct {
 	// MaxQueueSize specifies the maximum number of messages that can be queued
 	// for an outgoing connection before blocking.
 	MaxQueueSize int
+
+	// DisableDecoyTraffic disables sending decoy traffic.
+	DisableDecoyTraffic bool
 }
 
 func (c *Config) FixupAndValidate() error {

--- a/replica/config/config.go
+++ b/replica/config/config.go
@@ -84,6 +84,9 @@ type Config struct {
 	// KeepAliveInterval specifies the TCP keep-alive interval in milliseconds.
 	KeepAliveInterval int
 
+	// DisableDecoyTraffic disables sending decoy traffic.
+	DisableDecoyTraffic bool
+
 	// GenerateOnly halts and cleans up the server right after long term
 	// key generation.
 	GenerateOnly bool

--- a/replica/connector.go
+++ b/replica/connector.go
@@ -202,7 +202,7 @@ func (co *Connector) doReplication(cmd *commands.ReplicaWrite) {
 	successCount := 0
 	totalTargets := len(descs)
 
-	for i, desc := range descs {
+	for _, desc := range descs {
 		idHash := blake2b.Sum256(desc.IdentityKey)
 
 		// Check if connection exists before dispatching

--- a/replica/connector.go
+++ b/replica/connector.go
@@ -4,11 +4,8 @@
 package replica
 
 import (
-	"fmt"
 	"sync"
 	"time"
-
-	replicaCommon "github.com/katzenpost/katzenpost/replica/common"
 
 	"golang.org/x/crypto/blake2b"
 	"gopkg.in/op/go-logging.v1"
@@ -20,6 +17,7 @@ import (
 	"github.com/katzenpost/katzenpost/core/sphinx/constants"
 	"github.com/katzenpost/katzenpost/core/wire/commands"
 	"github.com/katzenpost/katzenpost/core/worker"
+	replicaCommon "github.com/katzenpost/katzenpost/replica/common"
 )
 
 type Connector struct {
@@ -136,7 +134,6 @@ func (co *Connector) queueForRetry(cmd commands.Command, idHash [32]byte) {
 		lastTry:  time.Now(),
 	}
 	co.retryQueue = append(co.retryQueue, retryCmd)
-	co.log.Debugf("Added command to retry queue for %x: %v", idHash[:8], getBoxID(cmd))
 }
 
 // processRetryQueue attempts to dispatch queued commands when connections become available
@@ -171,19 +168,13 @@ func (co *Connector) processRetryQueue() {
 }
 
 func (co *Connector) DispatchReplication(cmd *commands.ReplicaWrite) {
-	co.log.Infof("REPLICATION: Queueing replication for BoxID: %x", cmd.BoxID)
-	fmt.Printf("REPLICATION: Queueing replication for BoxID: %x\n", cmd.BoxID)
 	co.replicationCh <- cmd
 }
 
 func (co *Connector) doReplication(cmd *commands.ReplicaWrite) {
-	co.log.Infof("REPLICATION: Starting replication for BoxID: %x", cmd.BoxID)
-	fmt.Printf("REPLICATION: Starting replication for BoxID: %x\n", cmd.BoxID)
-
 	doc := co.server.PKIWorker.PKIDocument()
 	if doc == nil {
 		co.log.Error("REPLICATION: Failed - no PKI document available")
-		fmt.Printf("REPLICATION: Failed - no PKI document available\n")
 		return
 	}
 
@@ -191,26 +182,19 @@ func (co *Connector) doReplication(cmd *commands.ReplicaWrite) {
 	myIdBytes, err := co.server.identityPublicKey.MarshalBinary()
 	if err != nil {
 		co.log.Errorf("REPLICATION: Failed to marshal identity key: %v", err)
-		fmt.Printf("REPLICATION: Failed to marshal identity key: %v\n", err)
 	} else {
 		myIdHash := blake2b.Sum256(myIdBytes)
 		co.log.Infof("REPLICATION: My identity: %x", myIdHash[:8])
-		fmt.Printf("REPLICATION: My identity: %x\n", myIdHash[:8])
 	}
 
 	descs, err := replicaCommon.GetRemoteShards(co.server.identityPublicKey, cmd.BoxID, doc)
 	if err != nil {
 		co.log.Errorf("REPLICATION: Failed - GetRemoteShards err: %v", err)
-		fmt.Printf("REPLICATION: Failed - GetRemoteShards err: %v\n", err)
 		panic(err)
 	}
 
-	co.log.Infof("REPLICATION: Found %d remote shards for BoxID %x", len(descs), cmd.BoxID)
-	fmt.Printf("REPLICATION: Found %d remote shards for BoxID %x\n", len(descs), cmd.BoxID)
-
 	if len(descs) == 0 {
 		co.log.Infof("REPLICATION: No remote shards needed for BoxID %x", cmd.BoxID)
-		fmt.Printf("REPLICATION: No remote shards needed for BoxID %x\n", cmd.BoxID)
 		return
 	}
 
@@ -220,8 +204,6 @@ func (co *Connector) doReplication(cmd *commands.ReplicaWrite) {
 
 	for i, desc := range descs {
 		idHash := blake2b.Sum256(desc.IdentityKey)
-		co.log.Infof("REPLICATION: Dispatching to shard %d/%d: %s (ID: %x)", i+1, len(descs), desc.Name, idHash[:8])
-		fmt.Printf("REPLICATION: Dispatching to shard %d/%d: %s (ID: %x)\n", i+1, len(descs), desc.Name, idHash[:8])
 
 		// Check if connection exists before dispatching
 		co.RLock()
@@ -237,28 +219,20 @@ func (co *Connector) doReplication(cmd *commands.ReplicaWrite) {
 
 	if successCount == totalTargets {
 		co.log.Infof("REPLICATION: Successfully dispatched to all %d targets for BoxID %x", totalTargets, cmd.BoxID)
-		fmt.Printf("REPLICATION: Successfully dispatched to all %d targets for BoxID %x\n", totalTargets, cmd.BoxID)
 	} else {
 		co.log.Warningf("REPLICATION: Only dispatched to %d/%d targets for BoxID %x (others queued for retry)", successCount, totalTargets, cmd.BoxID)
-		fmt.Printf("REPLICATION: Only dispatched to %d/%d targets for BoxID %x (others queued for retry)\n", successCount, totalTargets, cmd.BoxID)
 	}
-
-	co.log.Infof("REPLICATION: Dispatch completed for BoxID %x", cmd.BoxID)
-	fmt.Printf("REPLICATION: Dispatch completed for BoxID %x\n", cmd.BoxID)
 }
 
 func (co *Connector) replicationWorker() {
 	co.log.Infof("REPLICATION: Starting replication worker")
-	fmt.Printf("REPLICATION: Starting replication worker\n")
 	for {
 		select {
 		case <-co.HaltCh():
 			co.log.Infof("REPLICATION: Worker terminating gracefully")
-			fmt.Printf("REPLICATION: Worker terminating gracefully\n")
 			return
 		case writeCmd := <-co.replicationCh:
 			co.log.Infof("REPLICATION: Worker received write command for BoxID: %x", writeCmd.BoxID)
-			fmt.Printf("REPLICATION: Worker received write command for BoxID: %x\n", writeCmd.BoxID)
 			co.doReplication(writeCmd)
 		}
 	}

--- a/replica/handlers.go
+++ b/replica/handlers.go
@@ -53,7 +53,10 @@ func (c *incomingConn) onReplicaCommand(rawCmd commands.Command) (commands.Comma
 		return nil, false
 	case *commands.ReplicaDecoy:
 		c.log.Debug("Received ReplicaDecoy from peer")
-		return nil, true
+		decoyReply := &commands.ReplicaDecoy{
+			Cmds: commands.NewStorageReplicaCommands(c.geo, schemes.ByName(c.l.server.cfg.ReplicaNIKEScheme)),
+		}
+		return decoyReply, true
 	case *commands.ReplicaWrite:
 		c.log.Debugf("Processing ReplicaWrite command for BoxID: %x", cmd.BoxID)
 		trunnelWrite := pigeonhole.WireCommandToTrunnelReplicaWrite(cmd)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable or disable decoy traffic sending.
* **Bug Fixes**
  * Simplified decoy traffic handling by merging drop and loop decoys into a single mechanism, improving efficiency and maintainability.
* **Improvements**
  * Enhanced replica command handling to provide a more complete decoy response.
  * Removed redundant console outputs in replication processes, relying solely on structured logging.
  * Clarified message structure with improved field grouping and documentation.
  * Reduced test concurrency to improve stability.
  * Simplified rate configuration by consolidating multiple rate fields into a single combined rate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->