### PR TITLE
authority: log one self-contained descriptor rejection reason

### DIFF
--- a/authority/voting/server/descriptor_authorization_test.go
+++ b/authority/voting/server/descriptor_authorization_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/hpqc/hash"
+
+	"github.com/katzenpost/katzenpost/core/pki"
+)
+
+// The descriptor authorization errors must name both the value the authority
+// pins and the value the descriptor announces, on one line, so that an
+// operator can diagnose a rejection without correlating separate log entries.
+func TestReplicaAuthorizationError(t *testing.T) {
+	idKey := []byte("storagereplica1-identity-key")
+	st := &state{
+		authorizedReplicaNodes: map[[publicKeyHashSize]byte]*authorizedReplicaInfo{
+			hash.Sum256(idKey): {Identifier: "storagereplica1", ReplicaID: 1},
+		},
+	}
+
+	require.NoError(t, st.replicaAuthorizationError(&pki.ReplicaDescriptor{
+		Name: "storagereplica1", ReplicaID: 1, IdentityKey: idKey,
+	}))
+
+	t.Run("ReplicaID mismatch names both values", func(t *testing.T) {
+		err := st.replicaAuthorizationError(&pki.ReplicaDescriptor{
+			Name: "storagereplica1", ReplicaID: 0, IdentityKey: idKey,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "ReplicaID mismatch")
+		require.Contains(t, err.Error(), "ReplicaID=1")     // pinned
+		require.Contains(t, err.Error(), "ReplicaID=0")     // announced
+		require.Contains(t, err.Error(), "storagereplica1") // node name
+	})
+
+	t.Run("name mismatch", func(t *testing.T) {
+		err := st.replicaAuthorizationError(&pki.ReplicaDescriptor{
+			Name: "impostor", ReplicaID: 1, IdentityKey: idKey,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "name mismatch")
+		require.Contains(t, err.Error(), "storagereplica1")
+		require.Contains(t, err.Error(), "impostor")
+	})
+
+	t.Run("identity key not pinned", func(t *testing.T) {
+		err := st.replicaAuthorizationError(&pki.ReplicaDescriptor{
+			Name: "storagereplica1", ReplicaID: 1, IdentityKey: []byte("unknown-key"),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not pinned")
+	})
+}
+
+func TestDescriptorAuthorizationError(t *testing.T) {
+	mixKey := []byte("mix1-identity-key")
+	st := &state{
+		authorizedMixes: map[[publicKeyHashSize]byte]string{
+			hash.Sum256(mixKey): "mix1",
+		},
+	}
+
+	require.NoError(t, st.descriptorAuthorizationError(&pki.MixDescriptor{
+		Name: "mix1", IdentityKey: mixKey,
+	}))
+
+	err := st.descriptorAuthorizationError(&pki.MixDescriptor{
+		Name: "wrong", IdentityKey: mixKey,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "name mismatch")
+	require.Contains(t, err.Error(), "mix")
+
+	err = st.descriptorAuthorizationError(&pki.MixDescriptor{
+		Name: "ghost", IdentityKey: []byte("unknown-key"),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not pinned")
+
+	// A descriptor cannot be both a gateway and a service node.
+	err = st.descriptorAuthorizationError(&pki.MixDescriptor{
+		Name: "twofaced", IdentityKey: mixKey, IsGatewayNode: true, IsServiceNode: true,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "contradictory")
+	require.Contains(t, err.Error(), "twofaced")
+}

--- a/authority/voting/server/state.go
+++ b/authority/voting/server/state.go
@@ -1880,67 +1880,75 @@ func staleEpochKeys(bkt *bolt.Bucket, cmpEpoch uint64) [][]byte {
 	return stale
 }
 
-func (s *state) isReplicaDescriptorAuthorized(desc *pki.ReplicaDescriptor) bool {
+// replicaAuthorizationError returns nil when desc is from a replica this
+// authority has pinned in its StorageReplicas configuration, or an error
+// describing the exact mismatch otherwise. Each message reports both the value
+// the authority pins and the value the descriptor announces, so that an
+// operator can see on a single line which side is wrong; the usual cause is a
+// replica running with a ReplicaID that does not match its pinned identity key.
+func (s *state) replicaAuthorizationError(desc *pki.ReplicaDescriptor) error {
 	pk := hash.Sum256(desc.IdentityKey)
 	replicaInfo, ok := s.authorizedReplicaNodes[pk]
 	if !ok {
-		s.log.Errorf("StorageReplica authentication failure: key hash %x not in map", pk)
-		return false
+		return fmt.Errorf("identity key hash %x is not pinned in this authority's StorageReplicas configuration", pk)
 	}
 	if replicaInfo.Identifier != desc.Name {
-		s.log.Errorf("StorageReplica authentication failure: name mismatch - map has '%s', descriptor has '%s'", replicaInfo.Identifier, desc.Name)
-		return false
+		return fmt.Errorf("name mismatch: authority pins name %q for this identity key, descriptor announces %q", replicaInfo.Identifier, desc.Name)
 	}
 	if replicaInfo.ReplicaID != desc.ReplicaID {
-		s.log.Errorf("StorageReplica authentication failure: ReplicaID mismatch - config has '%d', descriptor has '%d'", replicaInfo.ReplicaID, desc.ReplicaID)
+		return fmt.Errorf("ReplicaID mismatch: authority pins ReplicaID=%d for %q, descriptor announces ReplicaID=%d", replicaInfo.ReplicaID, replicaInfo.Identifier, desc.ReplicaID)
+	}
+	return nil
+}
+
+func (s *state) isReplicaDescriptorAuthorized(desc *pki.ReplicaDescriptor) bool {
+	if err := s.replicaAuthorizationError(desc); err != nil {
+		s.log.Errorf("StorageReplica authorization failure for descriptor name=%q ReplicaID=%d identity_hash=%x: %s",
+			desc.Name, desc.ReplicaID, hash.Sum256(desc.IdentityKey), err)
 		return false
 	}
-	s.log.Debugf("StorageReplica authentication OK: %s (ReplicaID=%d) with hash %x", replicaInfo.Identifier, replicaInfo.ReplicaID, pk)
+	s.log.Debugf("StorageReplica authentication OK: %s (ReplicaID=%d) with hash %x", desc.Name, desc.ReplicaID, hash.Sum256(desc.IdentityKey))
 	return true
 }
 
-func (s *state) isDescriptorAuthorized(desc *pki.MixDescriptor) bool {
+// descriptorAuthorizationError returns nil when desc is from a mix, gateway or
+// service node this authority has pinned. It returns an error naming the
+// mismatch otherwise: an unpinned identity key, a name that disagrees with the
+// pinned one, or a descriptor that claims to be both a gateway and a service
+// node at once. As with replicas, the message reports both the pinned and the
+// announced value.
+func (s *state) descriptorAuthorizationError(desc *pki.MixDescriptor) error {
 	pk := hash.Sum256(desc.IdentityKey)
-	if !desc.IsGatewayNode && !desc.IsServiceNode {
-		name, ok := s.authorizedMixes[pk]
-		if !ok {
-			s.log.Errorf("Mix authentication failure: key hash %x not authorized", pk)
-			return false
-		}
-		if name != desc.Name {
-			s.log.Errorf("Mix name mismatch: expected %s, got %s", name, desc.Name)
-			return false
-		}
-		s.log.Debugf("Mix authentication OK: %s with hash %x", desc.Name, pk)
-		return true
+	var role string
+	var authorized map[[publicKeyHashSize]byte]string
+	switch {
+	case desc.IsGatewayNode && !desc.IsServiceNode:
+		role, authorized = "gateway", s.authorizedGatewayNodes
+	case desc.IsServiceNode && !desc.IsGatewayNode:
+		role, authorized = "service node", s.authorizedServiceNodes
+	case !desc.IsGatewayNode && !desc.IsServiceNode:
+		role, authorized = "mix", s.authorizedMixes
+	default:
+		return fmt.Errorf("descriptor %q has contradictory node-type flags: marked as both a gateway and a service node", desc.Name)
 	}
-	if desc.IsGatewayNode {
-		name, ok := s.authorizedGatewayNodes[pk]
-		if !ok {
-			s.log.Errorf("Gateway authentication failure: key hash %x not in map", pk)
-			return false
-		}
-		if name != desc.Name {
-			s.log.Errorf("Gateway authentication failure: name mismatch - map has '%s', descriptor has '%s'", name, desc.Name)
-			return false
-		}
-		s.log.Debugf("Gateway authentication OK: %s with hash %x", name, pk)
-		return true
+	pinned, ok := authorized[pk]
+	if !ok {
+		return fmt.Errorf("%s identity key hash %x is not pinned in this authority's configuration", role, pk)
 	}
-	if desc.IsServiceNode {
-		name, ok := s.authorizedServiceNodes[pk]
-		if !ok {
-			s.log.Errorf("ServiceNode authentication failure: key hash %x not in map", pk)
-			return false
-		}
-		if name != desc.Name {
-			s.log.Errorf("ServiceNode authentication failure: name mismatch - map has '%s', descriptor has '%s'", name, desc.Name)
-			return false
-		}
-		s.log.Debugf("ServiceNode authentication OK: %s with hash %x", name, pk)
-		return true
+	if pinned != desc.Name {
+		return fmt.Errorf("%s name mismatch: authority pins %q for this identity key, descriptor announces %q", role, pinned, desc.Name)
 	}
-	panic("impossible")
+	return nil
+}
+
+func (s *state) isDescriptorAuthorized(desc *pki.MixDescriptor) bool {
+	if err := s.descriptorAuthorizationError(desc); err != nil {
+		s.log.Errorf("Node authorization failure for descriptor name=%q identity_hash=%x: %s",
+			desc.Name, hash.Sum256(desc.IdentityKey), err)
+		return false
+	}
+	s.log.Debugf("Node authentication OK: %s with hash %x", desc.Name, hash.Sum256(desc.IdentityKey))
+	return true
 }
 
 func (s *state) dupSig(sig commands.Sig) bool {

--- a/authority/voting/server/wire_handler.go
+++ b/authority/voting/server/wire_handler.go
@@ -570,8 +570,9 @@ func (s *Server) onPostReplicaDescriptor(peerID string, cmd *commands.PostReplic
 	}
 
 	// Ensure that the descriptor is from an allowed peer.
-	if !s.state.isReplicaDescriptorAuthorized(desc) {
-		s.log.Errorf("Peer %s: Identity key hash '%x' not authorized", peerID, hash.Sum256(desc.IdentityKey))
+	if err := s.state.replicaAuthorizationError(desc); err != nil {
+		s.log.Errorf("Peer %s: rejecting replica descriptor name=%q ReplicaID=%d identity_hash=%x: %s",
+			peerID, desc.Name, desc.ReplicaID, hash.Sum256(desc.IdentityKey), err)
 		instrument.DescriptorRejected("replica", "unauthorized")
 		resp.ErrorCode = commands.DescriptorForbidden
 		return resp
@@ -698,8 +699,8 @@ func (s *Server) onPostDescriptor(peerID string, cmd *commands.PostDescriptor, p
 
 	// Ensure that the descriptor is from an allowed peer.
 	s.log.Debugf("onPostDescriptor: Checking authorization for node %s from peer %s", strconv.QuoteToASCII(desc.Name), strconv.QuoteToASCII(peerID))
-	if !s.state.isDescriptorAuthorized(desc) {
-		s.log.Errorf("onPostDescriptor: AUTHORIZATION FAILED for node %s from peer %s: identity key hash %x not authorized", strconv.QuoteToASCII(desc.Name), strconv.QuoteToASCII(peerID), hash.Sum256(desc.IdentityKey))
+	if err := s.state.descriptorAuthorizationError(desc); err != nil {
+		s.log.Errorf("onPostDescriptor: AUTHORIZATION FAILED for node %s from peer %s: %s", strconv.QuoteToASCII(desc.Name), strconv.QuoteToASCII(peerID), err)
 		instrument.DescriptorRejected("mix", "unauthorized")
 		resp.ErrorCode = commands.DescriptorForbidden
 		return resp


### PR DESCRIPTION
A rejected descriptor was reported across two disjoint log lines: a wrapper naming the peer but not the reason, and an authorization-failure line naming the reason but not the node. A grep by node name found the former and missed the latter, which made a ReplicaID mismatch tedious to diagnose in the field.

The authorization checks now return an error that names both the pinned and the announced value, and the upload handler logs it on a single line alongside the node name, ReplicaID, and identity hash. The same applies to mix, gateway, and service descriptors. The node-type switch now lists the three valid roles explicitly and rejects, via its default arm, a descriptor that claims to be both a gateway and a service node, a contradiction the prior code silently accepted as a gateway. Tests cover each reason.