### PR TITLE
dirauth: add BindAddresses config field

### DIFF
--- a/authority/voting/server/config/config.go
+++ b/authority/voting/server/config/config.go
@@ -283,6 +283,9 @@ type Authority struct {
 	// Addresses are the listener addresses specified by a URL, e.g. tcp://1.2.3.4:1234 or quic://1.2.3.4:1234
 	// Both IPv4 and IPv6 as well as hostnames are valid.
 	Addresses []string
+	// BindAddresses are the IP addresses to bind to for incoming connections.
+	// If left empty, Addresses will be used.
+	BindAddresses []string
 }
 
 // UnmarshalTOML deserializes into non-nil instances of sign.PublicKey and kem.PublicKey
@@ -423,6 +426,10 @@ type Server struct {
 	// Addresses are the IP address/port combinations that the server will bind
 	// to for incoming connections.
 	Addresses []string
+
+	// BindAddresses are the IP addresses to bind to for incoming connections.
+	// If left empty, Addresses will be used.
+	BindAddresses []string
 
 	// DataDir is the absolute path to the server's state files.
 	DataDir string

--- a/authority/voting/server/server.go
+++ b/authority/voting/server/server.go
@@ -366,7 +366,11 @@ func New(cfg *config.Config) (*Server, error) {
 	s.state.Go(s.state.worker)
 
 	// Start up the listeners.
-	for _, v := range s.cfg.Server.Addresses {
+	listenAddresses := s.cfg.Server.Addresses
+	if len(s.cfg.Server.BindAddresses) > 0 {
+		listenAddresses = s.cfg.Server.BindAddresses
+	}
+	for _, v := range listenAddresses {
 		// parse the Address line as a URL
 		u, err := url.Parse(v)
 		if err == nil {


### PR DESCRIPTION
Allow Directory Authorities to bind to an internal addresses behind a NAT but the public IP may remain in the configuration in the Addresses configuration field.