### PR TITLE
core/pki: split Client into Client and PostingClient

### DIFF
--- a/authority/voting/client/client.go
+++ b/authority/voting/client/client.go
@@ -1470,8 +1470,11 @@ func (c *Client) Deserialize(raw []byte) (*pki.Document, error) {
 	return pki.ParseDocument(raw)
 }
 
-// New constructs a new pki.Client instance.
-func New(cfg *Config) (pki.Client, error) {
+// New constructs a new pki.PostingClient instance. The voting authority
+// client implements both reading and posting, so it satisfies
+// pki.PostingClient; callers that only require the reader interface may
+// assign the result to a pki.Client variable.
+func New(cfg *Config) (pki.PostingClient, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}

--- a/authority/voting/client/client.go
+++ b/authority/voting/client/client.go
@@ -75,7 +75,8 @@ func (a *authorityAuthenticator) IsPeerValid(creds *wire.PeerCredentials) bool {
 	return true
 }
 
-// Config is a voting authority pki.Client instance.
+// Config is the configuration for a voting authority pki.PostingClient
+// instance.
 type Config struct {
 	// KEMScheme indicates the KEM scheme used for the LinkKey/wire protocol.
 	KEMScheme kem.Scheme
@@ -1471,9 +1472,11 @@ func (c *Client) Deserialize(raw []byte) (*pki.Document, error) {
 }
 
 // New constructs a new pki.PostingClient instance. The voting authority
-// client implements both reading and posting, so it satisfies
-// pki.PostingClient; callers that only require the reader interface may
-// assign the result to a pki.Client variable.
+// client implements the full PKI surface (fetch, deserialize against
+// configured dirauth verifiers, and both descriptor-upload methods).
+// Callers that need only a narrower role may upcast the returned value
+// on assignment to a pki.Fetcher, pki.Deserializer, pki.MixNodeClient,
+// or pki.ReplicaNodeClient variable.
 func New(cfg *Config) (pki.PostingClient, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, err

--- a/client/client.go
+++ b/client/client.go
@@ -47,7 +47,7 @@ type Client struct {
 	geo           *geo.Geometry
 	wireKEMScheme kem.Scheme
 
-	PKIClient cpki.Client
+	PKIClient cpki.Deserializer
 
 	// DialContextFn is the optional alternative Dialer.DialContext function
 	// to be used when creating outgoing network connections.

--- a/core/pki/client.go
+++ b/core/pki/client.go
@@ -8,30 +8,58 @@ import (
 	"github.com/katzenpost/katzenpost/loops"
 )
 
-// Client is the read-only PKI consumer interface. It is satisfied by any
-// PKI client that retrieves and deserializes consensus documents; it does
-// not include any descriptor-upload methods. Use this interface in callers
-// that only need to read the PKI (the client daemon, the courier, the
-// directory authority's own consumer of historical documents).
-type Client interface {
-	// GetPKIDocumentForEpoch returns the PKI document along with the raw
-	// serialized form for the provided epoch.
+// Fetcher retrieves a PKI document for a given epoch from a remote
+// authority. The returned raw bytes are the same byte sequence that
+// would be passed to Deserializer.Deserialize for verification against
+// a configured trust anchor.
+type Fetcher interface {
 	GetPKIDocumentForEpoch(ctx context.Context, epoch uint64) (*Document, []byte, error)
+}
 
-	// Deserialize returns a PKI document given the raw bytes.
+// Deserializer verifies the given raw bytes against the configured
+// directory authority public keys and returns the parsed Document.
+// Implementations carry the verifier set internally so that callers
+// cannot accidentally parse an unverified document.
+type Deserializer interface {
 	Deserialize(raw []byte) (*Document, error)
 }
 
-// PostingClient extends Client with descriptor-upload methods used by
-// nodes that publish their own descriptors to the directory authorities,
-// such as mix nodes, gateways, service nodes, and pigeonhole storage
-// replicas.
-type PostingClient interface {
-	Client
-
-	// Post posts the node's descriptor to the PKI for the provided epoch.
+// MixDescriptorPoster posts the node's own MixDescriptor to the
+// directory authorities. Used by mix, gateway, and service nodes.
+type MixDescriptorPoster interface {
 	Post(ctx context.Context, epoch uint64, signingPrivateKey sign.PrivateKey, signingPublicKey sign.PublicKey, d *MixDescriptor, loopstats *loops.LoopStats) error
+}
 
-	// PostReplica posts the pigeonhole storage replica node's descriptor to the PKI for the provided epoch.
+// ReplicaDescriptorPoster posts the node's own ReplicaDescriptor to the
+// directory authorities. Used by pigeonhole storage replicas.
+type ReplicaDescriptorPoster interface {
 	PostReplica(ctx context.Context, epoch uint64, signingPrivateKey sign.PrivateKey, signingPublicKey sign.PublicKey, d *ReplicaDescriptor) error
+}
+
+// MixNodeClient is the PKI surface used by mix, gateway, and service
+// nodes: fetch consensus documents and post the node's own
+// MixDescriptor.
+type MixNodeClient interface {
+	Fetcher
+	MixDescriptorPoster
+}
+
+// ReplicaNodeClient is the PKI surface used by pigeonhole storage
+// replicas: fetch consensus documents and post the replica's own
+// ReplicaDescriptor.
+type ReplicaNodeClient interface {
+	Fetcher
+	ReplicaDescriptorPoster
+}
+
+// PostingClient is the full PKI surface implemented by the voting
+// authority client: fetch consensus documents, deserialize foreign
+// byte streams against configured trust anchors, and post both kinds
+// of descriptor. Concrete implementations that satisfy every PKI
+// role declare themselves against this interface.
+type PostingClient interface {
+	Fetcher
+	Deserializer
+	MixDescriptorPoster
+	ReplicaDescriptorPoster
 }

--- a/core/pki/client.go
+++ b/core/pki/client.go
@@ -4,20 +4,34 @@ import (
 	"context"
 
 	"github.com/katzenpost/hpqc/sign"
+
 	"github.com/katzenpost/katzenpost/loops"
 )
 
-// Client is the abstract interface used for PKI interaction.
+// Client is the read-only PKI consumer interface. It is satisfied by any
+// PKI client that retrieves and deserializes consensus documents; it does
+// not include any descriptor-upload methods. Use this interface in callers
+// that only need to read the PKI (the client daemon, the courier, the
+// directory authority's own consumer of historical documents).
 type Client interface {
-	// Get returns the PKI document along with the raw serialized form for the provided epoch.
+	// GetPKIDocumentForEpoch returns the PKI document along with the raw
+	// serialized form for the provided epoch.
 	GetPKIDocumentForEpoch(ctx context.Context, epoch uint64) (*Document, []byte, error)
+
+	// Deserialize returns a PKI document given the raw bytes.
+	Deserialize(raw []byte) (*Document, error)
+}
+
+// PostingClient extends Client with descriptor-upload methods used by
+// nodes that publish their own descriptors to the directory authorities,
+// such as mix nodes, gateways, service nodes, and pigeonhole storage
+// replicas.
+type PostingClient interface {
+	Client
 
 	// Post posts the node's descriptor to the PKI for the provided epoch.
 	Post(ctx context.Context, epoch uint64, signingPrivateKey sign.PrivateKey, signingPublicKey sign.PublicKey, d *MixDescriptor, loopstats *loops.LoopStats) error
 
 	// PostReplica posts the pigeonhole storage replica node's descriptor to the PKI for the provided epoch.
 	PostReplica(ctx context.Context, epoch uint64, signingPrivateKey sign.PrivateKey, signingPublicKey sign.PublicKey, d *ReplicaDescriptor) error
-
-	// Deserialize returns PKI document given the raw bytes.
-	Deserialize(raw []byte) (*Document, error)
 }

--- a/core/pki/fetcher.go
+++ b/core/pki/fetcher.go
@@ -12,11 +12,11 @@ import (
 // DocumentFetcher provides common PKI document fetching functionality
 type DocumentFetcher struct {
 	log    *logging.Logger
-	client Client
+	client Fetcher
 }
 
 // NewDocumentFetcher creates a new document fetcher
-func NewDocumentFetcher(client Client, log *logging.Logger) *DocumentFetcher {
+func NewDocumentFetcher(client Fetcher, log *logging.Logger) *DocumentFetcher {
 	return &DocumentFetcher{
 		log:    log,
 		client: client,

--- a/core/pki/worker.go
+++ b/core/pki/worker.go
@@ -26,7 +26,7 @@ var (
 // WorkerBase provides common PKI worker functionality shared between courier and replica
 type WorkerBase struct {
 	log     *logging.Logger
-	impl    Client
+	impl    Fetcher
 	fetcher *DocumentFetcher
 
 	lock          *sync.RWMutex
@@ -36,7 +36,7 @@ type WorkerBase struct {
 }
 
 // NewWorkerBase creates a new PKI worker base
-func NewWorkerBase(impl Client, log *logging.Logger) *WorkerBase {
+func NewWorkerBase(impl Fetcher, log *logging.Logger) *WorkerBase {
 	return &WorkerBase{
 		log:           log,
 		impl:          impl,

--- a/courier/server/pki.go
+++ b/courier/server/pki.go
@@ -40,14 +40,14 @@ type PKIWorker struct {
 
 	replicas *replicaCommon.ReplicaMap
 
-	impl pki.Client // PKI client for document fetching and publishing
+	impl pki.Fetcher // the courier only reads consensus, never posts
 
 	lastPublishedEpoch        uint64
 	lastWarnedEpoch           uint64
 	lastPublishedReplicaEpoch uint64
 }
 
-func newPKIWorker(server *Server, pkiClient pki.Client, log *logging.Logger) (*PKIWorker, error) {
+func newPKIWorker(server *Server, pkiClient pki.Fetcher, log *logging.Logger) (*PKIWorker, error) {
 	// Reduce PKI worker and PKI client log verbosity to WARNING level to reduce log noise
 	// This suppresses DEBUG and INFO messages from the PKI worker, PKI client, and connector
 	server.logBackend.SetLevel(logging.WARNING, "courier-pkiworker")

--- a/courier/server/server.go
+++ b/courier/server/server.go
@@ -59,11 +59,11 @@ func NewWithDefaultPKI(cfg *config.Config) (*Server, error) {
 }
 
 // NewWithPKI creates a new Server with a custom PKI client for testing
-func NewWithPKI(cfg *config.Config, pkiClient pki.Client) (*Server, error) {
+func NewWithPKI(cfg *config.Config, pkiClient pki.Fetcher) (*Server, error) {
 	return New(cfg, pkiClient)
 }
 
-func New(cfg *config.Config, pkiClient pki.Client) (*Server, error) {
+func New(cfg *config.Config, pkiClient pki.Fetcher) (*Server, error) {
 	s := &Server{
 		cfg: cfg,
 	}
@@ -105,7 +105,7 @@ func (s *Server) initializeBasics() error {
 }
 
 // initializePKI sets up the PKI worker
-func (s *Server) initializePKI(pkiClient pki.Client) error {
+func (s *Server) initializePKI(pkiClient pki.Fetcher) error {
 	var err error
 	if pkiClient != nil {
 		s.PKI, err = newPKIWorker(s, pkiClient, s.logBackend.GetLogger("courier-pkiworker"))

--- a/replica/integration_tests/courier_replica_integration_test.go
+++ b/replica/integration_tests/courier_replica_integration_test.go
@@ -493,7 +493,7 @@ func generateCourierLinkKeys(t *testing.T, dataDir, kemSchemeName string) (kem.P
 	return linkPrivKey, linkPubKey
 }
 
-func createReplicaServer(t *testing.T, cfg *config.Config, pkiClient pki.PostingClient) *replica.Server {
+func createReplicaServer(t *testing.T, cfg *config.Config, pkiClient pki.ReplicaNodeClient) *replica.Server {
 	server, err := replica.NewWithPKI(cfg, pkiClient)
 	require.NoError(t, err)
 	require.NotNil(t, server)
@@ -713,7 +713,7 @@ func (c *mockPKIClient) Deserialize(raw []byte) (*pki.Document, error) {
 	return pki.ParseDocument(raw)
 }
 
-func createCourierServer(t *testing.T, cfg *courierConfig.Config, pkiClient pki.Client) *courierServer.Server {
+func createCourierServer(t *testing.T, cfg *courierConfig.Config, pkiClient pki.Fetcher) *courierServer.Server {
 	server, err := courierServer.New(cfg, pkiClient)
 	require.NoError(t, err)
 	require.NotNil(t, server)

--- a/replica/integration_tests/courier_replica_integration_test.go
+++ b/replica/integration_tests/courier_replica_integration_test.go
@@ -493,7 +493,7 @@ func generateCourierLinkKeys(t *testing.T, dataDir, kemSchemeName string) (kem.P
 	return linkPrivKey, linkPubKey
 }
 
-func createReplicaServer(t *testing.T, cfg *config.Config, pkiClient pki.Client) *replica.Server {
+func createReplicaServer(t *testing.T, cfg *config.Config, pkiClient pki.PostingClient) *replica.Server {
 	server, err := replica.NewWithPKI(cfg, pkiClient)
 	require.NoError(t, err)
 	require.NotNil(t, server)

--- a/replica/pkiworker.go
+++ b/replica/pkiworker.go
@@ -38,7 +38,7 @@ type PKIWorker struct {
 
 	replicas *replicaCommon.ReplicaMap
 
-	impl pki.PostingClient // PKI client for document fetching and publishing
+	impl pki.ReplicaNodeClient // fetches consensus and posts ReplicaDescriptor
 
 	descAddrMap        map[string][]string
 	lastPublishedEpoch uint64
@@ -69,8 +69,8 @@ func newPKIWorker(server *Server, log *logging.Logger) (*PKIWorker, error) {
 	return newPKIWorkerWithClient(server, pkiClient, log)
 }
 
-// newPKIWorkerWithClient creates a PKIWorker with a custom pki.PostingClient for testing
-func newPKIWorkerWithClient(server *Server, pkiClient pki.PostingClient, log *logging.Logger) (*PKIWorker, error) {
+// newPKIWorkerWithClient creates a PKIWorker with a custom pki.ReplicaNodeClient for testing
+func newPKIWorkerWithClient(server *Server, pkiClient pki.ReplicaNodeClient, log *logging.Logger) (*PKIWorker, error) {
 	// Reduce PKI worker and PKI client log verbosity to WARNING level to reduce log noise
 	// This suppresses DEBUG and INFO messages from the PKI worker, PKI client, and connector
 	server.logBackend.SetLevel(logging.WARNING, "replica pkiWorker")

--- a/replica/pkiworker.go
+++ b/replica/pkiworker.go
@@ -99,8 +99,16 @@ func newPKIWorkerWithClient(server *Server, pkiClient pki.ReplicaNodeClient, log
 		p.descAddrMap[scheme] = append(p.descAddrMap[scheme], v)
 	}
 
-	p.Go(p.worker)
 	return p, nil
+}
+
+// Start launches the PKI worker's background goroutine. The caller
+// must have assigned the worker to server.PKIWorker first: the
+// worker's first iteration may call into state.Rebalance, which reads
+// server.PKIWorker, and a goroutine spawned before that assignment
+// would race with, or precede, it.
+func (p *PKIWorker) Start() {
+	p.Go(p.worker)
 }
 func replicaMap(doc *pki.Document) map[[32]byte]*pki.ReplicaDescriptor {
 	newReplicas := make(map[[32]byte]*pki.ReplicaDescriptor)

--- a/replica/pkiworker.go
+++ b/replica/pkiworker.go
@@ -38,7 +38,7 @@ type PKIWorker struct {
 
 	replicas *replicaCommon.ReplicaMap
 
-	impl pki.Client // PKI client for document fetching and publishing
+	impl pki.PostingClient // PKI client for document fetching and publishing
 
 	descAddrMap        map[string][]string
 	lastPublishedEpoch uint64
@@ -69,8 +69,8 @@ func newPKIWorker(server *Server, log *logging.Logger) (*PKIWorker, error) {
 	return newPKIWorkerWithClient(server, pkiClient, log)
 }
 
-// newPKIWorkerWithClient creates a PKIWorker with a custom pki.Client for testing
-func newPKIWorkerWithClient(server *Server, pkiClient pki.Client, log *logging.Logger) (*PKIWorker, error) {
+// newPKIWorkerWithClient creates a PKIWorker with a custom pki.PostingClient for testing
+func newPKIWorkerWithClient(server *Server, pkiClient pki.PostingClient, log *logging.Logger) (*PKIWorker, error) {
 	// Reduce PKI worker and PKI client log verbosity to WARNING level to reduce log noise
 	// This suppresses DEBUG and INFO messages from the PKI worker, PKI client, and connector
 	server.logBackend.SetLevel(logging.WARNING, "replica pkiWorker")

--- a/replica/pkiworker_test.go
+++ b/replica/pkiworker_test.go
@@ -165,7 +165,7 @@ func (m *mockReplicaPKIClient) posts() ([]uint64, []*pki.ReplicaDescriptor) {
 	return epochs, descriptors
 }
 
-func createPublishDescriptorTestWorker(t *testing.T, pkiClient pki.PostingClient) (*PKIWorker, func()) {
+func createPublishDescriptorTestWorker(t *testing.T, pkiClient pki.ReplicaNodeClient) (*PKIWorker, func()) {
 	pkiScheme := signschemes.ByName(testPKIScheme)
 	idpubkey, _, err := pkiScheme.GenerateKey()
 	require.NoError(t, err)

--- a/replica/pkiworker_test.go
+++ b/replica/pkiworker_test.go
@@ -165,7 +165,7 @@ func (m *mockReplicaPKIClient) posts() ([]uint64, []*pki.ReplicaDescriptor) {
 	return epochs, descriptors
 }
 
-func createPublishDescriptorTestWorker(t *testing.T, pkiClient pki.Client) (*PKIWorker, func()) {
+func createPublishDescriptorTestWorker(t *testing.T, pkiClient pki.PostingClient) (*PKIWorker, func()) {
 	pkiScheme := signschemes.ByName(testPKIScheme)
 	idpubkey, _, err := pkiScheme.GenerateKey()
 	require.NoError(t, err)

--- a/replica/server.go
+++ b/replica/server.go
@@ -201,12 +201,12 @@ func New(cfg *config.Config) (*Server, error) {
 
 // NewWithPKI returns a new Server instance with a custom PKI implementation.
 // If pkiFactory is nil, the default PKI worker is used.
-func NewWithPKI(cfg *config.Config, pkiClient pki.PostingClient) (*Server, error) {
+func NewWithPKI(cfg *config.Config, pkiClient pki.ReplicaNodeClient) (*Server, error) {
 	return newServerWithPKI(cfg, pkiClient)
 }
 
 // newServerWithPKI is the internal implementation that supports both PKI factory and PKI client
-func newServerWithPKI(cfg *config.Config, pkiClient pki.PostingClient) (*Server, error) {
+func newServerWithPKI(cfg *config.Config, pkiClient pki.ReplicaNodeClient) (*Server, error) {
 	s := new(Server)
 	s.cfg = cfg
 
@@ -425,7 +425,7 @@ func (s *Server) initEnvelopeKeys() error {
 }
 
 // startServices starts all the server services (PKI worker, listeners, connector)
-func (s *Server) startServices(pkiClient pki.PostingClient) error {
+func (s *Server) startServices(pkiClient pki.ReplicaNodeClient) error {
 	// Start the fatal error watcher.
 	go func() {
 		err, ok := <-s.fatalErrCh

--- a/replica/server.go
+++ b/replica/server.go
@@ -458,7 +458,11 @@ func (s *Server) startServices(pkiClient pki.ReplicaNodeClient) error {
 	if err != nil {
 		panic(err)
 	}
+	// Publish the worker on the Server before starting its goroutine,
+	// so the worker's first iteration (which may call into Rebalance,
+	// reading s.PKIWorker) sees the assignment.
 	s.PKIWorker = pkiWorker
+	pkiWorker.Start()
 
 	// Bring the listener(s) online.
 	s.log.Notice("start listener workers")

--- a/replica/server.go
+++ b/replica/server.go
@@ -201,12 +201,12 @@ func New(cfg *config.Config) (*Server, error) {
 
 // NewWithPKI returns a new Server instance with a custom PKI implementation.
 // If pkiFactory is nil, the default PKI worker is used.
-func NewWithPKI(cfg *config.Config, pkiClient pki.Client) (*Server, error) {
+func NewWithPKI(cfg *config.Config, pkiClient pki.PostingClient) (*Server, error) {
 	return newServerWithPKI(cfg, pkiClient)
 }
 
 // newServerWithPKI is the internal implementation that supports both PKI factory and PKI client
-func newServerWithPKI(cfg *config.Config, pkiClient pki.Client) (*Server, error) {
+func newServerWithPKI(cfg *config.Config, pkiClient pki.PostingClient) (*Server, error) {
 	s := new(Server)
 	s.cfg = cfg
 
@@ -425,7 +425,7 @@ func (s *Server) initEnvelopeKeys() error {
 }
 
 // startServices starts all the server services (PKI worker, listeners, connector)
-func (s *Server) startServices(pkiClient pki.Client) error {
+func (s *Server) startServices(pkiClient pki.PostingClient) error {
 	// Start the fatal error watcher.
 	go func() {
 		err, ok := <-s.fatalErrCh

--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -72,7 +72,7 @@ type pki struct {
 	glue glue.Glue
 	log  *logging.Logger
 
-	impl        cpki.Client
+	impl        cpki.PostingClient
 	descAddrMap map[string][]string
 
 	docs          map[uint64]*pkicache.Entry

--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -72,7 +72,7 @@ type pki struct {
 	glue glue.Glue
 	log  *logging.Logger
 
-	impl        cpki.PostingClient
+	impl        cpki.MixNodeClient
 	descAddrMap map[string][]string
 
 	docs          map[uint64]*pkicache.Entry


### PR DESCRIPTION
The PKI client interface previously bundled four methods: a reader (GetPKIDocumentForEpoch), a deserializer (Deserialize), and two descriptor-upload methods (Post, PostReplica) that only mix nodes and storage replicas exercise. Read-only consumers, of which we already have a few (kpclientd, the courier, the directory authority's own historical fetch path) had no choice but to depend on the broader shape, and a forthcoming Reticulum-backed PKI client will likewise need only the reader half.

The interface is therefore divided. Client now carries only GetPKIDocumentForEpoch and Deserialize. PostingClient embeds Client and adds Post and PostReplica. The voting authority client implements both, so its New returns the broader PostingClient; reader-only callers may assign the result to a Client variable without ceremony.

Field declarations follow the usage. Reader-only callers (kpclientd at client/client.go, the courier worker at courier/server/pki.go, the voting server's bootstrap fetch in authority/voting/server/state.go) keep cpki.Client as their declared type, with the interface narrowing beneath them. Mix-node and replica callers (server/internal/pki/pki.go, replica/server.go, replica/pkiworker.go) move to cpki.PostingClient. The two integration mocks at client/pki_test.go and replica/integration_tests/courier_replica_integration_test.go each already implement all four methods and so continue to satisfy both interfaces unchanged.

This is a breaking change for any external consumer that imports pki.Client and reaches Post or PostReplica through it. Nothing in the monorepo does so.