### PR TITLE
authority: fix consensus bugs in dirauth state management

### DIFF
--- a/authority/voting/server/state.go
+++ b/authority/voting/server/state.go
@@ -2090,8 +2090,10 @@ func newState(s *Server) (*state, error) {
 		st.verifiers[hash.Sum256From(auth.IdentityPublicKey)] = auth.IdentityPublicKey
 	}
 	st.verifiers[hash.Sum256From(s.IdentityKey())] = sign.PublicKey(s.IdentityKey())
-	st.threshold = len(st.verifiers)/2 + 1
-	st.dissenters = len(s.cfg.Authorities)/2 - 1
+	// Use consistent count for threshold calculations
+	totalAuthorities := len(st.verifiers)
+	st.threshold = totalAuthorities/2 + 1
+	st.dissenters = totalAuthorities/2 - 1
 
 	st.s.cfg.Server.PKISignatureScheme = s.cfg.Server.PKISignatureScheme
 	pkiSignatureScheme := signSchemes.ByName(s.cfg.Server.PKISignatureScheme)
@@ -2195,7 +2197,12 @@ func newState(s *Server) (*state, error) {
 		st.reverseHash[pk] = v.IdentityPublicKey
 		st.authorityNames[pk] = v.Identifier
 	}
-	st.reverseHash[hash.Sum256From(st.s.identityPublicKey)] = st.s.identityPublicKey
+
+	// Add self to the mappings
+	selfPk := hash.Sum256From(st.s.identityPublicKey)
+	st.reverseHash[selfPk] = st.s.identityPublicKey
+	st.authorityNames[selfPk] = st.s.cfg.Server.Identifier
+	st.authorizedAuthorities[selfPk] = true
 
 	st.documents = make(map[uint64]*pki.Document)
 	st.myconsensus = make(map[uint64]*pki.Document)


### PR DESCRIPTION
- Add self to authorityNames mapping to fix missing vote reporting
- Fix inconsistent threshold calculation using totalAuthorities count
- Add self-authorization to prevent vote rejection
- Ensures authority includes itself in consensus vote tallies

Fixes consensus failure where 3/4 votes with threshold=3 was incorrectly failing.