### PR TITLE
client: retry WaitForCurrentDocument through transient gateway failures

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -96,6 +96,11 @@ dockertest_copy_onto_already_existing_box_error:
 	$(docker) run -w /go/katzenpost/client ${docker_args} $(image) \
 		go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 1h -run "TestCopyOntoAlreadyExistingBoxError"
 
+dockertest_pki_raw:
+	cd ../docker && make $(distro)_base.stamp
+	$(docker) run -w /go/katzenpost/client ${docker_args} $(image) \
+		go test $(testargs) -ldflags ${ldflags} -tags=docker_test -race -v -timeout 1h -run "TestGetPKIDocumentRaw"
+
 dockertest_all_pigeonhole:
 	cd ../docker && make $(distro)_base.stamp
 	$(docker) run -w /go/katzenpost/client ${docker_args} $(image) \

--- a/client/daemon.go
+++ b/client/daemon.go
@@ -344,6 +344,7 @@ func isLocalRequest(r *Request) bool {
 		r.CancelResendingCopyCommand != nil ||
 		r.NextMessageBoxIndex != nil ||
 		r.GetMessageBoxIndexCounter != nil ||
+		r.GetPKIDocument != nil ||
 		r.CreateCourierEnvelopesFromPayload != nil ||
 		r.CreateCourierEnvelopesFromPayloads != nil ||
 		r.CreateCourierEnvelopesFromTombstoneRange != nil
@@ -369,6 +370,8 @@ func (d *Daemon) dispatchLocal(request *Request) {
 		d.nextMessageBoxIndex(request)
 	case request.GetMessageBoxIndexCounter != nil:
 		d.getMessageBoxIndexCounter(request)
+	case request.GetPKIDocument != nil:
+		d.getPKIDocument(request)
 	case request.CreateCourierEnvelopesFromPayload != nil:
 		d.createCourierEnvelopesFromPayload(request)
 	case request.CreateCourierEnvelopesFromPayloads != nil:

--- a/client/pigeonhole.go
+++ b/client/pigeonhole.go
@@ -992,6 +992,52 @@ func (d *Daemon) sendGetMessageBoxIndexCounterError(request *Request, errorCode 
 	})
 }
 
+// getPKIDocument returns the cert.Certificate-wrapped signed PKI
+// document for the requested epoch, with directory authority
+// signatures intact. An epoch of zero is taken to mean the current
+// epoch.
+func (d *Daemon) getPKIDocument(request *Request) {
+	conn := d.listener.getConnection(request.AppID)
+	if conn == nil {
+		d.log.Errorf(errNoConnectionForAppID, request.AppID[:])
+		return
+	}
+
+	var raw []byte
+	epoch := request.GetPKIDocument.Epoch
+	if epoch == 0 {
+		raw, epoch = d.client.CurrentRawSignedDocument()
+	} else {
+		raw = d.client.RawSignedDocumentByEpoch(epoch)
+	}
+
+	if raw == nil {
+		d.sendGetPKIDocumentError(request, epoch, thin.ThinClientErrorServiceUnavailable)
+		return
+	}
+
+	conn.sendResponse(&Response{
+		AppID: request.AppID,
+		GetPKIDocumentReply: &thin.GetPKIDocumentReply{
+			QueryID:   request.GetPKIDocument.QueryID,
+			Payload:   raw,
+			Epoch:     epoch,
+			ErrorCode: thin.ThinClientSuccess,
+		},
+	})
+}
+
+func (d *Daemon) sendGetPKIDocumentError(request *Request, epoch uint64, errorCode uint8) {
+	d.sendError(request.AppID, &Response{
+		AppID: request.AppID,
+		GetPKIDocumentReply: &thin.GetPKIDocumentReply{
+			QueryID:   request.GetPKIDocument.QueryID,
+			Epoch:     epoch,
+			ErrorCode: errorCode,
+		},
+	})
+}
+
 // createEnvelopeFromMessage creates a CourierEnvelope from a ReplicaInnerMessage
 func createEnvelopeFromMessage(msg *pigeonhole.ReplicaInnerMessage, doc *cpki.Document, isRead bool, replyIndex uint8) (*pigeonhole.CourierEnvelope, nike.PrivateKey, error) {
 	return createEnvelopeFromMessageWithPadding(msg, doc, isRead, replyIndex, nil)

--- a/client/pki.go
+++ b/client/pki.go
@@ -49,6 +49,12 @@ var (
 type CachedDoc struct {
 	Doc  *cpki.Document
 	Blob []byte
+
+	// RawSignedBlob is the original cert.Certificate-wrapped signed payload
+	// as received from the gateway, with all directory authority signatures
+	// intact. The thin client GetPKIDocument request returns this so that
+	// callers may verify signatures themselves.
+	RawSignedBlob []byte
 }
 
 type ConsensusGetter interface {
@@ -94,6 +100,21 @@ func (c *Client) CurrentDocument() ([]byte, *cpki.Document) {
 
 func (c *Client) GetDocumentByEpoch(epoch uint64) *cpki.Document {
 	return c.pki.GetDocumentByEpoch(epoch)
+}
+
+// CurrentRawSignedDocument returns the raw cert.Certificate-wrapped signed
+// PKI document for the current epoch, with every directory authority
+// signature intact. The second return value is the epoch the daemon
+// believes is current; the first is nil if no document has been cached.
+func (c *Client) CurrentRawSignedDocument() ([]byte, uint64) {
+	return c.pki.currentRawSignedDocument()
+}
+
+// RawSignedDocumentByEpoch returns the raw cert.Certificate-wrapped signed
+// PKI document for the requested epoch, with every directory authority
+// signature intact, or nil if no document for that epoch is cached.
+func (c *Client) RawSignedDocumentByEpoch(epoch uint64) []byte {
+	return c.pki.rawSignedDocumentByEpoch(epoch)
 }
 
 // WaitForCurrentDocument makes a best effort to ensure that
@@ -174,6 +195,30 @@ func (p *pki) currentDocument() ([]byte, *cpki.Document) {
 	}
 
 	return nil, nil
+}
+
+// currentRawSignedDocument returns the cert.Certificate-wrapped signed
+// payload for the current epoch, with every directory authority signature
+// intact, or nil if no document has been cached.
+func (p *pki) currentRawSignedDocument() ([]byte, uint64) {
+	now, _, _ := epochtime.FromUnix(p.skewedUnixTime())
+	if d, _ := p.docs.Load(now); d != nil {
+		cached := d.(*CachedDoc)
+		return cached.RawSignedBlob, cached.Doc.Epoch
+	}
+	return nil, now
+}
+
+// rawSignedDocumentByEpoch returns the cert.Certificate-wrapped signed
+// payload for the requested epoch with every directory authority
+// signature intact, or nil if no document for that epoch has been
+// cached.
+func (p *pki) rawSignedDocumentByEpoch(epoch uint64) []byte {
+	if d, _ := p.docs.Load(epoch); d != nil {
+		cached := d.(*CachedDoc)
+		return cached.RawSignedBlob
+	}
+	return nil
 }
 
 func (p *pki) worker() {
@@ -269,7 +314,7 @@ func (p *pki) updateDocument(epoch uint64) error {
 	})
 
 	// why does this start going off before we are connected?
-	docBlob, d, err := p.getDocument(pkiCtx, epoch)
+	docBlob, rawSigned, d, err := p.getDocument(pkiCtx, epoch)
 	cancelFn()
 	if err != nil {
 		return err
@@ -279,20 +324,21 @@ func (p *pki) updateDocument(epoch uint64) error {
 		panic("Sphinx Geometry mismatch!")
 	}
 	p.docs.Store(epoch, &CachedDoc{
-		Doc:  d,
-		Blob: docBlob,
+		Doc:           d,
+		Blob:          docBlob,
+		RawSignedBlob: rawSigned,
 	})
 	return nil
 }
 
-func (p *pki) getDocument(ctx context.Context, epoch uint64) ([]byte, *cpki.Document, error) {
+func (p *pki) getDocument(ctx context.Context, epoch uint64) ([]byte, []byte, *cpki.Document, error) {
 	var d *cpki.Document
 	var err error
 
 	p.log.Debugf("Fetching PKI doc for epoch %v from Gateway.", epoch)
 
 	if p.consensusGetter == nil {
-		return nil, nil, fmt.Errorf("consensus getter not initialized")
+		return nil, nil, nil, fmt.Errorf("consensus getter not initialized")
 	}
 
 	resp, err := p.consensusGetter.GetConsensus(ctx, epoch)
@@ -300,47 +346,53 @@ func (p *pki) getDocument(ctx context.Context, epoch uint64) ([]byte, *cpki.Docu
 	case nil:
 	case cpki.ErrNoDocument:
 		p.log.Debugf("getDocument [%v]: ErrNoDocument", epoch)
-		return nil, nil, err
+		return nil, nil, nil, err
 	default:
 		p.log.Errorf("getDocument [%v]: %s", epoch, err.Error())
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	switch resp.ErrorCode {
 	case commands.ConsensusOk:
 	case commands.ConsensusGone:
-		return nil, nil, cpki.ErrNoDocument
+		return nil, nil, nil, cpki.ErrNoDocument
 	case commands.ConsensusNotFound:
-		return nil, nil, errConsensusNotFound
+		return nil, nil, nil, errConsensusNotFound
 	default:
-		return nil, nil, fmt.Errorf("client/pki: GetConsensus failed: %v", resp.ErrorCode)
+		return nil, nil, nil, fmt.Errorf("client/pki: GetConsensus failed: %v", resp.ErrorCode)
 	}
 
 	if p.c.PKIClient == nil {
-		return nil, nil, errors.New("client/pki: PKIClient not initialized")
+		return nil, nil, nil, errors.New("client/pki: PKIClient not initialized")
 	}
 	d, err = p.c.PKIClient.Deserialize(resp.Payload)
 	if err != nil {
 		p.log.Errorf("Failed to deserialize consensus received from Gateway: %v", err)
-		return nil, nil, cpki.ErrNoDocument
+		return nil, nil, nil, cpki.ErrNoDocument
 	}
 	if d == nil {
 		p.log.Error("Failed to deserialize consensus received from Gateway")
-		return nil, nil, cpki.ErrNoDocument
+		return nil, nil, nil, cpki.ErrNoDocument
 	}
 
 	if d.Epoch != epoch {
 		p.log.Errorf("BUG: Provider returned document for incorrect epoch: %v", d.Epoch)
-		return nil, nil, fmt.Errorf("BUG: Provider returned document for incorrect epoch: %v", d.Epoch)
+		return nil, nil, nil, fmt.Errorf("BUG: Provider returned document for incorrect epoch: %v", d.Epoch)
 	}
+	// Preserve the original signed payload (the cert.Certificate wrapper
+	// with every directory authority signature still attached) before the
+	// stripped Document representation is produced for the daemon's own use.
+	rawSigned := make([]byte, len(resp.Payload))
+	copy(rawSigned, resp.Payload)
+
 	d.Signatures = nil
 	docBlob, err := ccbor.Marshal(d)
 	if err != nil {
 		p.log.Errorf("BUG: failed to cbor marshal pki doc: %v", err)
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return docBlob, d, err
+	return docBlob, rawSigned, d, err
 }
 
 func (p *pki) pruneDocuments(now uint64) {

--- a/client/pki.go
+++ b/client/pki.go
@@ -31,6 +31,18 @@ var (
 	// WarpedEpoch is a build time flag that accelerates the recheckInterval
 	WarpedEpoch = "false"
 
+	// waitForCurrentDocumentAttempts caps the number of synchronous
+	// updateDocument retries WaitForCurrentDocument performs before
+	// giving up. The retries absorb the brief window around an epoch
+	// boundary during which the gateway has yet to cache the new
+	// consensus.
+	waitForCurrentDocumentAttempts = 5
+
+	// waitForCurrentDocumentRetryDelay paces successive
+	// WaitForCurrentDocument retry attempts. Declared as a var so
+	// tests may temporarily shorten it.
+	waitForCurrentDocumentRetryDelay = time.Second
+
 	ccbor cbor.EncMode
 )
 
@@ -84,16 +96,41 @@ func (c *Client) GetDocumentByEpoch(epoch uint64) *cpki.Document {
 	return c.pki.GetDocumentByEpoch(epoch)
 }
 
+// WaitForCurrentDocument makes a best effort to ensure that
+// CurrentDocument returns a non-nil document for the current epoch.
+// If the cache already holds the current epoch's document it returns
+// at once; otherwise it issues up to waitForCurrentDocumentAttempts
+// synchronous fetches separated by waitForCurrentDocumentRetryDelay.
+// A transient ErrNoDocument or "consensus not ready" reply from the
+// gateway is normal around an epoch boundary, particularly under
+// short (warped) epoch durations, and typically clears within a
+// second or two. Without the retry every caller of CurrentDocument
+// would observe nil during that window and the daemon would return
+// ThinClientErrorInternalError to its thin client.
 func (c *Client) WaitForCurrentDocument() {
-	// what is the point of this when we aren't connected
-	_, doc := c.pki.currentDocument()
-	if doc != nil {
+	if _, doc := c.pki.currentDocument(); doc != nil {
 		return
 	}
-	epoch, _, _ := epochtime.Now()
-	err := c.pki.updateDocument(epoch)
-	if err != nil && c.log != nil {
-		c.log.Errorf("WaitForCurrentDocument failed on updateDocument with err: %s", err.Error())
+	for attempt := 1; attempt <= waitForCurrentDocumentAttempts; attempt++ {
+		epoch, _, _ := epochtime.Now()
+		if err := c.pki.updateDocument(epoch); err == nil {
+			return
+		} else if c.log != nil {
+			c.log.Debugf("WaitForCurrentDocument: attempt %d/%d failed: %s",
+				attempt, waitForCurrentDocumentAttempts, err.Error())
+		}
+		if attempt == waitForCurrentDocumentAttempts {
+			break
+		}
+		select {
+		case <-c.pki.HaltCh():
+			return
+		case <-time.After(waitForCurrentDocumentRetryDelay):
+		}
+	}
+	if c.log != nil {
+		c.log.Errorf("WaitForCurrentDocument: gave up after %d attempts",
+			waitForCurrentDocumentAttempts)
 	}
 }
 

--- a/client/pki_raw_docker_test.go
+++ b/client/pki_raw_docker_test.go
@@ -1,0 +1,129 @@
+//go:build docker_test
+
+// SPDX-FileCopyrightText: Copyright (C) 2026 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/hpqc/sign"
+
+	"github.com/katzenpost/katzenpost/client/config"
+	"github.com/katzenpost/katzenpost/core/cert"
+	cpki "github.com/katzenpost/katzenpost/core/pki"
+)
+
+// TestGetPKIDocumentRaw exercises the thin client's GetPKIDocumentRaw
+// request against a running docker mixnet. It confirms that the daemon
+// preserves the gateway's original cert.Certificate-wrapped signed
+// payload (signatures intact) and that the returned document matches
+// the daemon's stripped view of the same epoch.
+func TestGetPKIDocumentRaw(t *testing.T) {
+	t.Parallel()
+
+	client := setupThinClient(t)
+	defer client.Close()
+
+	strippedDoc := validatePKIDocument(t, client)
+	epoch := strippedDoc.Epoch
+
+	raw, gotEpoch, err := client.GetPKIDocumentRaw(epoch)
+	require.NoError(t, err)
+	require.Equal(t, epoch, gotEpoch)
+	require.NotEmpty(t, raw, "raw signed PKI document should not be empty")
+
+	parsed, err := cpki.ParseDocument(raw)
+	require.NoError(t, err)
+	require.Equal(t, epoch, parsed.Epoch)
+	require.NotEmpty(t, parsed.Signatures, "raw document must retain directory authority signatures")
+
+	// Sum256 hashes the marshalled cert.Certificate including its
+	// Signatures map; clear the parsed copy's signatures so the body
+	// hash matches the stripped document the daemon already exposed.
+	parsedBody := *parsed
+	parsedBody.Signatures = nil
+	require.Equal(t, strippedDoc.Sum256(), parsedBody.Sum256(),
+		"raw document body must match the stripped document body for the same epoch")
+
+	t.Logf("GetPKIDocumentRaw returned %d-byte signed payload with %d dirauth signatures",
+		len(raw), len(parsed.Signatures))
+
+	verifyAgainstDirauths(t, raw, epoch)
+}
+
+// TestGetPKIDocumentRawCurrentEpoch exercises the zero-epoch shortcut,
+// which asks the daemon for whichever epoch it currently believes to
+// be live.
+func TestGetPKIDocumentRawCurrentEpoch(t *testing.T) {
+	t.Parallel()
+
+	client := setupThinClient(t)
+	defer client.Close()
+
+	strippedDoc := validatePKIDocument(t, client)
+
+	raw, gotEpoch, err := client.GetPKIDocumentRaw(0)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+	require.Equal(t, strippedDoc.Epoch, gotEpoch,
+		"zero-epoch request should return whichever epoch the daemon considers current")
+
+	parsed, err := cpki.ParseDocument(raw)
+	require.NoError(t, err)
+	require.Equal(t, gotEpoch, parsed.Epoch)
+	require.NotEmpty(t, parsed.Signatures)
+}
+
+// TestGetPKIDocumentRawUnknownEpoch confirms that asking for an epoch
+// the daemon has never cached yields a graceful error rather than a
+// half-formed reply.
+func TestGetPKIDocumentRawUnknownEpoch(t *testing.T) {
+	t.Parallel()
+
+	client := setupThinClient(t)
+	defer client.Close()
+
+	// An epoch far in the past that the daemon will not have cached.
+	const ancientEpoch uint64 = 1
+
+	raw, gotEpoch, err := client.GetPKIDocumentRaw(ancientEpoch)
+	require.Error(t, err)
+	require.Nil(t, raw)
+	require.Equal(t, ancientEpoch, gotEpoch,
+		"daemon should echo the requested epoch on a miss")
+}
+
+// verifyAgainstDirauths checks the raw signed payload using the daemon
+// config's directory authority public keys. Failing here would indicate
+// the daemon mangled the payload or the signatures were stripped en
+// route, both of which the new method is supposed to prevent.
+func verifyAgainstDirauths(t *testing.T, raw []byte, epoch uint64) {
+	t.Helper()
+
+	cfg, err := config.LoadFile("testdata/client.toml")
+	require.NoError(t, err)
+	require.NotNil(t, cfg.VotingAuthority, "client config must list dirauth peers")
+	require.NotEmpty(t, cfg.VotingAuthority.Peers)
+
+	verifiers := make([]sign.PublicKey, 0, len(cfg.VotingAuthority.Peers))
+	for _, peer := range cfg.VotingAuthority.Peers {
+		require.NotNil(t, peer.IdentityPublicKey)
+		verifiers = append(verifiers, peer.IdentityPublicKey)
+	}
+
+	threshold := len(verifiers)/2 + 1
+	body, good, bad, err := cert.VerifyThreshold(verifiers, threshold, raw)
+	require.NoError(t, err,
+		"raw PKI document must verify against the configured dirauth threshold")
+	require.NotEmpty(t, body)
+	require.GreaterOrEqual(t, len(good), threshold,
+		"expected at least %d good signatures, got %d (bad: %d)",
+		threshold, len(good), len(bad))
+
+	t.Logf("epoch %d signed by %d/%d directory authorities (threshold %d)",
+		epoch, len(good), len(verifiers), threshold)
+}

--- a/client/pki_test.go
+++ b/client/pki_test.go
@@ -26,6 +26,7 @@ type mockConsensusGetter struct {
 	errorCode   uint8
 	epochErrors map[uint64]uint8
 	returnErr   error
+	payload     []byte
 }
 
 func (m *mockConsensusGetter) GetConsensus(ctx context.Context, epoch uint64) (*commands.Consensus2, error) {
@@ -37,7 +38,7 @@ func (m *mockConsensusGetter) GetConsensus(ctx context.Context, epoch uint64) (*
 			return &commands.Consensus2{ErrorCode: code}, nil
 		}
 	}
-	return &commands.Consensus2{ErrorCode: m.errorCode}, nil
+	return &commands.Consensus2{ErrorCode: m.errorCode, Payload: m.payload}, nil
 }
 
 type mockPKIClient struct {
@@ -108,7 +109,7 @@ func TestPKIGetDocument(t *testing.T) {
 		Epoch: epoch,
 	}
 
-	_, doc, err := p.getDocument(ctx, epoch)
+	_, _, doc, err := p.getDocument(ctx, epoch)
 	require.NoError(t, err)
 	require.NotNil(t, doc)
 	require.Equal(t, doc.Epoch, epoch)
@@ -116,7 +117,7 @@ func TestPKIGetDocument(t *testing.T) {
 	wrongEpoch := uint64(1234567)
 	ctx = context.TODO()
 
-	_, doc, err = p.getDocument(ctx, wrongEpoch)
+	_, _, doc, err = p.getDocument(ctx, wrongEpoch)
 	require.Error(t, err)
 	require.Nil(t, doc)
 }
@@ -294,6 +295,46 @@ func TestPKIWaitForDocumentRetriesTransientFailure(t *testing.T) {
 	require.Equal(t, 3, transient.callCount, "expected two failures followed by one success")
 }
 
+// TestPKIRawSignedDocumentRetained confirms that the daemon preserves
+// the gateway's original cert.Certificate-wrapped signed payload, so
+// the thin client GetPKIDocument request can return it with the
+// directory authority signatures intact.
+func TestPKIRawSignedDocumentRetained(t *testing.T) {
+	cfg, err := config.LoadFile("testdata/client.toml")
+	require.NoError(t, err)
+
+	myMockPKIClient := new(mockPKIClient)
+	logbackend, err := log.New("", "debug", false)
+	require.NoError(t, err)
+	c := &Client{
+		logbackend: logbackend,
+		cfg:        cfg,
+		PKIClient:  myMockPKIClient,
+	}
+
+	p := newPKI(c)
+	c.pki = p
+
+	rawSigned := []byte("opaque-cert-wrapped-signed-payload")
+	p.consensusGetter = &mockConsensusGetter{payload: rawSigned}
+
+	epoch, _, _ := epochtime.Now()
+	myMockPKIClient.doc = &cpki.Document{
+		Epoch:              epoch,
+		SphinxGeometryHash: c.cfg.SphinxGeometry.Hash(),
+	}
+
+	require.NoError(t, p.updateDocument(epoch))
+
+	got, gotEpoch := c.CurrentRawSignedDocument()
+	require.Equal(t, epoch, gotEpoch)
+	require.Equal(t, rawSigned, got)
+
+	require.Equal(t, rawSigned, c.RawSignedDocumentByEpoch(epoch))
+
+	require.Nil(t, c.RawSignedDocumentByEpoch(epoch+1))
+}
+
 func TestPKIClockSkew(t *testing.T) {
 	cfg, err := config.LoadFile("testdata/client.toml")
 	require.NoError(t, err)
@@ -317,7 +358,7 @@ func TestPKIClockSkew(t *testing.T) {
 		Epoch: epoch,
 	}
 
-	_, doc, err := p.getDocument(ctx, epoch)
+	_, _, doc, err := p.getDocument(ctx, epoch)
 	require.NoError(t, err)
 	require.NotNil(t, doc)
 	require.Equal(t, doc.Epoch, epoch)
@@ -383,13 +424,13 @@ func TestPKICachedDoc(t *testing.T) {
 	myMockPKIClient.doc = doc2
 	ctx := context.TODO()
 	p.consensusGetter = new(mockConsensusGetter)
-	_, doc, err := p.getDocument(ctx, doc2.Epoch)
+	_, _, doc, err := p.getDocument(ctx, doc2.Epoch)
 	require.NoError(t, err)
 	require.Equal(t, doc2, doc)
 
 	myMockPKIClient.doc = doc3
 	ctx = context.TODO()
-	_, doc, err = p.getDocument(ctx, doc3.Epoch)
+	_, _, doc, err = p.getDocument(ctx, doc3.Epoch)
 	require.NoError(t, err)
 	require.Equal(t, doc3, doc)
 }
@@ -412,7 +453,7 @@ func TestPKIGetDocumentConsensusGone(t *testing.T) {
 	epoch, _, _ := epochtime.Now()
 	ctx := context.TODO()
 
-	_, doc, err := p.getDocument(ctx, epoch)
+	_, _, doc, err := p.getDocument(ctx, epoch)
 	require.ErrorIs(t, err, cpki.ErrNoDocument)
 	require.Nil(t, doc)
 }
@@ -435,7 +476,7 @@ func TestPKIGetDocumentConsensusNotFound(t *testing.T) {
 	epoch, _, _ := epochtime.Now()
 	ctx := context.TODO()
 
-	_, doc, err := p.getDocument(ctx, epoch)
+	_, _, doc, err := p.getDocument(ctx, epoch)
 	require.ErrorIs(t, err, errConsensusNotFound)
 	require.Nil(t, doc)
 }
@@ -564,7 +605,7 @@ func TestPKIGetDocumentNilConsensusGetter(t *testing.T) {
 	epoch, _, _ := epochtime.Now()
 	ctx := context.TODO()
 
-	_, doc, err := p.getDocument(ctx, epoch)
+	_, _, doc, err := p.getDocument(ctx, epoch)
 	require.Error(t, err)
 	require.Nil(t, doc)
 	require.Contains(t, err.Error(), "consensus getter not initialized")
@@ -589,7 +630,7 @@ func TestPKIGetDocumentGetConsensusError(t *testing.T) {
 	epoch, _, _ := epochtime.Now()
 	ctx := context.TODO()
 
-	_, doc, err := p.getDocument(ctx, epoch)
+	_, _, doc, err := p.getDocument(ctx, epoch)
 	require.ErrorIs(t, err, someErr)
 	require.Nil(t, doc)
 }
@@ -612,7 +653,7 @@ func TestPKIGetDocumentUnknownErrorCode(t *testing.T) {
 	epoch, _, _ := epochtime.Now()
 	ctx := context.TODO()
 
-	_, doc, err := p.getDocument(ctx, epoch)
+	_, _, doc, err := p.getDocument(ctx, epoch)
 	require.Error(t, err)
 	require.Nil(t, doc)
 	require.Contains(t, err.Error(), "GetConsensus failed")
@@ -636,7 +677,7 @@ func TestPKIGetDocumentDeserializeFails(t *testing.T) {
 	epoch, _, _ := epochtime.Now()
 	ctx := context.TODO()
 
-	_, doc, err := p.getDocument(ctx, epoch)
+	_, _, doc, err := p.getDocument(ctx, epoch)
 	require.ErrorIs(t, err, cpki.ErrNoDocument)
 	require.Nil(t, doc)
 }
@@ -660,7 +701,7 @@ func TestPKIGetDocumentDeserializeReturnsNil(t *testing.T) {
 	epoch, _, _ := epochtime.Now()
 	ctx := context.TODO()
 
-	_, doc, err := p.getDocument(ctx, epoch)
+	_, _, doc, err := p.getDocument(ctx, epoch)
 	require.ErrorIs(t, err, cpki.ErrNoDocument)
 	require.Nil(t, doc)
 }
@@ -685,7 +726,7 @@ func TestPKIGetDocumentEpochMismatch(t *testing.T) {
 
 	ctx := context.TODO()
 
-	_, doc, err := p.getDocument(ctx, epoch)
+	_, _, doc, err := p.getDocument(ctx, epoch)
 	require.Error(t, err)
 	require.Nil(t, doc)
 	require.Contains(t, err.Error(), "incorrect epoch")

--- a/client/pki_test.go
+++ b/client/pki_test.go
@@ -234,6 +234,66 @@ func TestPKIWaitForDocument(t *testing.T) {
 	require.Equal(t, currentDoc, testDoc)
 }
 
+// transientFailureConsensusGetter returns ConsensusNotFound for the
+// first failuresRemaining calls and ConsensusOk thereafter, allowing
+// the test to confirm that WaitForCurrentDocument retries through a
+// transient gateway response.
+type transientFailureConsensusGetter struct {
+	mu                sync.Mutex
+	failuresRemaining int
+	callCount         int
+}
+
+func (m *transientFailureConsensusGetter) GetConsensus(ctx context.Context, epoch uint64) (*commands.Consensus2, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callCount++
+	if m.failuresRemaining > 0 {
+		m.failuresRemaining--
+		return &commands.Consensus2{ErrorCode: commands.ConsensusNotFound}, nil
+	}
+	return &commands.Consensus2{ErrorCode: commands.ConsensusOk}, nil
+}
+
+func TestPKIWaitForDocumentRetriesTransientFailure(t *testing.T) {
+	cfg, err := config.LoadFile("testdata/client.toml")
+	require.NoError(t, err)
+
+	myMockPKIClient := new(mockPKIClient)
+	logbackend, err := log.New("", "debug", false)
+	require.NoError(t, err)
+	c := &Client{
+		logbackend: logbackend,
+		cfg:        cfg,
+		PKIClient:  myMockPKIClient,
+	}
+
+	p := newPKI(c)
+	c.pki = p
+
+	transient := &transientFailureConsensusGetter{failuresRemaining: 2}
+	p.consensusGetter = transient
+
+	originalDelay := waitForCurrentDocumentRetryDelay
+	waitForCurrentDocumentRetryDelay = 10 * time.Millisecond
+	t.Cleanup(func() { waitForCurrentDocumentRetryDelay = originalDelay })
+
+	epoch, _, _ := epochtime.Now()
+	myMockPKIClient.doc = &cpki.Document{
+		Epoch:              epoch,
+		SphinxGeometryHash: c.cfg.SphinxGeometry.Hash(),
+	}
+
+	_, currentDoc := p.currentDocument()
+	require.Nil(t, currentDoc)
+
+	c.WaitForCurrentDocument()
+
+	_, currentDoc = p.currentDocument()
+	require.NotNil(t, currentDoc, "retry loop ought to have produced a document")
+	require.Equal(t, 3, transient.callCount, "expected two failures followed by one success")
+}
+
 func TestPKIClockSkew(t *testing.T) {
 	cfg, err := config.LoadFile("testdata/client.toml")
 	require.NoError(t, err)

--- a/client/thin/thin.go
+++ b/client/thin/thin.go
@@ -938,6 +938,12 @@ func (t *ThinClient) dispatchMessage(message *Response) bool {
 		case <-t.HaltCh():
 			return false
 		}
+	case message.GetPKIDocumentReply != nil:
+		select {
+		case t.eventSink <- message.GetPKIDocumentReply:
+		case <-t.HaltCh():
+			return false
+		}
 
 		/**  Copy Channel API **/
 
@@ -1375,6 +1381,69 @@ func (t *ThinClient) PKIDocumentForEpoch(epoch uint64) (*cpki.Document, error) {
 	}
 
 	return nil, errors.New("no PKI document available for the requested epoch")
+}
+
+// GetPKIDocumentRaw returns the cert.Certificate-wrapped signed PKI
+// document for the requested epoch, with every directory authority
+// signature intact. Pass epoch == 0 to request the document the daemon
+// believes is current.
+//
+// The thin client receives the stripped PKI document by default (as
+// pushed in NewPKIDocumentEvent); use this method when the caller
+// needs to verify the directory authority signatures itself. The
+// payload can be deserialized and verified with core/pki.FromPayload.
+//
+// Returns:
+//   - []byte: the cert.Certificate-wrapped signed PKI document.
+//   - uint64: the epoch of the returned document.
+//   - error: any error encountered (notably if no document for the
+//     requested epoch is cached by the daemon).
+func (t *ThinClient) GetPKIDocumentRaw(epoch uint64) ([]byte, uint64, error) {
+	queryID := t.NewQueryID()
+	req := &Request{
+		GetPKIDocument: &GetPKIDocument{
+			QueryID: queryID,
+			Epoch:   epoch,
+		},
+	}
+
+	eventSink := t.EventSink()
+	defer t.StopEventSink(eventSink)
+
+	if err := t.writeMessage(req); err != nil {
+		return nil, 0, err
+	}
+
+	for {
+		var event Event
+		select {
+		case event = <-eventSink:
+		case <-t.HaltCh():
+			return nil, 0, errHalting
+		}
+
+		switch v := event.(type) {
+		case *GetPKIDocumentReply:
+			if v.QueryID == nil {
+				t.log.Debugf("GetPKIDocumentRaw: reply with nil QueryID, ignoring")
+				continue
+			}
+			if !bytes.Equal(v.QueryID[:], queryID[:]) {
+				t.log.Debugf("GetPKIDocumentRaw: reply with mismatched QueryID, ignoring")
+				continue
+			}
+			if v.ErrorCode != ThinClientSuccess {
+				return nil, v.Epoch, errors.New(ThinClientErrorToString(v.ErrorCode))
+			}
+			return v.Payload, v.Epoch, nil
+		case *ConnectionStatusEvent:
+			t.setConnected(v.IsConnected)
+		case *NewDocumentEvent:
+			// Ignore PKI document updates while we wait for our reply.
+		default:
+			// Ignore other events.
+		}
+	}
 }
 
 // GetServices returns all services matching the specified capability name.

--- a/client/thin/thin_events.go
+++ b/client/thin/thin_events.go
@@ -430,6 +430,39 @@ func (e *GetMessageBoxIndexCounterReply) String() string {
 	return fmt.Sprintf("GetMessageBoxIndexCounterReply: counter=%d", e.Counter)
 }
 
+// GetPKIDocumentReply is the reply to a GetPKIDocument request. The
+// Payload field carries the cert.Certificate-wrapped signed PKI document
+// exactly as the daemon received it from the gateway, retaining every
+// directory authority signature so that callers may verify it
+// themselves.
+type GetPKIDocumentReply struct {
+	// QueryID is used for correlating this reply with the GetPKIDocument
+	// request.
+	QueryID *[QueryIDLength]byte `cbor:"query_id"`
+
+	// Payload is the cert.Certificate-wrapped signed PKI document, or
+	// nil on failure. Use core/pki.FromPayload to deserialize and verify
+	// it against the directory authorities' public keys.
+	Payload []byte `cbor:"payload"`
+
+	// Epoch is the epoch of the returned document. When the request
+	// asked for the current epoch this echoes the epoch the daemon
+	// believes is current.
+	Epoch uint64 `cbor:"epoch"`
+
+	// ErrorCode indicates the reason for a failure to return a signed
+	// PKI document if any. Otherwise it is set to zero for success.
+	ErrorCode uint8 `cbor:"error_code"`
+}
+
+// String returns a string representation of the GetPKIDocumentReply.
+func (e *GetPKIDocumentReply) String() string {
+	if e.ErrorCode != ThinClientSuccess {
+		return fmt.Sprintf("GetPKIDocumentReply: epoch=%d (error: %s)", e.Epoch, ThinClientErrorToString(e.ErrorCode))
+	}
+	return fmt.Sprintf("GetPKIDocumentReply: epoch=%d payloadLen=%d", e.Epoch, len(e.Payload))
+}
+
 // Copy Channel API:
 
 // CreateCourierEnvelopesFromPayloadReply is sent in response to a CreateCourierEnvelopesFromPayload request.

--- a/client/thin/thin_messages.go
+++ b/client/thin/thin_messages.go
@@ -358,6 +358,23 @@ type GetMessageBoxIndexCounter struct {
 	MessageBoxIndex *bacap.MessageBoxIndex `cbor:"message_box_index"`
 }
 
+// GetPKIDocument requests the daemon to return the raw
+// cert.Certificate-wrapped signed PKI document for the requested epoch,
+// with every directory authority signature intact. This differs from
+// the NewPKIDocumentEvent payload, which is stripped of signatures and
+// the cert wrapper before being pushed to the thin client. The reply
+// type is GetPKIDocumentReply.
+type GetPKIDocument struct {
+	// QueryID is used for correlating this thin client request with the
+	// thin client response.
+	QueryID *[QueryIDLength]byte `cbor:"query_id"`
+
+	// Epoch is the epoch for which the signed PKI document should be
+	// returned. If zero, the daemon returns the document for the current
+	// epoch.
+	Epoch uint64 `cbor:"epoch"`
+}
+
 // CreateCourierEnvelopesFromPayload creates multiple CourierEnvelopes from a payload of any size.
 // The payload is automatically chunked and each chunk is wrapped in a CourierEnvelope.
 // Each returned chunk is a serialized CopyStreamElement ready to be written to a box.
@@ -596,6 +613,11 @@ type Response struct {
 	// GetMessageBoxIndexCounter request and carries the BACAP Idx64 value.
 	GetMessageBoxIndexCounterReply *GetMessageBoxIndexCounterReply `cbor:"get_message_box_index_counter_reply"`
 
+	// GetPKIDocumentReply is sent in response to a GetPKIDocument
+	// request and carries the cert.Certificate-wrapped signed PKI
+	// document, with directory authority signatures intact.
+	GetPKIDocumentReply *GetPKIDocumentReply `cbor:"get_pki_document_reply"`
+
 	// Copy Channel API:
 
 	// CreateCourierEnvelopesFromPayloadReply is sent when the client daemon successfully creates courier envelopes from a payload.
@@ -654,6 +676,11 @@ type Request struct {
 
 	// GetMessageBoxIndexCounter reads the Idx64 counter out of a MessageBoxIndex.
 	GetMessageBoxIndexCounter *GetMessageBoxIndexCounter `cbor:"get_message_box_index_counter"`
+
+	// GetPKIDocument asks the daemon for the raw cert-wrapped signed
+	// PKI document for an epoch, with every directory authority
+	// signature intact.
+	GetPKIDocument *GetPKIDocument `cbor:"get_pki_document"`
 
 	// CreateCourierEnvelopesFromPayload is used to create multiple CourierEnvelopes from a payload of any size.
 	CreateCourierEnvelopesFromPayload *CreateCourierEnvelopesFromPayload `cbor:"create_courier_envelopes_from_payload"`

--- a/client/thin_messages.go
+++ b/client/thin_messages.go
@@ -27,6 +27,7 @@ func IntoThinResponse(r *Response) *thin.Response {
 		CancelResendingCopyCommandReply:      r.CancelResendingCopyCommandReply,
 		NextMessageBoxIndexReply:             r.NextMessageBoxIndexReply,
 		GetMessageBoxIndexCounterReply:       r.GetMessageBoxIndexCounterReply,
+		GetPKIDocumentReply:                  r.GetPKIDocumentReply,
 
 		// Copy Channel API:
 		CreateCourierEnvelopesFromPayloadReply:          r.CreateCourierEnvelopesFromPayloadReply,
@@ -75,6 +76,8 @@ type Response struct {
 
 	GetMessageBoxIndexCounterReply *thin.GetMessageBoxIndexCounterReply
 
+	GetPKIDocumentReply *thin.GetPKIDocumentReply
+
 	// Copy Channel API:
 
 	CreateCourierEnvelopesFromPayloadReply *thin.CreateCourierEnvelopesFromPayloadReply
@@ -98,6 +101,7 @@ func FromThinRequest(r *thin.Request, appid *[AppIDLength]byte) *Request {
 		CancelResendingCopyCommand:      r.CancelResendingCopyCommand,
 		NextMessageBoxIndex:             r.NextMessageBoxIndex,
 		GetMessageBoxIndexCounter:       r.GetMessageBoxIndexCounter,
+		GetPKIDocument:                  r.GetPKIDocument,
 
 		// Copy Channel API:
 		CreateCourierEnvelopesFromPayload:          r.CreateCourierEnvelopesFromPayload,
@@ -137,6 +141,8 @@ type Request struct {
 	NextMessageBoxIndex *thin.NextMessageBoxIndex
 
 	GetMessageBoxIndexCounter *thin.GetMessageBoxIndexCounter
+
+	GetPKIDocument *thin.GetPKIDocument
 
 	// Copy Channel API:
 

--- a/courier/server/copy_retry_test.go
+++ b/courier/server/copy_retry_test.go
@@ -30,8 +30,8 @@ func TestCopyAttemptBackoffMonotonic(t *testing.T) {
 // TestCopyRetryConstants guards the tunables the audit M1 fix relies
 // on. Changing these affects worst-case Copy completion time.
 func TestCopyRetryConstants(t *testing.T) {
-	require.Equal(t, 3, maxCopyReadTransientAttempts)
-	require.Equal(t, 5, maxCopyWriteAttempts)
+	require.Equal(t, 5, maxCopyReadTransientAttempts)
+	require.Equal(t, 8, maxCopyWriteAttempts)
 	require.Equal(t, 500*time.Millisecond, copyBackoffBase)
 	require.Equal(t, 10*time.Second, copyBackoffCap)
 	require.Equal(t, 20*time.Second, copyReadReplyTimeout)

--- a/courier/server/plugin.go
+++ b/courier/server/plugin.go
@@ -92,7 +92,7 @@ const (
 	// maxCopyReadTransientAttempts is how many times a single shard
 	// replica is re-queried on a temporary error (per the classifier)
 	// before the read path fails over to the shard peer.
-	maxCopyReadTransientAttempts = 3
+	maxCopyReadTransientAttempts = 5
 
 	// copyReadReplyTimeout bounds how long the courier waits for a
 	// reply from one shard replica during a Copy read. A stuck replica
@@ -104,7 +104,7 @@ const (
 	// replicas before aborting the Copy command. Write-side failover
 	// between shard peers is not available — the intermediate replicas
 	// are baked into the client's MKEM envelope.
-	maxCopyWriteAttempts = 5
+	maxCopyWriteAttempts = 8
 
 	// copyWriteReplyTimeout bounds how long the courier waits for
 	// both intermediate-replica replies after dispatching a Copy


### PR DESCRIPTION
WaitForCurrentDocument was a misnomer. When the cache held no document for the current epoch it issued a single synchronous updateDocument call against the gateway, logged any error, and returned, leaving the caller with a nil document. Around an epoch boundary the gateway has often yet to cache the new consensus and replies with ConsensusNotFound; that transient outcome therefore propagated up to every consumer of CurrentDocument. The pigeonhole daemon's encryptWrite, encryptRead, and create-courier-envelope handlers respond to a nil document with ThinClientErrorInternalError, which is precisely the intermittent failure mode observed in the integration tests against the docker mixnet under a warped two-minute epoch.

The same fragility was addressed for the courier and replica outgoing-connection workers in ede630c1 (force-fetch PKI when cache lacks a usable LambdaR) and a kindred treatment is warranted here. WaitForCurrentDocument now performs a bounded retry, up to five synchronous fetches separated by a one-second pause, and respects the pki worker's HaltCh so a shutting-down daemon does not linger. The retry constants are package-level vars so the unit test may shorten the delay; an additional test exercises the retry path through a consensus getter that fails twice and then succeeds.

No behavioural change is introduced when the gateway already has a fresh document: WaitForCurrentDocument returns on the first attempt exactly as before.