### PR TITLE
Raise stream payload and frame limits to 40 MiB

### DIFF
--- a/client/sack_daemon.go
+++ b/client/sack_daemon.go
@@ -19,10 +19,11 @@ import (
 
 // DefaultMaxStreamPayloadBytes is the ceiling on a WriteStream plaintext (and
 // a ReadStream result) when the kpclientd config leaves MaxStreamPayloadBytes
-// unset. It sits well below the wire frame limit (thin.MaxMessageSize) so the
-// daemon can answer an oversize request with a clean ThinClientErrorPayloadTooLarge
-// reply rather than have the frame rejected at the transport.
-const DefaultMaxStreamPayloadBytes = 8 * 1024 * 1024
+// unset. It matches the wire frame limit (thin.MaxMessageSize); an operator who
+// wants the daemon to answer oversize requests with a clean
+// ThinClientErrorPayloadTooLarge reply (rather than have the frame rejected at
+// the transport) sets MaxStreamPayloadBytes to something below the frame.
+const DefaultMaxStreamPayloadBytes = 40 * 1024 * 1024
 
 // resolveMaxStreamPayload turns a configured MaxStreamPayloadBytes into the
 // effective limit: unset (<= 0) yields the default, and any value above the

--- a/client/thin/thin.go
+++ b/client/thin/thin.go
@@ -114,11 +114,11 @@ const (
 	// thin-client/daemon socket. The 4-byte big-endian prefix is
 	// attacker-controlled in both directions; without a ceiling a
 	// hostile or buggy peer could declare a multi-gigabyte frame and
-	// drive the reader to allocate it before any payload arrives. 16
+	// drive the reader to allocate it before any payload arrives. 40
 	// MiB is far above any legitimate CBOR thin-client message yet far
 	// below a memory-exhaustion threat. Frames larger than this are
 	// rejected before allocation.
-	MaxMessageSize = 16 * 1024 * 1024
+	MaxMessageSize = 40 * 1024 * 1024
 )
 
 var (


### PR DESCRIPTION
Default MaxStreamPayloadBytes and the wire frame ceiling thin.MaxMessageSize both go to 40 MiB.