### PR TITLE
cmd/fetch: add --min-replicas readiness flag

### DIFF
--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -27,12 +27,14 @@ import (
 	"github.com/katzenpost/katzenpost/client/config"
 	"github.com/katzenpost/katzenpost/client/thin"
 	"github.com/katzenpost/katzenpost/common"
+	cpki "github.com/katzenpost/katzenpost/core/pki"
 )
 
 // Config holds the command line configuration
 type Config struct {
-	ConfigFile string
-	LogLevel   string
+	ConfigFile  string
+	LogLevel    string
+	MinReplicas int
 }
 
 // newRootCommand creates the root cobra command
@@ -69,6 +71,8 @@ and inspecting the current state of the mixnet topology.`,
 		"path to the thin client configuration file (TOML format)")
 	cmd.Flags().StringVarP(&cfg.LogLevel, "log_level", "l", "DEBUG",
 		"logging level (DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL)")
+	cmd.Flags().IntVarP(&cfg.MinReplicas, "min-replicas", "r", 0,
+		"keep waiting for further consensus documents until at least N storage replicas are present (0 = no requirement)")
 
 	return cmd
 }
@@ -106,9 +110,7 @@ func runFetch(cfg Config) error {
 		return fmt.Errorf("failed to connect to client daemon: %v", err)
 	}
 
-	// Check if we already have a PKI document
-	doc := client.PKIDocument()
-	if doc != nil {
+	if doc := client.PKIDocument(); doc != nil && hasEnoughReplicas(doc, cfg.MinReplicas) {
 		fmt.Printf("%v", doc)
 		return nil
 	}
@@ -120,12 +122,26 @@ func runFetch(cfg Config) error {
 	for {
 		select {
 		case event := <-eventSink:
-			if docEvent, ok := event.(*thin.NewDocumentEvent); ok {
-				fmt.Printf("%v", docEvent.Document)
-				return nil
+			docEvent, ok := event.(*thin.NewDocumentEvent)
+			if !ok {
+				continue
 			}
+			if !hasEnoughReplicas(docEvent.Document, cfg.MinReplicas) {
+				continue
+			}
+			fmt.Printf("%v", docEvent.Document)
+			return nil
 		case <-client.HaltCh():
 			return fmt.Errorf("connection closed before receiving PKI document")
 		}
 	}
+}
+
+// hasEnoughReplicas reports whether the given document satisfies the caller's
+// minimum replica requirement. A min of 0 imposes no constraint.
+func hasEnoughReplicas(doc *cpki.Document, min int) bool {
+	if min <= 0 {
+		return true
+	}
+	return doc != nil && len(doc.StorageReplicas) >= min
 }

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,7 @@ help:
 	@echo " courier-restart    - restart courier plugin via thwack interface"
 	@echo " servicenode-restart - restart servicenode container (heavier)"
 	@echo " replica-restart    - rebuild replica binary and restart all replica containers"
-	@echo " wait               - wait for testnet to have consensus"
+	@echo " wait               - wait for testnet to have consensus and at least 2 storage replicas"
 	@echo " watch              - tail -F all logs"
 	@echo " watch-replicas     - monitor all replica logs"
 	@echo " watch-auth         - monitor all directory authority logs"
@@ -324,7 +324,7 @@ show-latest-vote:
 
 wait: $(net_name)/running.stamp | $(cache_dir)
 	$(docker) run --network=host ${docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_base \
-	/$(net_name)/fetch.$(distro) -f /$(net_name)/client/thinclient.toml
+	/$(net_name)/fetch.$(distro) -f /$(net_name)/client/thinclient.toml -r 2
 
 debian_base.stamp:
 	$(docker) run $(replace_name) katzenpost_debian_base docker.io/golang:bullseye $(sh) -c "echo -e 'deb https://deb.debian.org/debian bullseye main\ndeb https://deb.debian.org/debian bullseye-updates main\ndeb https://deb.debian.org/debian-security bullseye-security main' > /etc/apt/sources.list && cat /etc/apt/sources.list && apt update && apt upgrade -y && apt install -y pv && adduser katzenpost --gecos '' --disabled-password && apt update && apt upgrade -y"


### PR DESCRIPTION
A freshly started docker mixnet may seal its first consensus document before any storage replica has had time to upload its descriptor, leaving the document with zero replicas. Any client that consults that document for a pigeonhole operation then fails at GetShards with "no shard replicas are currently online".

Add a --min-replicas (-r) flag that, when non-zero, makes fetch keep consuming NewDocumentEvent messages until a consensus document arrives with at least the requested number of replica descriptors. The default of 0 preserves the existing behaviour of returning the first document received.

This lets CI replace its blanket sleep with a deterministic readiness check, e.g. fetch -r 2 before running any pigeonhole test against a fresh mixnet.