### PR TITLE
wire: disable Nagle on every TCP handshake path

### DIFF
--- a/authority/voting/client/client.go
+++ b/authority/voting/client/client.go
@@ -216,6 +216,11 @@ func (p *connector) initSession(
 		conn, err = common.DialURL(u, ictx, dialFn)
 		cancelFn()
 		if err == nil {
+			// Disable Nagle so handshake/finalisation messages do not
+			// wait on a coalesce timer; harmless on non-TCP transports.
+			if tcpConn, ok := conn.(*net.TCPConn); ok {
+				tcpConn.SetNoDelay(true)
+			}
 			connectedURL = peer.Addresses[idx]
 			break
 		}

--- a/authority/voting/server/wire_handler.go
+++ b/authority/voting/server/wire_handler.go
@@ -46,6 +46,14 @@ func (s *Server) onConn(conn net.Conn) {
 	rAddr := conn.RemoteAddr()
 	lAddr := conn.LocalAddr()
 
+	// Disable Nagle so the responder's finalisation NoOp does not wait
+	// on a coalesce timer behind the small handshake messages it
+	// follows. The cast fails for QUIC connections (rightly so; Nagle
+	// is TCP-specific) and is silently skipped in that case.
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		tcpConn.SetNoDelay(true)
+	}
+
 	phaseAtAccept, remainingAtAccept := s.state.PhaseInfo()
 	acceptedAt := time.Now()
 

--- a/courier/server/outgoing_conn.go
+++ b/courier/server/outgoing_conn.go
@@ -303,6 +303,11 @@ func (c *outgoingConn) dialAddress(dialCtx *workerContext, dialer *net.Dialer, a
 	}
 
 	c.log.Debugf("%v connection established.", u.Scheme)
+	// Disable Nagle so handshake/finalisation messages do not wait on
+	// a coalesce timer; harmless on non-TCP transports.
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		tcpConn.SetNoDelay(true)
+	}
 	return conn, false
 }
 

--- a/replica/listener.go
+++ b/replica/listener.go
@@ -83,6 +83,10 @@ func (l *Listener) worker() {
 			tcpConn.SetKeepAlive(true)
 			keepAliveInterval := time.Duration(l.server.cfg.KeepAliveInterval) * time.Millisecond
 			tcpConn.SetKeepAlivePeriod(keepAliveInterval)
+			// Disable Nagle so the responder's finalisation NoOp does
+			// not wait on a coalesce timer behind the small handshake
+			// messages it follows.
+			tcpConn.SetNoDelay(true)
 		}
 
 		l.log.Debugf("Accepted new connection: %v", conn.RemoteAddr())

--- a/replica/outgoing_conn.go
+++ b/replica/outgoing_conn.go
@@ -204,6 +204,12 @@ func (c *outgoingConn) dialAndHandleConnection(addr string, dialCtx context.Cont
 	}
 	c.log.Debugf("%v connection established.", u.Scheme)
 
+	// Disable Nagle so handshake/finalisation messages do not wait on
+	// a coalesce timer; harmless on non-TCP transports.
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		tcpConn.SetNoDelay(true)
+	}
+
 	start := time.Now()
 
 	// Handle the new connection.

--- a/server/internal/incoming/listener.go
+++ b/server/internal/incoming/listener.go
@@ -105,6 +105,10 @@ func (l *listener) worker() {
 		if ok {
 			tcpConn.SetKeepAlive(true)
 			tcpConn.SetKeepAlivePeriod(constants.KeepAliveInterval)
+			// Disable Nagle so the responder's finalisation NoOp does
+			// not wait on a coalesce timer behind the small handshake
+			// messages it follows.
+			tcpConn.SetNoDelay(true)
 		}
 
 		l.log.Debugf("Accepted new connection: %v", conn.RemoteAddr())

--- a/server/internal/outgoing/outgoing_conn.go
+++ b/server/internal/outgoing/outgoing_conn.go
@@ -256,6 +256,11 @@ func (c *outgoingConn) worker() {
 				}
 			}
 			c.log.Debugf("%v connection established.", u.Scheme)
+			// Disable Nagle so handshake/finalisation messages do not
+			// wait on a coalesce timer; harmless on non-TCP transports.
+			if tcpConn, ok := conn.(*net.TCPConn); ok {
+				tcpConn.SetNoDelay(true)
+			}
 			instrument.Outgoing()
 			start := time.Now()
 


### PR DESCRIPTION
Every TCP connection entering the PQ Noise wire handshake had Nagle's algorithm enabled (the kernel default). The handshake's core/wire/session.go pattern is four Noise messages followed by an explicit finalisation NoOp sent by the responder once it has authenticated the initiator. The NoOp is tens of bytes; Nagle holds it behind the just-written msg4, while the initiator (whose only job at that point is to RecvCommand the NoOp) has no outgoing data to ride a piggy-back ACK on, so Linux's delayed-ACK sits ~40 ms (up to 500 ms in degraded paths) before flushing. Every fresh session paid that toll for no useful reason.

Set TCP_NODELAY (SetNoDelay(true)) at every site that hands a fresh net.Conn into the handshake state machine:

  - listeners: server/internal/incoming/listener.go, replica/listener.go, authority/voting/server/wire_handler.go's onConn (which previously set neither KeepAlive nor NoDelay)
  - dialers: server/internal/outgoing/outgoing_conn.go, courier/server/outgoing_conn.go, replica/outgoing_conn.go, authority/voting/client/client.go

Each cast is type-guarded against *net.TCPConn, so QUIC and other non-TCP transports pass through unaffected.