### PR TITLE
Fixup ping, clearer output name/queue id

### DIFF
--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -106,8 +106,12 @@ func sendPing(session *thin.ThinClient, serviceDesc *common.ServiceDescriptor, p
 }
 
 func sendPings(session *thin.ThinClient, serviceDesc *common.ServiceDescriptor, count int, concurrency int, printDiff bool) {
-	id := hash.Sum256(serviceDesc.MixDescriptor.IdentityKey)
-	fmt.Printf("%s\n", headerStyle.Render(fmt.Sprintf("Sending %d Sphinx packets to %x@%x", count, id, serviceDesc.RecipientQueueID)))
+	// Extract service name from RecipientQueueID (remove leading '+' if present)
+	serviceName := string(serviceDesc.RecipientQueueID)
+	nodeName := serviceDesc.MixDescriptor.Name
+
+	fmt.Println("Control-C to abort...")
+	fmt.Printf("%s\n", headerStyle.Render(fmt.Sprintf("Sending %d Sphinx packets to %s@%s", count, serviceName, nodeName)))
 
 	var passed, failed uint64
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved output messages for sending pings, now displaying the service and node names in a user-friendly format.
  * Added a "Control-C to abort..." prompt before the main status line for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->