### PR TITLE
Delayed reply scheduler

### DIFF
--- a/client/arq_compose_retry_test.go
+++ b/client/arq_compose_retry_test.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/op/go-logging.v1"
 
 	sphinxConstants "github.com/katzenpost/katzenpost/core/sphinx/constants"
+	"github.com/katzenpost/katzenpost/core/queue"
 )
 
 // TestRescheduleARQAfterComposeFailureRotatesMaps covers the arqDoResend
@@ -24,7 +25,7 @@ func TestRescheduleARQAfterComposeFailureRotatesMaps(t *testing.T) {
 		arqEnvelopeHashMap: make(map[[32]byte]*[sphinxConstants.SURBIDLength]byte),
 		replyLock:          new(sync.Mutex),
 		log:                logging.MustGetLogger("test"),
-		arqTimerQueue:      NewTimerQueue(func(interface{}) {}),
+		arqTimerQueue:      queue.NewTimerQueue(func(interface{}) {}),
 	}
 
 	oldSurbID := &[sphinxConstants.SURBIDLength]byte{}
@@ -58,7 +59,7 @@ func TestRescheduleARQAfterComposeFailureRotatesMaps(t *testing.T) {
 
 	// The pushCh entry proves the retry was queued; we cannot inspect the
 	// internal heap without starting the worker.
-	require.Equal(t, 1, len(d.arqTimerQueue.pushCh),
+	require.Equal(t, 1, d.arqTimerQueue.PushChLen(),
 		"retry must be pushed onto arqTimerQueue, not silently dropped")
 }
 
@@ -73,7 +74,7 @@ func TestRescheduleARQAfterComposeFailureWithDeletedMapEntry(t *testing.T) {
 		arqEnvelopeHashMap: make(map[[32]byte]*[sphinxConstants.SURBIDLength]byte),
 		replyLock:          new(sync.Mutex),
 		log:                logging.MustGetLogger("test"),
-		arqTimerQueue:      NewTimerQueue(func(interface{}) {}),
+		arqTimerQueue:      queue.NewTimerQueue(func(interface{}) {}),
 	}
 
 	staleSurbID := &[sphinxConstants.SURBIDLength]byte{}
@@ -97,7 +98,7 @@ func TestRescheduleARQAfterComposeFailureWithDeletedMapEntry(t *testing.T) {
 		"SURBID must be rotated to a fresh placeholder even when the old key was absent")
 	require.Same(t, arqMessage, d.arqSurbIDMap[*arqMessage.SURBID])
 	require.Equal(t, arqMessage.SURBID, d.arqEnvelopeHashMap[*envHash])
-	require.Equal(t, 1, len(d.arqTimerQueue.pushCh),
+	require.Equal(t, 1, d.arqTimerQueue.PushChLen(),
 		"retry must be pushed onto arqTimerQueue")
 }
 
@@ -109,7 +110,7 @@ func TestRescheduleARQAfterComposeFailureNilEnvelopeHash(t *testing.T) {
 		arqEnvelopeHashMap: make(map[[32]byte]*[sphinxConstants.SURBIDLength]byte),
 		replyLock:          new(sync.Mutex),
 		log:                logging.MustGetLogger("test"),
-		arqTimerQueue:      NewTimerQueue(func(interface{}) {}),
+		arqTimerQueue:      queue.NewTimerQueue(func(interface{}) {}),
 	}
 
 	arqMessage := &ARQMessage{EnvelopeHash: nil, SURBID: nil}

--- a/client/arq_resend_test.go
+++ b/client/arq_resend_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/katzenpost/katzenpost/core/log"
 	sphinxConstants "github.com/katzenpost/katzenpost/core/sphinx/constants"
+	"github.com/katzenpost/katzenpost/core/queue"
 )
 
 // TestEnqueueResendNeverLoses verifies that a flood of ARQ timer fires
@@ -36,7 +37,7 @@ func TestEnqueueResendNeverLoses(t *testing.T) {
 	}
 
 	var rearmed atomic.Int32
-	d.arqTimerQueue = NewTimerQueue(func(interface{}) {
+	d.arqTimerQueue = queue.NewTimerQueue(func(interface{}) {
 		rearmed.Add(1)
 	})
 
@@ -62,7 +63,7 @@ func TestEnqueueResendNeverLoses(t *testing.T) {
 	require.Len(t, a.resendCh, resendBuf)
 	// Every remaining attempt must be queued for retry on the timer —
 	// nothing silently dropped. With the TimerQueue worker unstarted, the
-	// re-armed items sit in pushCh rather than the internal heap.
-	require.Len(t, d.arqTimerQueue.pushCh, numResends-resendBuf,
+	// re-armed items sit in the push channel rather than the internal heap.
+	require.Equal(t, numResends-resendBuf, d.arqTimerQueue.PushChLen(),
 		"all resends that could not enter resendCh must be re-armed, none dropped")
 }

--- a/client/arq_surb_rotation_test.go
+++ b/client/arq_surb_rotation_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/op/go-logging.v1"
 
 	sphinxConstants "github.com/katzenpost/katzenpost/core/sphinx/constants"
+	"github.com/katzenpost/katzenpost/core/queue"
 )
 
 // TestRotateARQSurbIDLockedKeepsEnvelopeHashMapping is the regression test
@@ -126,7 +127,7 @@ func TestRotateARQSurbIDRemovesStaleTimerEntry(t *testing.T) {
 		arqEnvelopeHashMap: make(map[[32]byte]*[sphinxConstants.SURBIDLength]byte),
 		replyLock:          new(sync.Mutex),
 		log:                logging.MustGetLogger("test"),
-		arqTimerQueue:      NewTimerQueue(func(interface{}) {}),
+		arqTimerQueue:      queue.NewTimerQueue(func(interface{}) {}),
 	}
 	// The worker is intentionally NOT started. Enqueue/Cancel touch the
 	// heap synchronously under the queue's own mutex, so there is no race
@@ -148,7 +149,7 @@ func TestRotateARQSurbIDRemovesStaleTimerEntry(t *testing.T) {
 
 	// Simulate the initial Push that scheduled the original ARQ
 	// retransmit — enqueue directly to avoid depending on worker timing.
-	d.arqTimerQueue.queue.Enqueue(1000, oldSurbID)
+	d.arqTimerQueue.EnqueueDirect(1000, oldSurbID)
 	require.Equal(t, 1, d.arqTimerQueue.Len())
 
 	// Perform the production rotation pattern: capture the old SURB ID,
@@ -163,7 +164,7 @@ func TestRotateARQSurbIDRemovesStaleTimerEntry(t *testing.T) {
 		require.True(t, d.arqTimerQueue.Cancel(capturedOld),
 			"Cancel must find and remove the stale entry for the old SURB ID")
 	}
-	d.arqTimerQueue.queue.Enqueue(2000, newSurbID)
+	d.arqTimerQueue.EnqueueDirect(2000, newSurbID)
 
 	// The queue must now hold exactly one entry — the new SURB ID —
 	// rather than both the orphan and the replacement.

--- a/client/copy_poll_test.go
+++ b/client/copy_poll_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/op/go-logging.v1"
 
 	sphinxConstants "github.com/katzenpost/katzenpost/core/sphinx/constants"
+	"github.com/katzenpost/katzenpost/core/queue"
 )
 
 // TestScheduleCopyCommandPollRotationKeepsEnvelopeHashLive pins the
@@ -29,7 +30,7 @@ func TestScheduleCopyCommandPollRotationKeepsEnvelopeHashLive(t *testing.T) {
 	d := &Daemon{
 		arqSurbIDMap:       make(map[[sphinxConstants.SURBIDLength]byte]*ARQMessage),
 		arqEnvelopeHashMap: make(map[[32]byte]*[sphinxConstants.SURBIDLength]byte),
-		arqTimerQueue:      NewTimerQueue(func(_ interface{}) {}),
+		arqTimerQueue:      queue.NewTimerQueue(func(_ interface{}) {}),
 		replyLock:          new(sync.Mutex),
 		log:                logging.MustGetLogger("test"),
 	}

--- a/client/daemon.go
+++ b/client/daemon.go
@@ -26,6 +26,7 @@ import (
 	"github.com/katzenpost/katzenpost/client/thin"
 	"github.com/katzenpost/katzenpost/core/log"
 	cpki "github.com/katzenpost/katzenpost/core/pki"
+	"github.com/katzenpost/katzenpost/core/queue"
 	sphinxConstants "github.com/katzenpost/katzenpost/core/sphinx/constants"
 	"github.com/katzenpost/katzenpost/core/worker"
 	"github.com/katzenpost/katzenpost/pigeonhole"
@@ -86,14 +87,14 @@ type Daemon struct {
 	decoys    map[[sphinxConstants.SURBIDLength]byte]replyDescriptor
 	replyLock *sync.Mutex
 
-	timerQueue *TimerQueue
+	timerQueue *queue.TimerQueue
 	ingressCh  chan *sphinxReply
 	gcSurbIDCh chan *[sphinxConstants.SURBIDLength]byte
 
-	gcTimerQueue *TimerQueue
+	gcTimerQueue *queue.TimerQueue
 	gcReplyCh    chan *gcReply
 
-	arqTimerQueue      *TimerQueue
+	arqTimerQueue      *queue.TimerQueue
 	arqSurbIDMap       map[[sphinxConstants.SURBIDLength]byte]*ARQMessage
 	arqEnvelopeHashMap map[[32]byte]*[sphinxConstants.SURBIDLength]byte // EnvelopeHash -> SURB ID (for cancellation)
 
@@ -250,7 +251,7 @@ func (d *Daemon) Start() error {
 	d.cfg.Callbacks.OnConnFn = d.listener.updateConnectionStatus
 	d.cfg.Callbacks.OnDocumentFn = d.onDocument
 
-	d.timerQueue = NewTimerQueue(func(rawSurbID interface{}) {
+	d.timerQueue = queue.NewTimerQueue(func(rawSurbID interface{}) {
 		surbID, ok := rawSurbID.(*[sphinxConstants.SURBIDLength]byte)
 		if !ok {
 			panic("wtf, failed type assertion!")
@@ -265,7 +266,7 @@ func (d *Daemon) Start() error {
 		}
 	})
 	d.timerQueue.Start()
-	d.arqTimerQueue = NewTimerQueue(func(rawSurbID interface{}) {
+	d.arqTimerQueue = queue.NewTimerQueue(func(rawSurbID interface{}) {
 		surbID, ok := rawSurbID.(*[sphinxConstants.SURBIDLength]byte)
 		if !ok {
 			panic("wtf, failed type assertion!")
@@ -276,7 +277,7 @@ func (d *Daemon) Start() error {
 		d.enqueueResend(surbID)
 	})
 	d.arqTimerQueue.Start()
-	d.gcTimerQueue = NewTimerQueue(func(rawGCReply interface{}) {
+	d.gcTimerQueue = queue.NewTimerQueue(func(rawGCReply interface{}) {
 		myGcReply, ok := rawGCReply.(*gcReply)
 		if !ok {
 			panic("wtf, failed type assertion!")

--- a/client/docker_test_helpers.go
+++ b/client/docker_test_helpers.go
@@ -44,9 +44,9 @@ func registerClientForShutdown(c *thin.ThinClient) {
 }
 
 // setupThinClientWithConfig creates and connects a thin client with the specified configuration
-func setupThinClientWithConfig(t *testing.T, configFile, logLevel string) *thin.ThinClient {
+func setupThinClientWithConfig(tb testing.TB, configFile, logLevel string) *thin.ThinClient {
 	cfg, err := thin.LoadFile(configFile)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	logging := &config.Logging{
 		Disable: false,
@@ -55,18 +55,18 @@ func setupThinClientWithConfig(t *testing.T, configFile, logLevel string) *thin.
 	}
 
 	client := thin.NewThinClient(cfg, logging)
-	t.Log("thin client Dialing")
+	tb.Log("thin client Dialing")
 	err = client.Dial()
-	require.NoError(t, err)
-	t.Log("thin client connected")
+	require.NoError(tb, err)
+	tb.Log("thin client connected")
 
 	registerClientForShutdown(client)
 	return client
 }
 
 // setupThinClient creates and connects a thin client with default test configuration
-func setupThinClient(t *testing.T) *thin.ThinClient {
-	return setupThinClientWithConfig(t, defaultThinClientConfigFile, defaultTestLogLevel)
+func setupThinClient(tb testing.TB) *thin.ThinClient {
+	return setupThinClientWithConfig(tb, defaultThinClientConfigFile, defaultTestLogLevel)
 }
 
 // validatePKIDocument gets and validates the PKI document from a thin client

--- a/client/fairness_test.go
+++ b/client/fairness_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/katzenpost/katzenpost/core/log"
 	sphinxConstants "github.com/katzenpost/katzenpost/core/sphinx/constants"
+	"github.com/katzenpost/katzenpost/core/queue"
 )
 
 // newTestIncomingConn builds an incomingConn with just the fields the
@@ -216,7 +217,7 @@ func TestEnqueueResend_ReschedulesWhenClientQueueFull(t *testing.T) {
 	d := newSchedulerDaemon(t, l)
 	// Real arqTimerQueue with a no-op action: we inspect Len() without
 	// running any callback.
-	d.arqTimerQueue = NewTimerQueue(func(interface{}) {})
+	d.arqTimerQueue = queue.NewTimerQueue(func(interface{}) {})
 
 	// Fill A's resendCh.
 	var filler1, filler2 [sphinxConstants.SURBIDLength]byte
@@ -239,9 +240,9 @@ func TestEnqueueResend_ReschedulesWhenClientQueueFull(t *testing.T) {
 
 	require.Len(t, a.resendCh, resendBuf, "resendCh should still be full")
 	// The TimerQueue worker is not running in this test, so the push
-	// remains in pushCh (where Push enqueues synchronously) rather than
-	// in the internal heap that Len() exposes.
-	require.Len(t, d.arqTimerQueue.pushCh, 1, "retry must be re-armed on arqTimerQueue")
+	// remains in the push channel (where Push enqueues synchronously)
+	// rather than in the internal heap that Len() exposes.
+	require.Equal(t, 1, d.arqTimerQueue.PushChLen(), "retry must be re-armed on arqTimerQueue")
 	d.replyLock.Lock()
 	_, ok := d.arqSurbIDMap[surbID]
 	d.replyLock.Unlock()

--- a/client/pigeonhole_cancel_race_test.go
+++ b/client/pigeonhole_cancel_race_test.go
@@ -14,6 +14,7 @@ import (
 
 	sphinxConstants "github.com/katzenpost/katzenpost/core/sphinx/constants"
 	"github.com/katzenpost/katzenpost/client/thin"
+	"github.com/katzenpost/katzenpost/core/queue"
 )
 
 // newCancelRaceDaemon constructs the minimum Daemon shape the three
@@ -23,7 +24,7 @@ import (
 func newCancelRaceDaemon(t *testing.T) (*Daemon, *[AppIDLength]byte, chan *Response) {
 	t.Helper()
 	d, appID, responseCh := setupDaemonWithMockConn(t)
-	d.arqTimerQueue = NewTimerQueue(func(_ interface{}) {})
+	d.arqTimerQueue = queue.NewTimerQueue(func(_ interface{}) {})
 	d.arqTimerQueue.Start()
 	t.Cleanup(func() { d.arqTimerQueue.Halt() })
 	return d, appID, responseCh
@@ -142,7 +143,7 @@ func stubDaemonForHandleReply(t *testing.T) *Daemon {
 		replyLock:          new(sync.Mutex),
 		arqSurbIDMap:       make(map[[sphinxConstants.SURBIDLength]byte]*ARQMessage),
 		arqEnvelopeHashMap: make(map[[32]byte]*[sphinxConstants.SURBIDLength]byte),
-		arqTimerQueue:      NewTimerQueue(func(_ interface{}) {}),
+		arqTimerQueue:      queue.NewTimerQueue(func(_ interface{}) {}),
 		log:                logging.MustGetLogger("test"),
 	}
 	d.arqTimerQueue.Start()

--- a/client/pigeonhole_latency_bench_test.go
+++ b/client/pigeonhole_latency_bench_test.go
@@ -1,0 +1,92 @@
+//go:build latency_bench && docker_test
+
+// SPDX-FileCopyrightText: Copyright (C) 2026 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package client
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/hpqc/rand"
+)
+
+// BenchmarkPigeonholeWrite measures end-to-end latency for one
+// pigeonhole write (courier acceptance / replica reply), with no
+// artificial delays. Requires a running docker mixnet.
+//
+// Build tags: latency_bench && docker_test. Both are required so the
+// benchmark stays out of CI (which sets only docker_test) and is run
+// only by hand. Invoke as:
+//
+//	go test -tags='docker_test latency_bench' \
+//	    -bench=BenchmarkPigeonholeWrite -count=1 -run=^$ \
+//	    -benchtime=20x ./client/
+//
+// Reports b.N's median and p95 in milliseconds via b.ReportMetric so
+// pre-change and post-change runs may be compared directly.
+//
+// The existing pigeonhole integration tests are unsuitable for this
+// purpose: they include a 30-second sleep between write and read to
+// bridge the write→replication→read race
+// (client/pigeonhole_docker_test.go:101). A latency benchmark cannot
+// tolerate that.
+func BenchmarkPigeonholeWrite(b *testing.B) {
+	client := setupThinClient(b)
+	defer client.Close()
+
+	seed := make([]byte, 32)
+	_, err := rand.Reader.Read(seed)
+	require.NoError(b, err)
+
+	writeCap, _, msgIdx, err := client.NewKeypair(seed)
+	require.NoError(b, err)
+	require.NotNil(b, writeCap)
+	require.NotNil(b, msgIdx)
+
+	// Sized over 29 bytes so the courier returns ReplyTypePayload rather
+	// than ReplyTypeAck. See pigeonhole_docker_test.go:74 for the
+	// rationale.
+	payload := []byte(
+		"benchmark payload, sized over twenty-nine bytes to elicit ReplyTypePayload from the courier",
+	)
+
+	durations := make([]time.Duration, 0, b.N)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		ciphertext, envDesc, envHash, nextIdx, err :=
+			client.EncryptWrite(payload, writeCap, msgIdx)
+		require.NoError(b, err)
+		replyIdx := uint8(0)
+		b.StartTimer()
+
+		start := time.Now()
+		_, err = client.StartResendingEncryptedMessage(
+			nil, writeCap, nil, &replyIdx, envDesc, ciphertext, envHash,
+		)
+		elapsed := time.Since(start)
+
+		require.NoError(b, err)
+
+		b.StopTimer()
+		durations = append(durations, elapsed)
+		msgIdx = nextIdx
+		b.StartTimer()
+	}
+	b.StopTimer()
+
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+	median := durations[len(durations)/2]
+	p95 := durations[(len(durations)*95)/100]
+	if p95 >= time.Duration(len(durations)) {
+		p95 = durations[len(durations)-1]
+	}
+	b.ReportMetric(float64(median.Milliseconds()), "median_ms")
+	b.ReportMetric(float64(p95.Milliseconds()), "p95_ms")
+}

--- a/client/send_integration_test.go
+++ b/client/send_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/katzenpost/katzenpost/core/sphinx/geo"
 	pigeonholeGeo "github.com/katzenpost/katzenpost/pigeonhole/geo"
 	replicaCommon "github.com/katzenpost/katzenpost/replica/common"
+	"github.com/katzenpost/katzenpost/core/queue"
 )
 
 // createFullMockPKIDocument creates a PKI document with gateway, service nodes,
@@ -236,9 +237,9 @@ func setupFullClient(t *testing.T) (*Daemon, *Client, *[AppIDLength]byte, chan *
 		decoys:                    make(map[[sphinxConstants.SURBIDLength]byte]replyDescriptor),
 		replyLock:          new(sync.Mutex),
 		secureRand:                rand.NewMath(),
-		timerQueue:                NewTimerQueue(func(interface{}) {}),
+		timerQueue:                queue.NewTimerQueue(func(interface{}) {}),
 		gcSurbIDCh:                make(chan *[sphinxConstants.SURBIDLength]byte, 10),
-		arqTimerQueue:             NewTimerQueue(func(interface{}) {}),
+		arqTimerQueue:             queue.NewTimerQueue(func(interface{}) {}),
 	}
 	d.timerQueue.Start()
 	d.arqTimerQueue.Start()

--- a/client/timer_queue_test.go
+++ b/client/timer_queue_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/katzenpost/hpqc/rand"
 
 	sConstants "github.com/katzenpost/katzenpost/core/sphinx/constants"
+	"github.com/katzenpost/katzenpost/core/queue"
 )
 
 func TestTimerQueueHalt(t *testing.T) {
@@ -22,7 +23,7 @@ func TestTimerQueueHalt(t *testing.T) {
 	noop := func(ignored interface{}) {
 		t.Log("action")
 	}
-	q := NewTimerQueue(noop)
+	q := queue.NewTimerQueue(noop)
 	q.Start()
 	surbID := [sConstants.SURBIDLength]byte{}
 	_, err := rand.Reader.Read(surbID[:])
@@ -67,7 +68,7 @@ func TestTimerQueuePush(t *testing.T) {
 			actionsLock.Unlock()
 		}
 	}
-	q := NewTimerQueue(noop)
+	q := queue.NewTimerQueue(noop)
 	q.Start()
 
 	require.Equal(t, 0, q.Len())

--- a/client/timer_queue_unit_test.go
+++ b/client/timer_queue_unit_test.go
@@ -9,11 +9,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/katzenpost/katzenpost/core/queue"
 )
 
 func TestTimerQueuePeekPopLen(t *testing.T) {
 	noop := func(interface{}) {}
-	q := NewTimerQueue(noop)
+	q := queue.NewTimerQueue(noop)
 	// Don't start the worker — test the queue data structure directly
 
 	require.Equal(t, 0, q.Len())
@@ -21,9 +22,9 @@ func TestTimerQueuePeekPopLen(t *testing.T) {
 	require.Nil(t, q.Pop())
 
 	// Enqueue directly (bypassing Push/pushCh/worker)
-	q.queue.Enqueue(300, "third")
-	q.queue.Enqueue(100, "first")
-	q.queue.Enqueue(200, "second")
+	q.EnqueueDirect(300, "third")
+	q.EnqueueDirect(100, "first")
+	q.EnqueueDirect(200, "second")
 
 	require.Equal(t, 3, q.Len())
 
@@ -49,12 +50,12 @@ func TestTimerQueuePeekPopLen(t *testing.T) {
 
 func TestTimerQueueCancelRemovesMatchingEntry(t *testing.T) {
 	noop := func(interface{}) {}
-	q := NewTimerQueue(noop)
+	q := queue.NewTimerQueue(noop)
 	// Don't start the worker — test the heap primitive directly.
 
-	q.queue.Enqueue(100, "a")
-	q.queue.Enqueue(200, "b")
-	q.queue.Enqueue(300, "c")
+	q.EnqueueDirect(100, "a")
+	q.EnqueueDirect(200, "b")
+	q.EnqueueDirect(300, "c")
 	require.Equal(t, 3, q.Len())
 
 	require.True(t, q.Cancel("b"))
@@ -73,10 +74,10 @@ func TestTimerQueueCancelRemovesMatchingEntry(t *testing.T) {
 
 func TestTimerQueueCancelAbsentValueReturnsFalse(t *testing.T) {
 	noop := func(interface{}) {}
-	q := NewTimerQueue(noop)
+	q := queue.NewTimerQueue(noop)
 
-	q.queue.Enqueue(100, "a")
-	q.queue.Enqueue(200, "b")
+	q.EnqueueDirect(100, "a")
+	q.EnqueueDirect(200, "b")
 
 	require.False(t, q.Cancel("never-pushed"))
 	require.Equal(t, 2, q.Len())
@@ -84,15 +85,15 @@ func TestTimerQueueCancelAbsentValueReturnsFalse(t *testing.T) {
 
 func TestTimerQueueCancelPointerIdentity(t *testing.T) {
 	noop := func(interface{}) {}
-	q := NewTimerQueue(noop)
+	q := queue.NewTimerQueue(noop)
 
 	// Two distinct pointers to byte arrays with identical contents.
 	p1 := &[4]byte{1, 2, 3, 4}
 	p2 := &[4]byte{1, 2, 3, 4}
 	require.NotSame(t, p1, p2)
 
-	q.queue.Enqueue(100, p1)
-	q.queue.Enqueue(200, p2)
+	q.EnqueueDirect(100, p1)
+	q.EnqueueDirect(200, p2)
 	require.Equal(t, 2, q.Len())
 
 	require.True(t, q.Cancel(p1))
@@ -111,7 +112,7 @@ func TestTimerQueueCancelDoesNotFireAction(t *testing.T) {
 		fired.Add(1)
 	}
 
-	q := NewTimerQueue(action)
+	q := queue.NewTimerQueue(action)
 	q.Start()
 	defer func() {
 		go q.Halt()
@@ -145,7 +146,7 @@ func TestTimerQueueWorkerFiresCallback(t *testing.T) {
 		}
 	}
 
-	q := NewTimerQueue(action)
+	q := queue.NewTimerQueue(action)
 	q.Start()
 	defer func() {
 		go q.Halt()

--- a/core/queue/timer_queue.go
+++ b/core/queue/timer_queue.go
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: © 2023 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only
-package client
+
+package queue
 
 import (
 	"math"
 	"sync"
 	"time"
 
-	"github.com/katzenpost/katzenpost/core/queue"
 	"github.com/katzenpost/katzenpost/core/worker"
 )
 
@@ -19,7 +19,7 @@ type pushedItem struct {
 type TimerQueue struct {
 	worker.Worker
 
-	queue  *queue.PriorityQueue
+	queue  *PriorityQueue
 	timer  *time.Timer
 	mutex  sync.RWMutex
 	action func(interface{})
@@ -35,7 +35,7 @@ func NewTimerQueue(action func(interface{})) *TimerQueue {
 	// isn't blocking on it's select statement's timer channel.
 	return &TimerQueue{
 		timer:  time.NewTimer(0),
-		queue:  queue.New(),
+		queue:  New(),
 		action: action,
 		pushCh: make(chan *pushedItem, 100),
 	}
@@ -45,7 +45,7 @@ func (t *TimerQueue) Start() {
 	t.Go(t.worker)
 }
 
-func (t *TimerQueue) Peek() *queue.Entry {
+func (t *TimerQueue) Peek() *Entry {
 	t.mutex.RLock()
 	defer t.mutex.RUnlock()
 	return t.queue.Peek()
@@ -92,6 +92,24 @@ func (t *TimerQueue) Push(priority uint64, value interface{}) {
 	}:
 	case <-t.HaltCh():
 	}
+}
+
+// PushChLen reports the number of items presently buffered in the push
+// channel waiting to be ingested by the worker. Intended for tests that
+// wish to assert "items were pushed but the worker has not yet drained
+// them"; production callers should not depend on this value.
+func (t *TimerQueue) PushChLen() int {
+	return len(t.pushCh)
+}
+
+// EnqueueDirect inserts an entry directly into the internal heap,
+// bypassing the push channel and any worker buffering. Intended for
+// tests that wish to populate the heap without running the worker.
+// Holds the queue's write lock for the duration of the call.
+func (t *TimerQueue) EnqueueDirect(priority uint64, value interface{}) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	t.queue.Enqueue(priority, value)
 }
 
 func (t *TimerQueue) worker() {

--- a/courier/server/outgoing_conn.go
+++ b/courier/server/outgoing_conn.go
@@ -305,6 +305,39 @@ func (c *outgoingConn) dialAddress(dialCtx *workerContext, dialer *net.Dialer, a
 	return conn, false
 }
 
+// applyPKILambdaR tries to push a non-zero LambdaR (and its max delay)
+// into the sender's ExpDist. The cached PKI document is consulted
+// first; if it is missing or carries an unusable LambdaR, we force a
+// fresh fetch from the directory authorities and try once more.
+// Returns true if and only if UpdateRate was called with a usable
+// rate. The caller must not activate the sender on a false return,
+// because ExpDist with averageRate == 0 silently never ticks.
+func (c *outgoingConn) applyPKILambdaR() bool {
+	if c.tryUpdateRateFromCache() {
+		return true
+	}
+	c.log.Warningf("PKI cache lacks a usable LambdaR; force-fetching")
+	if err := c.co.Server().PKI.ForceFetchPKI(); err != nil {
+		c.log.Errorf("force-fetch PKI failed: %v", err)
+		return false
+	}
+	return c.tryUpdateRateFromCache()
+}
+
+func (c *outgoingConn) tryUpdateRateFromCache() bool {
+	doc := c.co.Server().PKI.LastCachedPKIDocument()
+	if doc == nil {
+		return false
+	}
+	rate, err := kpcommon.LambdaRateToMs(doc.LambdaR)
+	if err != nil {
+		c.log.Errorf("Invalid LambdaR %v in PKI document: %v", doc.LambdaR, err)
+		return false
+	}
+	c.sender.UpdateRate(rate, doc.LambdaRMaxDelay)
+	return true
+}
+
 func (c *outgoingConn) onConnEstablished(conn net.Conn, closeCh <-chan struct{}) (wasHalted bool) {
 	defer func() {
 		c.log.Debugf("TCP connection closed. (wasHalted: %v)", wasHalted)
@@ -317,13 +350,15 @@ func (c *outgoingConn) onConnEstablished(conn net.Conn, closeCh <-chan struct{})
 	}
 	defer w.Close()
 
-	if doc := c.co.Server().PKI.LastCachedPKIDocument(); doc != nil {
-		rate, err := kpcommon.LambdaRateToMs(doc.LambdaR)
-		if err != nil {
-			c.log.Errorf("Invalid LambdaR %v in PKI document: %v", doc.LambdaR, err)
-		} else {
-			c.sender.UpdateRate(rate, doc.LambdaRMaxDelay)
-		}
+	// We must call UpdateRate with a real LambdaR before activating the
+	// sender. Skipping it (or accepting a zero LambdaR from a stale or
+	// uninitialised cache) leaves ExpDist.averageRate at 0, in which
+	// case the sender's worker schedules its next tick at MaxInt64 and
+	// never fires for the lifetime of this session. That manifests as
+	// a courier whose outbound stream silently dries up.
+	if !c.applyPKILambdaR() {
+		c.log.Errorf("aborting connection: unable to obtain a non-zero LambdaR from the PKI")
+		return
 	}
 	c.sender.UpdateConnectionStatus(true)
 	defer c.sender.UpdateConnectionStatus(false)

--- a/replica/handlers.go
+++ b/replica/handlers.go
@@ -42,7 +42,7 @@ func (c *incomingConn) createReplicaMessageReply(nikeScheme string, errorCode ui
 	}
 }
 
-func (c *incomingConn) onReplicaCommand(rawCmd commands.Command, inCh chan *senderRequest) (*senderRequest, bool) {
+func (c *incomingConn) onReplicaCommand(rawCmd commands.Command, emitter *delayedReplyEmitter) (*senderRequest, bool) {
 	if _, isDecoy := rawCmd.(*commands.ReplicaDecoy); !isDecoy {
 		c.log.Debugf("onReplicaCommand received command type: %T with value: %+v", rawCmd, rawCmd)
 	}
@@ -74,6 +74,7 @@ func (c *incomingConn) onReplicaCommand(rawCmd commands.Command, inCh chan *send
 		c.log.Debugf("Processing ReplicaMessage command with ciphertext length: %d", len(cmd.Ciphertext))
 		// Handle asynchronously so proxy requests don't block the
 		// command loop. Semaphore limits active handlers.
+		recvAt := time.Now()
 		c.l.server.Add(1)
 		go func() {
 			defer c.l.server.Done()
@@ -98,12 +99,7 @@ func (c *incomingConn) onReplicaCommand(rawCmd commands.Command, inCh chan *send
 				return
 			default:
 			}
-			select {
-			case inCh <- &senderRequest{ReplicaMessageReply: resp}:
-			case <-c.l.closeAllCh:
-				c.log.Debugf("Terminating gracefully.")
-				return
-			}
+			emitter.Enqueue(&senderRequest{ReplicaMessageReply: resp, recvAt: recvAt})
 		}()
 		return nil, true
 	default:

--- a/replica/incoming_conn.go
+++ b/replica/incoming_conn.go
@@ -24,7 +24,6 @@ import (
 	"github.com/katzenpost/hpqc/rand"
 	"github.com/katzenpost/hpqc/sign"
 
-	"github.com/katzenpost/katzenpost/common"
 	"github.com/katzenpost/katzenpost/core/epochtime"
 	"github.com/katzenpost/katzenpost/core/pki"
 	sConstants "github.com/katzenpost/katzenpost/core/sphinx/constants"
@@ -32,7 +31,6 @@ import (
 	"github.com/katzenpost/katzenpost/core/wire"
 	"github.com/katzenpost/katzenpost/core/wire/commands"
 	"github.com/katzenpost/katzenpost/core/worker"
-	"github.com/katzenpost/katzenpost/replica/instrument"
 )
 
 var incomingConnID uint64
@@ -105,27 +103,13 @@ func (c *incomingConn) worker() {
 		return
 	}
 
-	// Constant time message output whether or not decoy traffic
-	// is enabled.
-	inCh := make(chan *senderRequest, c.l.server.cfg.IncomingQueueSize)
+	// Egress channel: the emitter pushes scheduled replies here; the
+	// egressSender goroutine drains it onto the wire as fast as the
+	// session allows. There is no longer a paced consumer with a
+	// bounded inbound queue and an explicit outbound queue: the
+	// TimerQueue inside the emitter is the only buffer.
 	outCh := make(chan *senderRequest, c.l.server.cfg.IncomingQueueSize)
-	nikeScheme := nikeschemes.ByName(c.l.server.cfg.ReplicaNIKEScheme)
-	cmds := commands.NewStorageReplicaCommands(c.geo, nikeScheme)
-	sender := newSender(inCh, outCh, c.l.server.cfg.DisableDecoyTraffic, c.l.server.logBackend, cmds, fmt.Sprintf("%d", c.id))
-
-	// LambdaR is a near-constant network tunable, so a one-epoch-stale doc is
-	// fine here. Skip the UpdateRate call entirely if no doc is cached;
-	// the sender will use its previously-configured rate (or stay idle on
-	// first-ever connect) and the periodic resweep will catch up.
-	if doc := c.l.server.PKIWorker.LastCachedPKIDocument(); doc != nil {
-		rate, err := common.LambdaRateToMs(doc.LambdaR)
-		if err != nil {
-			c.log.Errorf("Invalid LambdaR %v in PKI document: %v", doc.LambdaR, err)
-		} else {
-			sender.UpdateRate(rate, doc.LambdaRMaxDelay)
-		}
-	}
-	sender.UpdateConnectionStatus(true)
+	emitter := newDelayedReplyEmitter(outCh, c.l.server.logBackend, fmt.Sprintf("%d", c.id))
 
 	// Channel to signal egress sender to drain and exit
 	egressDoneCh := make(chan struct{})
@@ -139,19 +123,18 @@ func (c *incomingConn) worker() {
 	}()
 
 	// Run command processing loop synchronously - blocks until connection closes
-	c.processCommands(session, creds, inCh)
+	c.processCommands(session, creds, emitter)
 
 	// Connection closed - begin shutdown sequence:
-	// 1. Mark as disconnected (stops sender from generating new decoys)
-	sender.UpdateConnectionStatus(false)
+	// 1. Halt the emitter so its TimerQueue worker stops scheduling
+	//    new sends and the action goroutines unblock via the
+	//    TimerQueue's halt channel.
+	emitter.Halt()
 
-	// 2. Halt sender to stop its worker goroutine
-	sender.Halt()
-
-	// 3. Signal egressSender to drain remaining messages and exit
+	// 2. Signal egressSender to drain remaining messages and exit
 	close(egressDoneCh)
 
-	// 4. Wait for egressSender to finish
+	// 3. Wait for egressSender to finish
 	wg.Wait()
 }
 
@@ -312,7 +295,7 @@ func (c *incomingConn) closeOldConnections() error {
 }
 
 // processCommands handles the main command processing loop
-func (c *incomingConn) processCommands(session *wire.Session, creds *wire.PeerCredentials, inCh chan *senderRequest) {
+func (c *incomingConn) processCommands(session *wire.Session, creds *wire.PeerCredentials, emitter *delayedReplyEmitter) {
 	// Start the reauthenticate ticker.
 	reauthMs := time.Duration(c.l.server.cfg.ReauthInterval) * time.Millisecond
 	reauth := time.NewTicker(reauthMs)
@@ -332,8 +315,10 @@ func (c *incomingConn) processCommands(session *wire.Session, creds *wire.PeerCr
 			continue
 		}
 
+		recvAt := time.Now()
+
 		// Handle all of the storage replica commands.
-		resp, allGood := c.onReplicaCommand(rawCmd, inCh)
+		resp, allGood := c.onReplicaCommand(rawCmd, emitter)
 		if !allGood {
 			c.log.Debugf("Got a disconnect or we failed to handle replica command: %v", rawCmd)
 			return
@@ -341,19 +326,15 @@ func (c *incomingConn) processCommands(session *wire.Session, creds *wire.PeerCr
 
 		if resp != nil {
 			if resp.ReplicaDecoy == nil {
-				c.log.Debugf("Sending response to inCh: %T", resp)
+				c.log.Debugf("Enqueueing response: %T", resp)
 			}
 			select {
 			case <-c.l.closeAllCh:
 				return
 			default:
 			}
-			select {
-			case inCh <- resp:
-				instrument.IncomingQueueLength(fmt.Sprintf("%d", c.id), len(inCh))
-			case <-c.l.closeAllCh:
-				return
-			}
+			resp.recvAt = recvAt
+			emitter.Enqueue(resp)
 		}
 	}
 }

--- a/replica/incoming_conn_test.go
+++ b/replica/incoming_conn_test.go
@@ -185,8 +185,10 @@ func TestIncomingConn(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(ids), 0)
 
-	dummyCh := make(chan *senderRequest, 10)
-	replyCommand, ok := inConn.onReplicaCommand(new(commands.NoOp), dummyCh)
+	dummyOut := make(chan *senderRequest, 10)
+	dummyEmitter := newDelayedReplyEmitter(dummyOut, server.logBackend, "test")
+	defer dummyEmitter.Halt()
+	replyCommand, ok := inConn.onReplicaCommand(new(commands.NoOp), dummyEmitter)
 	require.True(t, ok)
 	require.Nil(t, replyCommand)
 

--- a/replica/instrument/prometheus.go
+++ b/replica/instrument/prometheus.go
@@ -6,6 +6,7 @@ package instrument
 import (
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -20,16 +21,30 @@ var (
 			Help: "Number of decoy commands received from couriers",
 		},
 	)
-	incomingDecoysSent = prometheus.NewCounter(
+	incomingDecoyRepliesEmitted = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "katzenpost_replica_incoming_decoys_sent_total",
-			Help: "Number of decoy responses sent back to couriers",
+			Name: "katzenpost_replica_incoming_decoy_replies_emitted_total",
+			Help: "Number of decoy replies (responses to peer decoys) emitted by the delayed-reply scheduler on incoming connections.",
 		},
 	)
-	incomingMessagesSent = prometheus.NewCounter(
+	incomingRealRepliesEmitted = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "katzenpost_replica_incoming_messages_sent_total",
-			Help: "Number of real responses sent back to couriers",
+			Name: "katzenpost_replica_incoming_real_replies_emitted_total",
+			Help: "Number of real replies (ReplicaWriteReply, ReplicaMessageReply) emitted by the delayed-reply scheduler on incoming connections.",
+		},
+	)
+	incomingRealReplyLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "katzenpost_replica_incoming_real_reply_latency_seconds",
+			Help:    "Wall-clock latency from inbound real-command receipt to outbound real-reply emission on incoming connections (i.e. processing time plus the per-reply uniform jitter).",
+			Buckets: prometheus.DefBuckets,
+		},
+	)
+	incomingDecoyReplyLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "katzenpost_replica_incoming_decoy_reply_latency_seconds",
+			Help:    "Wall-clock latency from inbound peer-decoy receipt to outbound decoy-reply emission on incoming connections (i.e. processing time plus the per-reply uniform jitter).",
+			Buckets: prometheus.DefBuckets,
 		},
 	)
 	incomingQueueLength = prometheus.NewGaugeVec(
@@ -91,8 +106,10 @@ var (
 func StartPrometheusListener(address string) {
 	registerOnce.Do(func() {
 		prometheus.MustRegister(incomingDecoysReceived)
-		prometheus.MustRegister(incomingDecoysSent)
-		prometheus.MustRegister(incomingMessagesSent)
+		prometheus.MustRegister(incomingDecoyRepliesEmitted)
+		prometheus.MustRegister(incomingRealRepliesEmitted)
+		prometheus.MustRegister(incomingRealReplyLatency)
+		prometheus.MustRegister(incomingDecoyReplyLatency)
 		prometheus.MustRegister(incomingQueueLength)
 		prometheus.MustRegister(replicationDispatched)
 		prometheus.MustRegister(replicationLatency)
@@ -114,14 +131,20 @@ func IncomingDecoysReceived() {
 	incomingDecoysReceived.Inc()
 }
 
-// IncomingDecoysSent increments the counter for decoy responses sent back to couriers
-func IncomingDecoysSent() {
-	incomingDecoysSent.Inc()
+// IncomingDecoyReplyEmitted increments the counter for decoy replies
+// (responses to peer decoys) emitted on incoming connections, and
+// records the per-reply latency.
+func IncomingDecoyReplyEmitted(latency time.Duration) {
+	incomingDecoyRepliesEmitted.Inc()
+	incomingDecoyReplyLatency.Observe(latency.Seconds())
 }
 
-// IncomingMessagesSent increments the counter for real responses sent back to couriers
-func IncomingMessagesSent() {
-	incomingMessagesSent.Inc()
+// IncomingRealReplyEmitted increments the counter for real replies
+// (ReplicaWriteReply, ReplicaMessageReply) emitted on incoming
+// connections, and records the per-reply latency.
+func IncomingRealReplyEmitted(latency time.Duration) {
+	incomingRealRepliesEmitted.Inc()
+	incomingRealReplyLatency.Observe(latency.Seconds())
 }
 
 // IncomingQueueLength sets the incoming queue depth gauge for a peer

--- a/replica/outgoing_conn.go
+++ b/replica/outgoing_conn.go
@@ -398,16 +398,14 @@ func (c *outgoingConn) onConnEstablished(conn net.Conn, closeCh <-chan struct{})
 	cmds := commands.NewStorageReplicaCommands(c.geo, nikeScheme)
 	sender := newOutgoingSender(c.ch, outCh, c.co.Server().cfg.DisableDecoyTraffic, c.co.Server().LogBackend(), cmds, c.dst.Name)
 
-	// LambdaR is near-constant; tolerate a one-epoch-stale doc. Skip the
-	// UpdateRate call if nothing is cached — the sender will use its prior
-	// rate (or stay idle on first-ever connect) and the resweep will catch up.
-	if doc := c.co.Server().PKIWorker.LastCachedPKIDocument(); doc != nil {
-		rate, err := common.LambdaRateToMs(doc.LambdaR)
-		if err != nil {
-			c.log.Errorf("Invalid LambdaR %v in PKI document: %v", doc.LambdaR, err)
-		} else {
-			sender.UpdateRate(rate, doc.LambdaRMaxDelay)
-		}
+	// We must call UpdateRate with a real LambdaR before activating the
+	// sender. Skipping it (or accepting a zero LambdaR from a stale or
+	// uninitialised cache) leaves ExpDist.averageRate at 0 and the
+	// sender silently never ticks for the lifetime of this session.
+	if !applyOutgoingLambdaR(sender, c.co.Server().PKIWorker, c.log) {
+		c.log.Errorf("aborting outgoing connection: unable to obtain a non-zero LambdaR from the PKI")
+		sender.Halt()
+		return
 	}
 	sender.UpdateConnectionStatus(true)
 
@@ -587,4 +585,35 @@ func newOutgoingConn(co GenericConnector, dst *cpki.ReplicaDescriptor, geo *geo.
 	// the connection map.
 
 	return c
+}
+
+// applyOutgoingLambdaR pushes a non-zero LambdaR into the sender's
+// ExpDist before the sender is activated. It tries the PKI cache
+// first; if that yields no usable rate, it forces a fresh PKI fetch
+// and tries once more. Returns true iff UpdateRate was successfully
+// called with a real rate.
+func applyOutgoingLambdaR(sender *outgoingSender, pkiWorker *PKIWorker, log *logging.Logger) bool {
+	if tryUpdateOutgoingRateFromCache(sender, pkiWorker, log) {
+		return true
+	}
+	log.Warningf("PKI cache lacks a usable LambdaR; force-fetching")
+	if err := pkiWorker.ForceFetchPKI(); err != nil {
+		log.Errorf("force-fetch PKI failed: %v", err)
+		return false
+	}
+	return tryUpdateOutgoingRateFromCache(sender, pkiWorker, log)
+}
+
+func tryUpdateOutgoingRateFromCache(sender *outgoingSender, pkiWorker *PKIWorker, log *logging.Logger) bool {
+	doc := pkiWorker.LastCachedPKIDocument()
+	if doc == nil {
+		return false
+	}
+	rate, err := common.LambdaRateToMs(doc.LambdaR)
+	if err != nil {
+		log.Errorf("Invalid LambdaR %v in PKI document: %v", doc.LambdaR, err)
+		return false
+	}
+	sender.UpdateRate(rate, doc.LambdaRMaxDelay)
+	return true
 }

--- a/replica/sender.go
+++ b/replica/sender.go
@@ -5,21 +5,29 @@ package replica
 
 import (
 	"fmt"
+	mrand "math/rand"
+	"sync"
+	"time"
 
 	"gopkg.in/op/go-logging.v1"
 
 	"github.com/katzenpost/katzenpost/common"
 	"github.com/katzenpost/katzenpost/core/log"
+	"github.com/katzenpost/katzenpost/core/queue"
 	"github.com/katzenpost/katzenpost/core/wire/commands"
 	"github.com/katzenpost/katzenpost/core/worker"
 	"github.com/katzenpost/katzenpost/replica/instrument"
 )
 
-// senderRequest represents a command to send to a peer
+// senderRequest represents a command to send to a peer.
+// recvAt is set by processCommands at the moment the inbound command
+// finished decoding; the emitter uses it to record the per-reply
+// latency histogram (t_emit - t_recv) for the privacy gate.
 type senderRequest struct {
 	ReplicaDecoy        *commands.ReplicaDecoy
 	ReplicaWriteReply   *commands.ReplicaWriteReply
 	ReplicaMessageReply *commands.ReplicaMessageReply
+	recvAt              time.Time
 }
 
 func (s *senderRequest) command() commands.Command {
@@ -35,102 +43,87 @@ func (s *senderRequest) command() commands.Command {
 	return nil
 }
 
-// sender is essentially a channel pipeline from "in" to "out" channels where
-// the delay between sending is controlled by an exponential distribution
-// and we always send something every time the exponential distribution ticks.
-// if there are no messages within the "in" channel then we send a decoy message.
-type sender struct {
-	worker.Worker
+// replyJitterMax bounds the per-reply uniform random delay applied by
+// delayedReplyEmitter on incoming connections. This generalises §5.4 of
+// the Echomix paper ("Each reply is independently delayed, with delays
+// sampled from a uniform distribution") to all replies, so that
+// per-reply latency hides processing-time variance and the wire stays
+// at a constant Poisson rate driven by the peer's command rate.
+//
+// Expected steady-state TimerQueue depth per connection by Little's
+// Law is LambdaR * replyJitterMax / 2, which at the docker default
+// LambdaR = 0.005 (5 events/s per pair) is about 0.125 items.
+const replyJitterMax = 50 * time.Millisecond
 
-	log              *logging.Logger
-	in               chan *senderRequest
-	out              chan *senderRequest
-	sendQueryOrDecoy *common.ExpDist
-	disableDecoys    bool
-	peerName         string
-
-	commands *commands.Commands
+// delayedReplyEmitter takes the place of the older paced "sender" on
+// the responder side of every incoming connection. processCommands
+// calls Enqueue for each reply (real or decoy-in-response-to-peer-decoy),
+// the emitter draws an i.i.d. delay from Uniform[0, replyJitterMax]
+// and pushes the reply into a TimerQueue keyed by ready-at time.
+// The TimerQueue's worker emits each reply to the egress channel when
+// its delay elapses. There is no LambdaR-paced consumer here; the
+// reply rate equals the peer's command rate by 1:1 correspondence and
+// no fresh decoys are generated on this side.
+type delayedReplyEmitter struct {
+	log      *logging.Logger
+	out      chan *senderRequest
+	tq       *queue.TimerQueue
+	rng      *mrand.Rand
+	rngLock  sync.Mutex
+	peerName string
 }
 
-// newSender starts it's worker but does nothing by default until
-// methods UpdateConnectionStatus and UpdateRates are called.
-// The worker only works when we have a connection and when we have
-// a rate set.
-func newSender(in chan *senderRequest, out chan *senderRequest, disableDecoys bool, logBackend *log.Backend, commands *commands.Commands, peerName string) *sender {
-	s := &sender{
-		log:              logBackend.GetLogger("replica/sender"),
-		in:               in,
-		out:              out,
-		sendQueryOrDecoy: common.NewExpDist(),
-		disableDecoys:    disableDecoys,
-		commands:         commands,
-		peerName:         peerName,
+func newDelayedReplyEmitter(out chan *senderRequest, logBackend *log.Backend, peerName string) *delayedReplyEmitter {
+	e := &delayedReplyEmitter{
+		log:      logBackend.GetLogger("replica/delayedReplyEmitter"),
+		out:      out,
+		rng:      mrand.New(mrand.NewSource(time.Now().UnixNano())),
+		peerName: peerName,
 	}
-	s.Go(s.worker)
-	return s
-}
-
-// halt is called by the worker() routine when it exits
-func (s *sender) halt() {
-	s.log.Debug("sender stopping ExpDist worker")
-	s.sendQueryOrDecoy.Halt()
-}
-
-func (s *sender) worker() {
-	defer s.halt() // shutdown expdist workers on return after read from HaltCh()
-	for {
+	e.tq = queue.NewTimerQueue(func(v interface{}) {
+		req := v.(*senderRequest)
+		// Halt path: tq.HaltCh() closes when Halt() is called, which
+		// lets a stuck send exit promptly when the connection retires.
 		select {
-		case <-s.HaltCh():
+		case e.out <- req:
+		case <-e.tq.HaltCh():
 			return
-		case <-s.sendQueryOrDecoy.OutCh():
-			// ExpDist tick - send real message if available, otherwise send decoy
-			var toSend *senderRequest
-			select {
-			case toSend = <-s.in:
-				instrument.IncomingMessagesSent()
-			case <-s.HaltCh():
-				return
-			default:
-				// No real response - send decoy if enabled
-				if s.disableDecoys {
-					instrument.IncomingQueueLength(s.peerName, len(s.in))
-					continue
-				}
-				toSend = &senderRequest{
-					ReplicaDecoy: &commands.ReplicaDecoy{
-						Cmds: s.commands,
-					},
-				}
-				instrument.IncomingDecoysSent()
-			}
-			instrument.IncomingQueueLength(s.peerName, len(s.in))
-			if toSend != nil {
-				select {
-				case s.out <- toSend:
-				case <-s.HaltCh():
-					return
-				}
-			}
 		}
-	}
+		latency := time.Since(req.recvAt)
+		if req.ReplicaDecoy != nil {
+			instrument.IncomingDecoyReplyEmitted(latency)
+		} else {
+			instrument.IncomingRealReplyEmitted(latency)
+		}
+	})
+	e.tq.Start()
+	return e
 }
 
-func (s *sender) UpdateConnectionStatus(isConnected bool) {
-	s.sendQueryOrDecoy.UpdateConnectionStatus(isConnected)
+// Enqueue schedules a reply for emission after a Uniform[0,
+// replyJitterMax] delay. Safe for concurrent use.
+func (e *delayedReplyEmitter) Enqueue(reply *senderRequest) {
+	e.rngLock.Lock()
+	delayNs := e.rng.Int63n(int64(replyJitterMax))
+	e.rngLock.Unlock()
+	readyAt := uint64(time.Now().UnixNano() + delayNs)
+	e.tq.Push(readyAt, reply)
+	instrument.IncomingQueueLength(e.peerName, e.tq.Len())
 }
 
-func (s *sender) UpdateRate(rate, maxDelay uint64) error {
-	if rate <= 0 {
-		return fmt.Errorf("invalid rate: %v", rate)
-	}
-	s.sendQueryOrDecoy.UpdateRate(rate, maxDelay)
-	return nil
-}
+// Halt stops the underlying TimerQueue and waits for its worker to
+// exit. Safe to call multiple times.
+func (e *delayedReplyEmitter) Halt() { e.tq.Halt() }
+
+// Len reports the depth of the underlying TimerQueue.
+func (e *delayedReplyEmitter) Len() int { return e.tq.Len() }
 
 // outgoingSender is a sender for outgoing replica-to-replica connections.
-// It works like the incoming sender but operates on commands.Command
-// rather than senderRequest. On each ExpDist tick it sends a real command
-// from the queue if available, otherwise a decoy.
+// It works on commands.Command. On each ExpDist tick it sends a real
+// command from the queue if available, otherwise a decoy. This is the
+// originator side; the producer (replication writes) operates at
+// rho << 1 so the M/M/1 boundary case that motivated the responder
+// redesign does not apply here.
 type outgoingSender struct {
 	worker.Worker
 


### PR DESCRIPTION
Very important fix to performance problems with courier + replica decoy traffic. Replaces the replica FIFO queue + poisson dispatcher with a reply scheduler which schedules each reply independently, just like the mix nodes do.