### PR TITLE
courier: default Logging.File to courier.log

### DIFF
--- a/CONFIG_CHANGES.md
+++ b/CONFIG_CHANGES.md
@@ -282,6 +282,16 @@ Source: `courier/server/config/config.go`.
   `netip.ParseAddrPort` to `net.SplitHostPort` so a bridge-network
   courier may bind on its docker-compose hostname).
 
+### Defaults
+
+- `[Logging]` `File` now defaults to `courier.log` (resolved against
+  `DataDir`) when left empty, instead of stdout. The courier is always
+  launched as a CBOR plugin and announces its socket path on stdout, so
+  an empty `File` previously corrupted that handshake and the service
+  node refused to start. Set an absolute `File` to override the
+  location, or `Disable = true` to silence logging entirely. This takes
+  effect even if the operator's TOML is otherwise unchanged.
+
 No removals or breaking changes.
 
 ## Client daemon, kpclientd (`client.toml`)

--- a/courier/server/config/config.go
+++ b/courier/server/config/config.go
@@ -16,6 +16,12 @@ import (
 
 const (
 	DefaultMaxQueueSize = 64 // Default outgoing connection queue size.
+
+	// DefaultLogFile is the log file the courier falls back to when no
+	// Logging.File is configured. The courier is always launched as a
+	// CBOR plugin and announces its socket path on stdout, so logging
+	// to stdout (the empty-File behaviour) would corrupt that handshake.
+	DefaultLogFile = "courier.log"
 )
 
 // Type aliases for common configuration structures
@@ -92,6 +98,11 @@ func (c *Config) FixupAndValidate() error {
 	}
 	if err := c.Logging.Validate(); err != nil {
 		return err
+	}
+	if c.Logging.File == "" {
+		// Resolved against DataDir at log-init time; keeps stdout
+		// clear for the plugin socket handshake.
+		c.Logging.File = DefaultLogFile
 	}
 	if c.WireKEMScheme == "" {
 		return errors.New("config: Server: WireKEMScheme is not set")

--- a/courier/server/config/config_test.go
+++ b/courier/server/config/config_test.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (C) 2024 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/katzenpost/core/sphinx/geo"
+)
+
+func newValidCourierConfig() *Config {
+	return &Config{
+		PKI:            &PKI{},
+		WireKEMScheme:  "x25519",
+		DataDir:        "/var/lib/courier",
+		SphinxGeometry: &geo.Geometry{},
+		Logging:        &Logging{Level: "INFO"},
+	}
+}
+
+// The courier announces its plugin socket on stdout, so an unset
+// Logging.File (which otherwise means "log to stdout") must fall back
+// to a file rather than corrupt the handshake.
+func TestFixupAndValidateDefaultsLogFile(t *testing.T) {
+	cfg := newValidCourierConfig()
+	require.NoError(t, cfg.FixupAndValidate())
+	require.Equal(t, DefaultLogFile, cfg.Logging.File)
+}
+
+// A nil Logging block defaults to stdout via DefaultLogging; the same
+// fallback must apply so the handshake stays clean.
+func TestFixupAndValidateDefaultsLogFileWhenLoggingNil(t *testing.T) {
+	cfg := newValidCourierConfig()
+	cfg.Logging = nil
+	require.NoError(t, cfg.FixupAndValidate())
+	require.Equal(t, DefaultLogFile, cfg.Logging.File)
+}
+
+// An explicitly configured File must be preserved untouched.
+func TestFixupAndValidatePreservesExplicitLogFile(t *testing.T) {
+	cfg := newValidCourierConfig()
+	cfg.Logging.File = "/var/log/katzenpost/courier.log"
+	require.NoError(t, cfg.FixupAndValidate())
+	require.Equal(t, "/var/log/katzenpost/courier.log", cfg.Logging.File)
+}


### PR DESCRIPTION
The courier is invariably launched as a CBOR plugin and announces its socket path upon stdout. An empty Logging.File directed the courier's own logs to that selfsame stdout, whereupon the startup banner was mistaken for the socket path and the service node declined to start. FixupAndValidate now falls back to courier.log, resolved against DataDir, leaving stdout clear for the handshake.