### PR TITLE
courier: stop best-effort tombstone cleanup from hanging Copy

### DIFF
--- a/courier/server/plugin.go
+++ b/courier/server/plugin.go
@@ -795,12 +795,18 @@ func (e *Courier) processCopyCommand(copyCmd *pigeonhole.CopyCommand) *pigeonhol
 		e.log.Warningf("processCopyCommand: %d bytes remaining in decoder buffer after processing", decoder.Remaining())
 	}
 
-	// Tombstones are best-effort: we've already written the destination
-	// envelopes, so an incomplete temp-stream cleanup is a cache
-	// inefficiency, not a correctness failure.
-	e.writeTombstonesToTempChannel(writeCap, boxIDList)
-
 	e.log.Debugf("processCopyCommand: processed %d envelopes from %d boxes", envelopesProcessed, len(boxIDList))
+
+	// Tombstones are best-effort: the destination envelopes are
+	// already written, so an incomplete temp-stream cleanup is a cache
+	// inefficiency, not a correctness failure. It must therefore not
+	// gate the terminal Copy reply: the daemon polls InProgress until
+	// processCopyCommand returns, and a run of replica-rejected
+	// tombstone writes can span minutes per box, hanging the client.
+	// Run it off the reply path; boxIDList and writeCap are local and
+	// no longer touched here, so the goroutine owns them safely.
+	go e.writeTombstonesToTempChannel(writeCap, boxIDList)
+
 	return copySucceededReply()
 }
 
@@ -1249,6 +1255,19 @@ func (e *Courier) dispatchTombstone(
 					e.log.Debugf("dispatchTombstone: success on attempt %d", attempt+1)
 				}
 				return true
+			}
+		}
+		for _, r := range replies {
+			if r.ErrorCode == pigeonhole.ReplicaErrorBoxAlreadyExists {
+				// A box-already-exists rejection is permanent: the
+				// destination holds differing data and writes are
+				// immutable, so every escalating-backoff retry will
+				// be rejected identically (this is the run that spans
+				// minutes per box and hung the client). Bail at once.
+				// Transient errors (e.g. DatabaseFailure) still fall
+				// through to the retry below.
+				e.log.Debugf("dispatchTombstone: attempt %d permanently rejected (box already exists), not retrying", attempt+1)
+				return false
 			}
 		}
 		e.log.Debugf("dispatchTombstone: attempt %d produced %d replies, none successful", attempt+1, len(replies))

--- a/courier/server/tombstone_dispatch_test.go
+++ b/courier/server/tombstone_dispatch_test.go
@@ -135,6 +135,28 @@ func TestDispatchTombstoneRetriesOnAllErrors(t *testing.T) {
 	require.True(t, ok, "retry after all-errors must succeed on the second attempt")
 }
 
+// TestDispatchTombstoneBoxAlreadyExistsNotRetried pins the fix for the
+// copy-command hang: a BoxAlreadyExists rejection is permanent (the
+// destination holds differing data and writes are immutable), so
+// dispatchTombstone must fail on the first attempt rather than burn
+// the full escalating-backoff budget, which spanned minutes per box
+// and stalled the client's terminal Copy status. Exactly one attempt
+// is planned; were the rejection retried, the drive helper would see
+// no second reply and the dispatch would not return in time.
+func TestDispatchTombstoneBoxAlreadyExistsNotRetried(t *testing.T) {
+	courier := createTestCourier(t)
+	conn := newFakeConnector()
+	courier.server.connector = conn
+
+	replicaIDs := []uint8{7, 8}
+	messages, envHash := buildTestTombstoneMessages(replicaIDs, 0xAE)
+
+	ok := driveTombstoneDispatch(t, courier, conn, envHash, replicaIDs, messages, [][]uint8{
+		{pigeonhole.ReplicaErrorBoxAlreadyExists, pigeonhole.ReplicaErrorBoxAlreadyExists},
+	})
+	require.False(t, ok, "a permanent BoxAlreadyExists rejection must not be retried")
+}
+
 // TestDispatchTombstoneSingleShardSuccess covers the degraded case
 // where only one shard's envelope key was usable (the other shard's
 // key was missing or failed to unmarshal). The dispatch still works


### PR DESCRIPTION
processCopyCommand returned the terminal Copy reply only after writeTombstonesToTempChannel finished. That cleanup is best-effort by its own admission, yet for each box it called dispatchTombstone, which retried a replica-rejected write through the full escalating-backoff budget. When the destination box already held differing data the rejection was permanent, so every box burned roughly a minute of doomed retries while the daemon, polling for the terminal status, resent forever and the client hung until its timeout. This is the courier half of the recurring CI stall.

Two changes, each minimal and modelled on dispatchCopyEnvelope:

- processCopyCommand now returns copySucceededReply immediately and runs writeTombstonesToTempChannel in a goroutine. The copy is already complete once the envelopes are dispatched; the temp-stream tombstones are a cache courtesy and must not gate the reply. This alone removes the client-visible hang. boxIDList and writeCap are local and untouched thereafter, so the goroutine owns them.

- dispatchTombstone now treats a BoxAlreadyExists reply as the permanent rejection it is and returns at once, as dispatchCopyEnvelope already does, instead of retrying a write that immutability guarantees will be refused identically. Genuinely transient errors (e.g. DatabaseFailure) still retry, so the existing retry test is unaffected; a new test pins the no-retry behaviour for the permanent case.

courier/server tests all pass.