### PR TITLE
server/incoming: admit clients when any usable PKI doc is cached

### DIFF
--- a/courier/server/copy_pki_gap_test.go
+++ b/courier/server/copy_pki_gap_test.go
@@ -1,0 +1,46 @@
+// copy_pki_gap_test.go - Tests for shard-document resolution across an epoch gap.
+// Copyright (C) 2026  The Katzenpost Authors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/katzenpost/core/epochtime"
+	"github.com/katzenpost/katzenpost/core/pki"
+)
+
+// TestPKIDocForShardingFallback verifies that shard resolution falls back to the
+// most recently cached document during the window after an epoch rollover, when
+// the current epoch's document has not yet been fetched. Without this, the Copy
+// read and tombstone paths would refuse to operate during that gap even though
+// the previous document is cached and shard membership is unchanged.
+func TestPKIDocForShardingFallback(t *testing.T) {
+	courier := createTestCourier(t)
+	// Stop the background PKI worker so the cache is solely under test control.
+	courier.server.PKI.Halt()
+
+	now, _, _ := epochtime.Now()
+
+	// Nothing cached: the genuine no-document case is still surfaced as nil.
+	require.Nil(t, courier.pkiDocForSharding())
+
+	// Post-rollover gap: only the previous epoch's document is cached, so the
+	// current-epoch lookup is nil but the fallback returns the previous one.
+	prev := &pki.Document{Epoch: now - 1}
+	courier.server.PKI.SetDocumentForEpoch(now-1, prev, []byte("prev"))
+	require.Nil(t, courier.server.PKI.PKIDocument(), "current epoch must be absent")
+	got := courier.pkiDocForSharding()
+	require.NotNil(t, got, "must fall back to the cached previous document")
+	require.Equal(t, now-1, got.Epoch)
+
+	// Once the current epoch's document arrives, it is preferred.
+	cur := &pki.Document{Epoch: now}
+	courier.server.PKI.SetDocumentForEpoch(now, cur, []byte("cur"))
+	got = courier.pkiDocForSharding()
+	require.NotNil(t, got)
+	require.Equal(t, now, got.Epoch)
+}

--- a/courier/server/plugin.go
+++ b/courier/server/plugin.go
@@ -424,6 +424,18 @@ func (e *Courier) getCurrentEpoch() uint64 {
 	return 0
 }
 
+// pkiDocForSharding returns the current epoch's document, or the most recently
+// cached one during the window after an epoch rotation before the new document
+// has been fetched. Shard membership is stable across adjacent epochs, so a
+// one-epoch-stale document yields the shards every peer computes.
+func (e *Courier) pkiDocForSharding() *cpki.Document {
+	doc := e.server.PKI.PKIDocument()
+	if doc == nil {
+		doc = e.server.PKI.LastCachedPKIDocument()
+	}
+	return doc
+}
+
 // logFinalCacheState logs the final state of the cache entry
 func (e *Courier) logFinalCacheState(reply *commands.ReplicaMessageReply) {
 	finalEntry := e.dedupCache[*reply.EnvelopeHash]
@@ -1091,7 +1103,7 @@ func (e *Courier) readNextBox(reader *bacap.StatefulReader, boxID *[bacap.BoxIDS
 func (e *Courier) readBoxFromShardReplicas(boxID *[bacap.BoxIDSize]byte) (*pigeonhole.ReplicaReadReply, uint8, error) {
 	e.log.Debugf("readBoxFromShardReplicas: Reading box %x", boxID[:8])
 
-	doc := e.server.PKI.PKIDocument()
+	doc := e.pkiDocForSharding()
 	if doc == nil {
 		return nil, 0, fmt.Errorf("PKI document is nil")
 	}
@@ -1259,7 +1271,7 @@ func (e *Courier) writeTombstonesToTempChannel(writeCap *bacap.WriteCap, boxIDs 
 	}
 
 	// Get PKI document for replica selection
-	doc := e.server.PKI.PKIDocument()
+	doc := e.pkiDocForSharding()
 	if doc == nil {
 		e.log.Errorf("writeTombstonesToTempChannel: PKI document is nil")
 		instrument.DroppedByReason("tombstone_nil_pki")

--- a/server/internal/glue/glue.go
+++ b/server/internal/glue/glue.go
@@ -70,6 +70,7 @@ type PKI interface {
 	AuthenticateConnection(*wire.PeerCredentials, bool) (*pki.MixDescriptor, bool, bool)
 	GetRawConsensus(uint64) ([]byte, error)
 	CurrentDocument() (*pki.Document, error)
+	HasUsableDocument() bool
 }
 
 type Gateway interface {

--- a/server/internal/incoming/listener.go
+++ b/server/internal/incoming/listener.go
@@ -114,14 +114,17 @@ func (l *listener) worker() {
 			continue
 		}
 
-		// If no PKI document has been loaded yet, we cannot validate
-		// any incoming peer credentials at IsPeerValid time and would
-		// produce spurious handshake failures on the initiator side
-		// during the boot convergence window. Refuse the connection
-		// at the TCP layer instead and let the initiator's Connector
-		// retry on its existing backoff once both sides have converged.
-		if _, perr := l.glue.PKI().CurrentDocument(); perr != nil {
-			l.log.Debugf("Refusing connection from %v: no PKI document loaded yet", conn.RemoteAddr())
+		// If we hold no usable PKI document in the valid epoch window, we
+		// cannot validate any incoming peer credentials at IsPeerValid time
+		// and would produce spurious handshake failures on the initiator side
+		// during the boot convergence window. Refuse the connection at the TCP
+		// layer instead and let the initiator's Connector retry on its existing
+		// backoff once both sides have converged. We accept on any document in
+		// the window, not just the current epoch's, so a client can still be
+		// served from the previous document during the gap after an epoch
+		// rollover but before the new consensus has been fetched.
+		if !l.glue.PKI().HasUsableDocument() {
+			l.log.Debugf("Refusing connection from %v: no usable PKI document", conn.RemoteAddr())
 			conn.Close()
 			handshakeinstrument.IncomingRefusedNoPKIDoc()
 			continue

--- a/server/internal/incoming/listener_gate_test.go
+++ b/server/internal/incoming/listener_gate_test.go
@@ -1,0 +1,103 @@
+// listener_gate_test.go - Tests for the incoming listener admission gate.
+// Copyright (C) 2026  The Katzenpost Authors.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+
+package incoming
+
+import (
+	"container/list"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"gopkg.in/op/go-logging.v1"
+
+	"github.com/katzenpost/katzenpost/server/internal/glue"
+)
+
+// fakePKI satisfies glue.PKI; only HasUsableDocument is exercised by the gate.
+type fakePKI struct {
+	glue.PKI
+	usable bool
+}
+
+func (f *fakePKI) HasUsableDocument() bool { return f.usable }
+
+// fakeGlue satisfies glue.Glue; only PKI() is exercised by the gate.
+type fakeGlue struct {
+	glue.Glue
+	pki glue.PKI
+}
+
+func (g *fakeGlue) PKI() glue.PKI { return g.pki }
+
+type gateAddr struct{}
+
+func (gateAddr) Network() string { return "test" }
+func (gateAddr) String() string  { return "test" }
+
+// permError is a permanent net.Error so worker() returns once the listener is
+// closed, rather than spinning.
+type permError struct{}
+
+func (permError) Error() string   { return "listener closed" }
+func (permError) Timeout() bool   { return false }
+func (permError) Temporary() bool { return false }
+
+// gateListener feeds a single connection to worker(), then reports a permanent
+// error so the accept loop exits cleanly.
+type gateListener struct {
+	conns     chan net.Conn
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func (l *gateListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.conns:
+		return c, nil
+	case <-l.done:
+		return nil, permError{}
+	}
+}
+
+func (l *gateListener) Close() error {
+	l.closeOnce.Do(func() { close(l.done) })
+	return nil
+}
+
+func (l *gateListener) Addr() net.Addr { return gateAddr{} }
+
+// TestListenerRefusesWithoutUsableDocument verifies the accept-time gate closes
+// an incoming connection when the gateway holds no usable PKI document. This is
+// the boot case the gate must still reject; the complementary admit case (a
+// cached previous-epoch document, the bug this change fixes) is covered by
+// pki.TestHasUsableDocument.
+func TestListenerRefusesWithoutUsableDocument(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	gl := &gateListener{conns: make(chan net.Conn, 1), done: make(chan struct{})}
+	gl.conns <- serverConn
+
+	l := &listener{
+		glue:       &fakeGlue{pki: &fakePKI{usable: false}},
+		log:        logging.MustGetLogger("incoming_gate_test"),
+		l:          gl,
+		conns:      list.New(),
+		closeAllCh: make(chan interface{}),
+	}
+
+	go l.worker()
+	defer gl.Close()
+
+	if err := clientConn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := clientConn.Read(make([]byte, 1)); err == nil {
+		t.Fatal("expected the gate to close the connection when no usable document is cached")
+	}
+}

--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -858,6 +858,18 @@ func (p *pki) CurrentDocument() (*cpki.Document, error) {
 	return nil, cpki.ErrNoDocument
 }
 
+// HasUsableDocument reports whether we hold at least one PKI document in the
+// valid epoch window [now+1 .. now-(NumMixKeys-1)]. This is the condition under
+// which the node can authenticate peers and serve clients, including the window
+// after an epoch rollover but before the new consensus has been fetched, when
+// only the previous epoch's document is cached. It is deliberately more lenient
+// than CurrentDocument(), which requires the document for the current epoch
+// specifically.
+func (p *pki) HasUsableDocument() bool {
+	docs, _, _, _ := p.documentsForAuthentication()
+	return len(docs) > 0
+}
+
 func (p *pki) GetRawConsensus(epoch uint64) ([]byte, error) {
 	if ok, err := p.getFailedFetch(epoch); ok {
 		p.log.Debugf("GetRawConsensus failure: no cached PKI document for epoch %v: %v", epoch, err)

--- a/server/internal/pki/pki_test.go
+++ b/server/internal/pki/pki_test.go
@@ -11,8 +11,36 @@ package pki
 import (
 	"testing"
 
+	"github.com/katzenpost/katzenpost/core/epochtime"
 	cpki "github.com/katzenpost/katzenpost/core/pki"
+	"github.com/katzenpost/katzenpost/server/internal/pkicache"
 )
+
+// TestHasUsableDocument verifies the admission predicate the incoming listener
+// relies on: a gateway with no document at all refuses connections (the boot
+// case), but a gateway holding the previous epoch's document accepts them, so a
+// client may still be served during the window after an epoch rollover but
+// before the new consensus has been fetched.
+func TestHasUsableDocument(t *testing.T) {
+	now, _, _ := epochtime.Now()
+
+	p := &pki{docs: make(map[uint64]*pkicache.Entry)}
+
+	if p.HasUsableDocument() {
+		t.Fatal("no cached document: expected not usable (boot case)")
+	}
+
+	p.docs[now-1] = &pkicache.Entry{}
+	if !p.HasUsableDocument() {
+		t.Fatal("previous-epoch document cached: expected usable")
+	}
+
+	delete(p.docs, now-1)
+	p.docs[now] = &pkicache.Entry{}
+	if !p.HasUsableDocument() {
+		t.Fatal("current-epoch document cached: expected usable")
+	}
+}
 
 func TestMakeDescAddrMapBracketsIPv6(t *testing.T) {
 	m, err := makeDescAddrMap([]string{"tcp://[2a02:898:246:64::34:78]:4242"})


### PR DESCRIPTION
The accept gate keyed on the current epoch's document, so gateways, service nodes, and mix nodes refused connections at every epoch rollover despite holding a valid previous document. Gate on HasUsableDocument instead, preserving the boot-window refusal when nothing is cached.