### PR TITLE
dirauth: always restore persisted state, regardless of version

### DIFF
--- a/authority/voting/server/state.go
+++ b/authority/voting/server/state.go
@@ -2500,114 +2500,108 @@ func (s *state) restorePersistence() error {
 		}
 
 		if b := bkt.Get([]byte(versionKey)); b != nil {
-			// Well it looks like we loaded as opposed to created.
-			storedVersion := string(b)
-			currentVersion := versioninfo.Short()
-			if storedVersion != currentVersion {
-				s.log.Warningf("Software version changed (%s -> %s), ignoring persisted state", storedVersion, currentVersion)
-			} else {
-				// Figure out which epochs to restore for.
-				now, _, _ := epochtime.Now()
-				epochs := []uint64{now - 1, now, now + 1}
+			// The database was previously initialised; restore persisted state.
+			// Figure out which epochs to restore for.
+			now, _, _ := epochtime.Now()
+			epochs := []uint64{now - 1, now, now + 1}
 
-				// Restore the replica descriptors.
-				for _, epoch := range epochs {
-					epochBytes := epochToBytes(epoch)
-					eDescsBkt := replicaDescsBkt.Bucket(epochBytes)
-					if eDescsBkt == nil {
-						s.log.Debugf("No persisted Descriptors for epoch: %v.", epoch)
+			// Restore the replica descriptors.
+			for _, epoch := range epochs {
+				epochBytes := epochToBytes(epoch)
+				eDescsBkt := replicaDescsBkt.Bucket(epochBytes)
+				if eDescsBkt == nil {
+					s.log.Debugf("No persisted Descriptors for epoch: %v.", epoch)
+					continue
+				}
+				c := eDescsBkt.Cursor()
+				for wantHash, rawDesc := c.First(); wantHash != nil; wantHash, rawDesc = c.Next() {
+					if len(wantHash) != publicKeyHashSize {
+						panic("stored hash should be 32 bytes")
+					}
+					desc := new(pki.ReplicaDescriptor)
+					err := desc.Unmarshal(rawDesc)
+					if err != nil {
+						s.log.Errorf("Failed to validate persisted descriptor: %v", err)
 						continue
 					}
-					c := eDescsBkt.Cursor()
-					for wantHash, rawDesc := c.First(); wantHash != nil; wantHash, rawDesc = c.Next() {
-						if len(wantHash) != publicKeyHashSize {
-							panic("stored hash should be 32 bytes")
-						}
-						desc := new(pki.ReplicaDescriptor)
-						err := desc.Unmarshal(rawDesc)
-						if err != nil {
-							s.log.Errorf("Failed to validate persisted descriptor: %v", err)
-							continue
-						}
-						idHash := hash.Sum256(desc.IdentityKey)
-						if !hmac.Equal(wantHash, idHash[:]) {
-							s.log.Errorf("Discarding persisted descriptor: key mismatch")
-							continue
-						}
-
-						if !s.isReplicaDescriptorAuthorized(desc) {
-							s.log.Warningf("Discarding persisted descriptor: %v", desc)
-							continue
-						}
-
-						_, ok := s.replicaDescriptors[epoch]
-						if !ok {
-							s.replicaDescriptors[epoch] = make(map[[publicKeyHashSize]byte]*pki.ReplicaDescriptor)
-						}
-
-						s.replicaDescriptors[epoch][hash.Sum256(desc.IdentityKey)] = desc
-						s.log.Debugf("Restored replica descriptor for epoch %v: %+v", epoch, desc)
-					}
-				}
-
-				for _, epoch := range epochs {
-					epochBytes := epochToBytes(epoch)
-					if rawDoc := docsBkt.Get(epochBytes); rawDoc != nil {
-						_, _, _, err := cert.VerifyThreshold(s.getVerifiers(), s.threshold, rawDoc)
-						if err != nil {
-							s.log.Errorf("Failed to verify threshold on restored document")
-							break
-						}
-						doc, err := s.doParseDocument(rawDoc)
-						if err != nil {
-							s.log.Errorf("Failed to validate persisted document: %v", err)
-						} else if doc.Epoch != epoch {
-							s.log.Errorf("Persisted document has unexpected epoch: %v", doc.Epoch)
-						} else {
-							s.log.Debugf("Restored Document for epoch %v: %v.", epoch, doc)
-							s.documents[epoch] = doc
-						}
-					}
-
-					eDescsBkt := descsBkt.Bucket(epochBytes)
-					if eDescsBkt == nil {
-						s.log.Debugf("No persisted Descriptors for epoch: %v.", epoch)
+					idHash := hash.Sum256(desc.IdentityKey)
+					if !hmac.Equal(wantHash, idHash[:]) {
+						s.log.Errorf("Discarding persisted descriptor: key mismatch")
 						continue
 					}
 
-					c := eDescsBkt.Cursor()
-					for wantHash, rawDesc := c.First(); wantHash != nil; wantHash, rawDesc = c.Next() {
-						if len(wantHash) != publicKeyHashSize {
-							panic("stored hash should be 32 bytes")
-						}
-						desc := new(pki.MixDescriptor)
-						err := desc.UnmarshalBinary(rawDesc)
-						if err != nil {
-							s.log.Errorf("Failed to validate persisted descriptor: %v", err)
-							continue
-						}
-						idHash := hash.Sum256(desc.IdentityKey)
-						if !hmac.Equal(wantHash, idHash[:]) {
-							s.log.Errorf("Discarding persisted descriptor: key mismatch")
-							continue
-						}
-
-						if !s.isDescriptorAuthorized(desc) {
-							s.log.Warningf("Discarding persisted descriptor: %v", desc)
-							continue
-						}
-
-						_, ok := s.descriptors[epoch]
-						if !ok {
-							s.descriptors[epoch] = make(map[[publicKeyHashSize]byte]*pki.MixDescriptor)
-						}
-
-						s.descriptors[epoch][hash.Sum256(desc.IdentityKey)] = desc
-						s.log.Debugf("Restored descriptor for epoch %v: %+v", epoch, desc)
+					if !s.isReplicaDescriptorAuthorized(desc) {
+						s.log.Warningf("Discarding persisted descriptor: %v", desc)
+						continue
 					}
+
+					_, ok := s.replicaDescriptors[epoch]
+					if !ok {
+						s.replicaDescriptors[epoch] = make(map[[publicKeyHashSize]byte]*pki.ReplicaDescriptor)
+					}
+
+					s.replicaDescriptors[epoch][hash.Sum256(desc.IdentityKey)] = desc
+					s.log.Debugf("Restored replica descriptor for epoch %v: %+v", epoch, desc)
 				}
-				return nil
 			}
+
+			for _, epoch := range epochs {
+				epochBytes := epochToBytes(epoch)
+				if rawDoc := docsBkt.Get(epochBytes); rawDoc != nil {
+					_, _, _, err := cert.VerifyThreshold(s.getVerifiers(), s.threshold, rawDoc)
+					if err != nil {
+						s.log.Errorf("Failed to verify threshold on restored document")
+						break
+					}
+					doc, err := s.doParseDocument(rawDoc)
+					if err != nil {
+						s.log.Errorf("Failed to validate persisted document: %v", err)
+					} else if doc.Epoch != epoch {
+						s.log.Errorf("Persisted document has unexpected epoch: %v", doc.Epoch)
+					} else {
+						s.log.Debugf("Restored Document for epoch %v: %v.", epoch, doc)
+						s.documents[epoch] = doc
+					}
+				}
+
+				eDescsBkt := descsBkt.Bucket(epochBytes)
+				if eDescsBkt == nil {
+					s.log.Debugf("No persisted Descriptors for epoch: %v.", epoch)
+					continue
+				}
+
+				c := eDescsBkt.Cursor()
+				for wantHash, rawDesc := c.First(); wantHash != nil; wantHash, rawDesc = c.Next() {
+					if len(wantHash) != publicKeyHashSize {
+						panic("stored hash should be 32 bytes")
+					}
+					desc := new(pki.MixDescriptor)
+					err := desc.UnmarshalBinary(rawDesc)
+					if err != nil {
+						s.log.Errorf("Failed to validate persisted descriptor: %v", err)
+						continue
+					}
+					idHash := hash.Sum256(desc.IdentityKey)
+					if !hmac.Equal(wantHash, idHash[:]) {
+						s.log.Errorf("Discarding persisted descriptor: key mismatch")
+						continue
+					}
+
+					if !s.isDescriptorAuthorized(desc) {
+						s.log.Warningf("Discarding persisted descriptor: %v", desc)
+						continue
+					}
+
+					_, ok := s.descriptors[epoch]
+					if !ok {
+						s.descriptors[epoch] = make(map[[publicKeyHashSize]byte]*pki.MixDescriptor)
+					}
+
+					s.descriptors[epoch][hash.Sum256(desc.IdentityKey)] = desc
+					s.log.Debugf("Restored descriptor for epoch %v: %+v", epoch, desc)
+				}
+			}
+			return nil
 		}
 
 		return bkt.Put([]byte(versionKey), []byte(versioninfo.Short()))

--- a/authority/voting/server/state_persistence_test.go
+++ b/authority/voting/server/state_persistence_test.go
@@ -1,4 +1,4 @@
-// state_persistence_test.go - Tests for persistence version handling.
+// state_persistence_test.go - Tests for persistence epoch pruning.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/carlmjohnson/versioninfo"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
 )
@@ -85,49 +84,4 @@ func TestPrunePersistedEpochs(t *testing.T) {
 	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
 		return prunePersistedEpochs(tx, cmpEpoch)
 	}))
-}
-
-func TestPersistenceVersionHandling(t *testing.T) {
-	currentVersion := versioninfo.Short()
-
-	tests := []struct {
-		name           string
-		storedVersion  []byte
-		shouldMismatch bool
-	}{
-		{"legacy byte format", []byte{0}, true},
-		{"old version string", []byte("v0.0.0-old"), true},
-		{"current version", []byte(currentVersion), false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dbPath := filepath.Join(t.TempDir(), "persistence.db")
-			db, err := bolt.Open(dbPath, 0600, nil)
-			require.NoError(t, err)
-
-			err = db.Update(func(tx *bolt.Tx) error {
-				bkt, _ := tx.CreateBucketIfNotExists([]byte("metadata"))
-				return bkt.Put([]byte("version"), tt.storedVersion)
-			})
-			require.NoError(t, err)
-			db.Close()
-
-			db, err = bolt.Open(dbPath, 0600, nil)
-			require.NoError(t, err)
-			defer db.Close()
-
-			var stored string
-			db.View(func(tx *bolt.Tx) error {
-				stored = string(tx.Bucket([]byte("metadata")).Get([]byte("version")))
-				return nil
-			})
-
-			if tt.shouldMismatch {
-				require.NotEqual(t, stored, currentVersion)
-			} else {
-				require.Equal(t, stored, currentVersion)
-			}
-		})
-	}
 }


### PR DESCRIPTION
A directory authority discarded its persisted state whenever the running software's version string differed from the one recorded in the database. The version string is no indicator of the persistence schema, so a benign version bump would have an upgraded authority come up blind, with a fresh genesis epoch and no prior shared random value, splitting the vote against its un-upgraded peers. This made staggered upgrades impossible.

We therefore restore persisted state whenever the database was previously initialised, without consulting the version. Should the schema ever change in earnest, operators will clear the old persistence.db as a matter of course; no gate is wanted here.