### PR TITLE
authority: add exponential backoff retries

### DIFF
--- a/authority/Makefile
+++ b/authority/Makefile
@@ -7,15 +7,8 @@ test:
 lint:
 	golint ./...
 
-test-internal:
-	go test -race -cover -v ./internal/...
-
 test-voting:
 	go test -race -cover -v ./voting/...
-
-# no tests here
-test-nonvoting:
-	go test -race -cover -v ./nonvoting/...
 
 coverage-file:
 	go test ./... -coverprofile=coverage.out

--- a/authority/voting/server/config/config_test.go
+++ b/authority/voting/server/config/config_test.go
@@ -1,0 +1,152 @@
+// config_test.go - Tests for Katzenpost voting authority config.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultRetryAttempts(t *testing.T) {
+	attempts := DefaultRetryAttempts()
+	if attempts < minRetryAttempts {
+		t.Errorf("DefaultRetryAttempts() = %d, want >= %d", attempts, minRetryAttempts)
+	}
+	t.Logf("DefaultRetryAttempts() = %d (minimum: %d)", attempts, minRetryAttempts)
+}
+
+func TestDefaultRetryMaxDelay(t *testing.T) {
+	maxDelay := DefaultRetryMaxDelay()
+	if maxDelay <= 0 {
+		t.Errorf("DefaultRetryMaxDelay() = %v, want > 0", maxDelay)
+	}
+	t.Logf("DefaultRetryMaxDelay() = %v", maxDelay)
+}
+
+func TestServerApplyRetryDefaults(t *testing.T) {
+	t.Run("empty config gets defaults", func(t *testing.T) {
+		cfg := &Server{}
+		cfg.applyRetryDefaults()
+
+		if cfg.PeerRetryMaxAttempts != DefaultRetryAttempts() {
+			t.Errorf("PeerRetryMaxAttempts = %d, want %d", cfg.PeerRetryMaxAttempts, DefaultRetryAttempts())
+		}
+		if cfg.PeerRetryBaseDelay != defaultRetryBaseDelay {
+			t.Errorf("PeerRetryBaseDelay = %v, want %v", cfg.PeerRetryBaseDelay, defaultRetryBaseDelay)
+		}
+		if cfg.PeerRetryMaxDelay != DefaultRetryMaxDelay() {
+			t.Errorf("PeerRetryMaxDelay = %v, want %v", cfg.PeerRetryMaxDelay, DefaultRetryMaxDelay())
+		}
+		if cfg.PeerRetryJitter != defaultRetryJitter {
+			t.Errorf("PeerRetryJitter = %v, want %v", cfg.PeerRetryJitter, defaultRetryJitter)
+		}
+	})
+
+	t.Run("explicit values preserved", func(t *testing.T) {
+		cfg := &Server{
+			PeerRetryMaxAttempts: 25,
+			PeerRetryBaseDelay:   3 * time.Second,
+			PeerRetryMaxDelay:    45 * time.Second,
+			PeerRetryJitter:      0.15,
+		}
+		cfg.applyRetryDefaults()
+
+		if cfg.PeerRetryMaxAttempts != 25 {
+			t.Errorf("PeerRetryMaxAttempts changed to %d", cfg.PeerRetryMaxAttempts)
+		}
+		if cfg.PeerRetryBaseDelay != 3*time.Second {
+			t.Errorf("PeerRetryBaseDelay changed to %v", cfg.PeerRetryBaseDelay)
+		}
+		if cfg.PeerRetryMaxDelay != 45*time.Second {
+			t.Errorf("PeerRetryMaxDelay changed to %v", cfg.PeerRetryMaxDelay)
+		}
+		if cfg.PeerRetryJitter != 0.15 {
+			t.Errorf("PeerRetryJitter changed to %v", cfg.PeerRetryJitter)
+		}
+	})
+
+	t.Run("jitter capped at 1.0", func(t *testing.T) {
+		cfg := &Server{
+			PeerRetryJitter: 2.5,
+		}
+		cfg.applyRetryDefaults()
+
+		if cfg.PeerRetryJitter != 1.0 {
+			t.Errorf("PeerRetryJitter = %v, want 1.0 (capped)", cfg.PeerRetryJitter)
+		}
+	})
+
+	t.Run("negative values get defaults", func(t *testing.T) {
+		cfg := &Server{
+			PeerRetryMaxAttempts: -5,
+			PeerRetryBaseDelay:   -1 * time.Second,
+			PeerRetryMaxDelay:    -10 * time.Second,
+			PeerRetryJitter:      -0.5,
+		}
+		cfg.applyRetryDefaults()
+
+		if cfg.PeerRetryMaxAttempts != DefaultRetryAttempts() {
+			t.Errorf("negative PeerRetryMaxAttempts not defaulted: %d", cfg.PeerRetryMaxAttempts)
+		}
+		if cfg.PeerRetryBaseDelay != defaultRetryBaseDelay {
+			t.Errorf("negative PeerRetryBaseDelay not defaulted: %v", cfg.PeerRetryBaseDelay)
+		}
+		if cfg.PeerRetryMaxDelay != DefaultRetryMaxDelay() {
+			t.Errorf("negative PeerRetryMaxDelay not defaulted: %v", cfg.PeerRetryMaxDelay)
+		}
+		if cfg.PeerRetryJitter != defaultRetryJitter {
+			t.Errorf("negative PeerRetryJitter not defaulted: %v", cfg.PeerRetryJitter)
+		}
+	})
+}
+
+func TestServerDisableIPv4IPv6(t *testing.T) {
+	t.Run("defaults are false", func(t *testing.T) {
+		cfg := &Server{}
+		if cfg.DisableIPv4 {
+			t.Error("DisableIPv4 should default to false")
+		}
+		if cfg.DisableIPv6 {
+			t.Error("DisableIPv6 should default to false")
+		}
+	})
+
+	t.Run("can be set to true", func(t *testing.T) {
+		cfg := &Server{
+			DisableIPv4: true,
+			DisableIPv6: true,
+		}
+		if !cfg.DisableIPv4 {
+			t.Error("DisableIPv4 should be true")
+		}
+		if !cfg.DisableIPv6 {
+			t.Error("DisableIPv6 should be true")
+		}
+	})
+}
+
+func BenchmarkDefaultRetryAttempts(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = DefaultRetryAttempts()
+	}
+}
+
+func BenchmarkApplyRetryDefaults(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cfg := &Server{}
+		cfg.applyRetryDefaults()
+	}
+}

--- a/authority/voting/server/retry.go
+++ b/authority/voting/server/retry.go
@@ -1,0 +1,122 @@
+// retry.go - Katzenpost voting authority retry logic.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package server
+
+import (
+	"errors"
+	"math/rand"
+	"net"
+	"strings"
+	"time"
+)
+
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, p := range []string{
+		"connection refused",
+		"connection reset",
+		"broken pipe",
+		"eof",
+		"timeout",
+		"deadline exceeded",
+		"network is unreachable",
+		"no route to host",
+		"i/o timeout",
+	} {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return false
+}
+
+func retryDelay(baseDelay, maxDelay time.Duration, jitter float64, attempt int) time.Duration {
+	delay := baseDelay * time.Duration(1<<uint(attempt))
+	if delay > maxDelay {
+		delay = maxDelay
+	}
+	if jitter > 0 {
+		delay += time.Duration(float64(delay) * jitter * rand.Float64())
+	}
+	return delay
+}
+
+func detectAddressCapabilities(addresses []string) (hasIPv4, hasIPv6 bool) {
+	for _, addr := range addresses {
+		host := addr
+		if idx := strings.Index(addr, "://"); idx >= 0 {
+			host = addr[idx+3:]
+		}
+		if strings.HasPrefix(host, "[") {
+			hasIPv6 = true
+			continue
+		}
+		colonIdx := strings.LastIndex(host, ":")
+		if colonIdx > 0 {
+			host = host[:colonIdx]
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			hasIPv4 = true
+			continue
+		}
+		if ip.To4() != nil {
+			hasIPv4 = true
+		} else {
+			hasIPv6 = true
+		}
+	}
+	return
+}
+
+func isUsableAddress(addr string, hasIPv4, hasIPv6, disableIPv4, disableIPv6 bool) bool {
+	host := addr
+	if idx := strings.Index(addr, "://"); idx >= 0 {
+		host = addr[idx+3:]
+	}
+	if strings.HasPrefix(host, "[") {
+		if end := strings.Index(host, "]"); end > 0 {
+			host = host[1:end]
+		}
+	} else if idx := strings.LastIndex(host, ":"); idx > 0 {
+		host = host[:idx]
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return true
+	}
+	if ip.To4() != nil {
+		return hasIPv4 && !disableIPv4
+	}
+	return hasIPv6 && !disableIPv6
+}
+
+func filterUsableAddresses(addrs []string, hasIPv4, hasIPv6, disableIPv4, disableIPv6 bool) []string {
+	result := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		if isUsableAddress(addr, hasIPv4, hasIPv6, disableIPv4, disableIPv6) {
+			result = append(result, addr)
+		}
+	}
+	return result
+}

--- a/authority/voting/server/retry_test.go
+++ b/authority/voting/server/retry_test.go
@@ -1,0 +1,312 @@
+// retry_test.go - Tests for Katzenpost voting authority retry logic.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package server
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/katzenpost/katzenpost/authority/voting/server/config"
+)
+
+func TestIsTransientError(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected bool
+	}{
+		{nil, false},
+		{errors.New("connection refused"), true},
+		{errors.New("CONNECTION REFUSED"), true},
+		{errors.New("read: connection reset by peer"), true},
+		{io.EOF, true},
+		{errors.New("dial tcp: i/o timeout"), true},
+		{errors.New("context deadline exceeded"), true},
+		{errors.New("network is unreachable"), true},
+		{errors.New("no route to host"), true},
+		{errors.New("broken pipe"), true},
+		{errors.New("authentication failed"), false},
+		{errors.New("certificate invalid"), false},
+		{errors.New("VoteTooLate"), false},
+		{errors.New("permission denied"), false},
+	}
+	for _, tt := range tests {
+		got := isTransientError(tt.err)
+		if got != tt.expected {
+			t.Errorf("isTransientError(%v) = %v, want %v", tt.err, got, tt.expected)
+		}
+	}
+}
+
+func TestRetryDelay(t *testing.T) {
+	tests := []struct {
+		baseDelay time.Duration
+		maxDelay  time.Duration
+		jitter    float64
+		attempt   int
+		minDelay  time.Duration
+		maxResult time.Duration
+	}{
+		{1 * time.Second, 10 * time.Second, 0, 0, 1 * time.Second, 1 * time.Second},
+		{1 * time.Second, 10 * time.Second, 0, 1, 2 * time.Second, 2 * time.Second},
+		{1 * time.Second, 10 * time.Second, 0, 2, 4 * time.Second, 4 * time.Second},
+		{1 * time.Second, 10 * time.Second, 0, 3, 8 * time.Second, 8 * time.Second},
+		{1 * time.Second, 10 * time.Second, 0, 4, 10 * time.Second, 10 * time.Second},
+		{1 * time.Second, 10 * time.Second, 0, 5, 10 * time.Second, 10 * time.Second},
+		{2 * time.Second, 30 * time.Second, 0, 0, 2 * time.Second, 2 * time.Second},
+		{2 * time.Second, 30 * time.Second, 0, 1, 4 * time.Second, 4 * time.Second},
+		{2 * time.Second, 30 * time.Second, 0, 2, 8 * time.Second, 8 * time.Second},
+		{2 * time.Second, 30 * time.Second, 0, 3, 16 * time.Second, 16 * time.Second},
+		{2 * time.Second, 30 * time.Second, 0, 4, 30 * time.Second, 30 * time.Second},
+	}
+	for _, tt := range tests {
+		got := retryDelay(tt.baseDelay, tt.maxDelay, tt.jitter, tt.attempt)
+		if got < tt.minDelay || got > tt.maxResult {
+			t.Errorf("retryDelay(%v, %v, %v, %d) = %v, want between %v and %v",
+				tt.baseDelay, tt.maxDelay, tt.jitter, tt.attempt, got, tt.minDelay, tt.maxResult)
+		}
+	}
+}
+
+func TestRetryDelayWithJitter(t *testing.T) {
+	baseDelay := 1 * time.Second
+	maxDelay := 10 * time.Second
+	jitter := 0.5
+
+	for i := 0; i < 20; i++ {
+		delay := retryDelay(baseDelay, maxDelay, jitter, 0)
+		if delay < baseDelay || delay > baseDelay+time.Duration(float64(baseDelay)*jitter) {
+			t.Errorf("retryDelay with jitter out of range: %v", delay)
+		}
+	}
+}
+
+func TestDetectAddressCapabilities(t *testing.T) {
+	tests := []struct {
+		addresses []string
+		wantIPv4  bool
+		wantIPv6  bool
+	}{
+		{[]string{"tcp://192.168.1.1:8080"}, true, false},
+		{[]string{"tcp://[2001:db8::1]:8080"}, false, true},
+		{[]string{"tcp://192.168.1.1:8080", "tcp://[2001:db8::1]:8080"}, true, true},
+		{[]string{"tcp://hostname:8080"}, true, false},
+		{[]string{"quic://10.0.0.1:443"}, true, false},
+		{[]string{"tcp://[::1]:8080"}, false, true},
+		{[]string{}, false, false},
+	}
+	for _, tt := range tests {
+		gotIPv4, gotIPv6 := detectAddressCapabilities(tt.addresses)
+		if gotIPv4 != tt.wantIPv4 || gotIPv6 != tt.wantIPv6 {
+			t.Errorf("detectAddressCapabilities(%v) = (%v, %v), want (%v, %v)",
+				tt.addresses, gotIPv4, gotIPv6, tt.wantIPv4, tt.wantIPv6)
+		}
+	}
+}
+
+func TestIsUsableAddress(t *testing.T) {
+	tests := []struct {
+		addr        string
+		hasIPv4     bool
+		hasIPv6     bool
+		disableIPv4 bool
+		disableIPv6 bool
+		expected    bool
+	}{
+		{"tcp://192.168.1.1:8080", true, false, false, false, true},
+		{"tcp://192.168.1.1:8080", false, true, false, false, false},
+		{"tcp://192.168.1.1:8080", true, false, true, false, false},
+		{"tcp://[2001:db8::1]:8080", false, true, false, false, true},
+		{"tcp://[2001:db8::1]:8080", true, false, false, false, false},
+		{"tcp://[2001:db8::1]:8080", true, true, false, true, false},
+		{"tcp://hostname:8080", false, false, false, false, true},
+		{"tcp://hostname:8080", true, true, true, true, true},
+		{"tcp://[fd00::1]:8080", false, true, false, false, true},
+		{"tcp://[fe80::1]:8080", false, true, false, false, true},
+	}
+	for _, tt := range tests {
+		got := isUsableAddress(tt.addr, tt.hasIPv4, tt.hasIPv6, tt.disableIPv4, tt.disableIPv6)
+		if got != tt.expected {
+			t.Errorf("isUsableAddress(%q, v4=%v, v6=%v, disV4=%v, disV6=%v) = %v, want %v",
+				tt.addr, tt.hasIPv4, tt.hasIPv6, tt.disableIPv4, tt.disableIPv6, got, tt.expected)
+		}
+	}
+}
+
+func TestFilterUsableAddresses(t *testing.T) {
+	addrs := []string{
+		"tcp://192.168.1.1:8080",
+		"tcp://[2001:db8::1]:8080",
+		"tcp://10.0.0.1:443",
+		"tcp://[fd00::2]:8080",
+	}
+
+	t.Run("IPv4 only", func(t *testing.T) {
+		filtered := filterUsableAddresses(addrs, true, false, false, false)
+		if len(filtered) != 2 {
+			t.Errorf("expected 2 addresses, got %d: %v", len(filtered), filtered)
+		}
+	})
+
+	t.Run("IPv6 only", func(t *testing.T) {
+		filtered := filterUsableAddresses(addrs, false, true, false, false)
+		if len(filtered) != 2 {
+			t.Errorf("expected 2 addresses, got %d: %v", len(filtered), filtered)
+		}
+	})
+
+	t.Run("dual stack", func(t *testing.T) {
+		filtered := filterUsableAddresses(addrs, true, true, false, false)
+		if len(filtered) != 4 {
+			t.Errorf("expected 4 addresses, got %d: %v", len(filtered), filtered)
+		}
+	})
+
+	t.Run("dual stack with IPv6 disabled", func(t *testing.T) {
+		filtered := filterUsableAddresses(addrs, true, true, false, true)
+		if len(filtered) != 2 {
+			t.Errorf("expected 2 addresses, got %d: %v", len(filtered), filtered)
+		}
+	})
+
+	t.Run("dual stack with IPv4 disabled", func(t *testing.T) {
+		filtered := filterUsableAddresses(addrs, true, true, true, false)
+		if len(filtered) != 2 {
+			t.Errorf("expected 2 addresses, got %d: %v", len(filtered), filtered)
+		}
+	})
+}
+
+func TestDefaultRetryAttempts(t *testing.T) {
+	attempts := config.DefaultRetryAttempts()
+	if attempts < 5 {
+		t.Errorf("DefaultRetryAttempts() = %d, want >= 5", attempts)
+	}
+	t.Logf("DefaultRetryAttempts() = %d", attempts)
+}
+
+func TestDefaultRetryMaxDelay(t *testing.T) {
+	maxDelay := config.DefaultRetryMaxDelay()
+	if maxDelay <= 0 {
+		t.Errorf("DefaultRetryMaxDelay() = %v, want > 0", maxDelay)
+	}
+	t.Logf("DefaultRetryMaxDelay() = %v", maxDelay)
+}
+
+func TestRetryBehaviorSimulation(t *testing.T) {
+	t.Run("success first attempt", func(t *testing.T) {
+		attempts := 0
+		err := simulateRetry(3, func() error {
+			attempts++
+			return nil
+		})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if attempts != 1 {
+			t.Errorf("expected 1 attempt, got %d", attempts)
+		}
+	})
+
+	t.Run("success after retries", func(t *testing.T) {
+		attempts := 0
+		err := simulateRetry(5, func() error {
+			attempts++
+			if attempts < 3 {
+				return errors.New("connection refused")
+			}
+			return nil
+		})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if attempts != 3 {
+			t.Errorf("expected 3 attempts, got %d", attempts)
+		}
+	})
+
+	t.Run("permanent error no retry", func(t *testing.T) {
+		attempts := 0
+		err := simulateRetry(5, func() error {
+			attempts++
+			return errors.New("authentication failed")
+		})
+		if err == nil {
+			t.Error("expected error")
+		}
+		if attempts != 1 {
+			t.Errorf("expected 1 attempt for permanent error, got %d", attempts)
+		}
+	})
+
+	t.Run("max retries exceeded", func(t *testing.T) {
+		attempts := 0
+		err := simulateRetry(3, func() error {
+			attempts++
+			return errors.New("connection refused")
+		})
+		if err == nil {
+			t.Error("expected error after max retries")
+		}
+		if attempts != 4 {
+			t.Errorf("expected 4 attempts (initial + 3 retries), got %d", attempts)
+		}
+	})
+}
+
+func simulateRetry(maxAttempts int, fn func() error) error {
+	var lastErr error
+	for attempt := 0; attempt <= maxAttempts; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !isTransientError(err) {
+			return err
+		}
+	}
+	return lastErr
+}
+
+func BenchmarkIsTransientError(b *testing.B) {
+	err := errors.New("connection refused")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isTransientError(err)
+	}
+}
+
+func BenchmarkRetryDelay(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		retryDelay(2*time.Second, 30*time.Second, 0.2, i%5)
+	}
+}
+
+func BenchmarkFilterUsableAddresses(b *testing.B) {
+	addrs := []string{
+		"tcp://192.168.1.1:8080",
+		"tcp://[2001:db8::1]:8080",
+		"tcp://10.0.0.1:443",
+		"tcp://hostname:8080",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		filterUsableAddresses(addrs, true, true, false, false)
+	}
+}


### PR DESCRIPTION
Add configurable retry behavior when authorities fail to connect to peers during consensus rounds. Transient network errors (connection refused, timeouts, etc.) now trigger retries with exponential backoff instead of immediate failure.

New config options:
- PeerRetryMaxAttempts: max retries (default: 1 per 10s of consensus window, min 5)
- PeerRetryBaseDelay: initial backoff delay (default: 2s)
- PeerRetryMaxDelay: backoff cap (default: consensus window)
- PeerRetryJitter: randomness factor 0.0-1.0 (default: 0.2)
- DisableIPv4/DisableIPv6: skip addresses by protocol

Changes:
- Add retry.go with transient error detection, backoff calculation, and IPv4/IPv6 address filtering helpers
- Refactor sendCommandToPeer() to wrap doSendCommand() in retry loop
- Detect local address capabilities at startup to filter peer addresses
- Normalize log messages in send*ToAuthorities functions
- Add comprehensive tests for retry logic and config defaults
- Remove unused Makefile targets (test-internal, test-nonvoting)

Permanent errors (auth failures, protocol errors) fail immediately without retry. Retry exhaustion surfaces the same error to callers.