### PR TITLE
Drop timeoutOverride from the voting client's initSession

### DIFF
--- a/authority/voting/client/benchmark_test.go
+++ b/authority/voting/client/benchmark_test.go
@@ -250,7 +250,7 @@ func runConcurrentHandshakes(
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
-			c, err := connectors[idx].initSession(ctx, clientLinkPrivKey, nil, peer, 30*time.Second)
+			c, err := connectors[idx].initSession(ctx, clientLinkPrivKey, nil, peer)
 			durations[idx] = time.Since(start)
 
 			if err != nil {
@@ -370,7 +370,7 @@ func BenchmarkHandshakeLatencyDistribution(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		c, err := conn.initSession(ctx, clientLinkPrivKey, nil, peer, 30*time.Second)
+		c, err := conn.initSession(ctx, clientLinkPrivKey, nil, peer)
 		cancel()
 
 		if err != nil {

--- a/authority/voting/client/benchmark_test.go
+++ b/authority/voting/client/benchmark_test.go
@@ -258,7 +258,7 @@ func runConcurrentHandshakes(
 				return
 			}
 
-			c.conn.Close()
+			c.Close()
 		}(c)
 	}
 
@@ -377,7 +377,7 @@ func BenchmarkHandshakeLatencyDistribution(b *testing.B) {
 			b.Fatalf("handshake failed: %v", err)
 		}
 
-		c.conn.Close()
+		c.Close()
 		connWg.Wait() // Wait for server-side handshake to complete
 	}
 }

--- a/authority/voting/client/client.go
+++ b/authority/voting/client/client.go
@@ -171,12 +171,22 @@ func newConnector(cfg *Config) *connector {
 	}
 }
 
+// sessionTimeouts returns the dial, handshake and response timeouts for a PKI
+// client session: each configured value clamped to the deadline carried by ctx,
+// so a single attempt never outruns the caller's window. A ctx with no deadline
+// leaves the configured values untouched.
+func sessionTimeouts(cfg *Config, ctx context.Context) (dial, handshake, response time.Duration) {
+	dial = clampTimeoutToContext(ctx, time.Duration(cfg.DialTimeoutSec)*time.Second)
+	handshake = clampTimeoutToContext(ctx, time.Duration(cfg.HandshakeTimeoutSec)*time.Second)
+	response = clampTimeoutToContext(ctx, time.Duration(cfg.ResponseTimeoutSec)*time.Second)
+	return
+}
+
 func (p *connector) initSession(
 	ctx context.Context,
 	linkKey kem.PrivateKey,
 	signingKey sign.PublicKey,
 	peer *config.Authority,
-	timeoutOverride time.Duration,
 ) (*connection, error) {
 	var conn net.Conn
 	var err error
@@ -186,14 +196,7 @@ func (p *connector) initSession(
 		return fmt.Sprintf("peer %s (%s)", peer.Identifier, strings.Join(peer.Addresses, ","))
 	}
 
-	dialTimeout := time.Duration(p.cfg.DialTimeoutSec) * time.Second
-	handshakeTimeout := time.Duration(p.cfg.HandshakeTimeoutSec) * time.Second
-	responseTimeout := time.Duration(p.cfg.ResponseTimeoutSec) * time.Second
-	if timeoutOverride > 0 {
-		dialTimeout = timeoutOverride
-		handshakeTimeout = timeoutOverride
-		responseTimeout = timeoutOverride
-	}
+	dialTimeout, handshakeTimeout, responseTimeout := sessionTimeouts(p.cfg, ctx)
 
 	p.log.Debugf("Client timeouts: dial=%v, handshake=%v, response=%v", dialTimeout, handshakeTimeout, responseTimeout)
 
@@ -345,7 +348,7 @@ func (p *connector) initSessionWithRetry(
 			}
 		}
 
-		conn, err := p.initSession(ctx, linkKey, signingKey, peer, 0)
+		conn, err := p.initSession(ctx, linkKey, signingKey, peer)
 		if err == nil {
 			if attempt > 0 {
 				p.log.Noticef("authority %s: connected after %d retries", peer.Identifier, attempt)
@@ -528,20 +531,16 @@ func (p *connector) postAuthorityOnce(
 	cmd commands.Command,
 	peer *config.Authority,
 	round int,
-	timeout time.Duration,
 ) postAttemptResult {
 	start := time.Now()
-	attemptCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
-	conn, err := p.initSession(attemptCtx, linkKey, signingKey, peer, timeout)
+	conn, err := p.initSession(ctx, linkKey, signingKey, peer)
 	if err != nil {
 		elapsed := time.Since(start)
 		p.log.Warningf(
-			"post authority %s: attempt failed after %v timeout=%v: %v",
+			"post authority %s: attempt failed after %v: %v",
 			peer.Identifier,
 			elapsed,
-			timeout,
 			err,
 		)
 		return postAttemptResult{
@@ -558,10 +557,9 @@ func (p *connector) postAuthorityOnce(
 	if err != nil {
 		elapsed := time.Since(start)
 		p.log.Warningf(
-			"post authority %s: round trip failed after %v timeout=%v: %v",
+			"post authority %s: round trip failed after %v: %v",
 			peer.Identifier,
 			elapsed,
-			timeout,
 			err,
 		)
 		return postAttemptResult{
@@ -641,9 +639,8 @@ func (p *connector) runPostRound(
 
 	for _, state := range states {
 		state := state
-		timeout := clampTimeoutToContext(ctx, time.Duration(p.cfg.HandshakeTimeoutSec)*time.Second)
 		w.Go(func() {
-			resultsCh <- p.postAuthorityOnce(ctx, linkKey, signingKey, cmd, state.peer, state.attempts, timeout)
+			resultsCh <- p.postAuthorityOnce(ctx, linkKey, signingKey, cmd, state.peer, state.attempts)
 		})
 	}
 

--- a/authority/voting/client/client.go
+++ b/authority/voting/client/client.go
@@ -157,6 +157,15 @@ func (cfg *Config) validate() error {
 type connection struct {
 	conn    net.Conn
 	session *wire.Session
+	watch   *connWatcher
+}
+
+// Close stops the context watcher, if any, and closes the connection.
+func (c *connection) Close() {
+	if c.watch != nil {
+		c.watch.stop()
+	}
+	c.conn.Close()
 }
 
 type connector struct {
@@ -171,15 +180,29 @@ func newConnector(cfg *Config) *connector {
 	}
 }
 
-// sessionTimeouts returns the dial, handshake and response timeouts for a PKI
-// client session: each configured value clamped to the deadline carried by ctx,
-// so a single attempt never outruns the caller's window. A ctx with no deadline
-// leaves the configured values untouched.
-func sessionTimeouts(cfg *Config, ctx context.Context) (dial, handshake, response time.Duration) {
-	dial = clampTimeoutToContext(ctx, time.Duration(cfg.DialTimeoutSec)*time.Second)
-	handshake = clampTimeoutToContext(ctx, time.Duration(cfg.HandshakeTimeoutSec)*time.Second)
-	response = clampTimeoutToContext(ctx, time.Duration(cfg.ResponseTimeoutSec)*time.Second)
-	return
+// connWatcher closes a connection when its context is cancelled, interrupting an
+// in-flight handshake or round trip the moment the caller cancels or the upload
+// window deadline elapses. It is stopped, without closing the connection, once
+// the exchange completes normally and ownership passes to the caller.
+type connWatcher struct {
+	stopCh chan struct{}
+	once   sync.Once
+}
+
+func watchConn(ctx context.Context, conn net.Conn) *connWatcher {
+	w := &connWatcher{stopCh: make(chan struct{})}
+	go func() {
+		select {
+		case <-ctx.Done():
+			conn.Close()
+		case <-w.stopCh:
+		}
+	}()
+	return w
+}
+
+func (w *connWatcher) stop() {
+	w.once.Do(func() { close(w.stopCh) })
 }
 
 func (p *connector) initSession(
@@ -196,7 +219,13 @@ func (p *connector) initSession(
 		return fmt.Sprintf("peer %s (%s)", peer.Identifier, strings.Join(peer.Addresses, ","))
 	}
 
-	dialTimeout, handshakeTimeout, responseTimeout := sessionTimeouts(p.cfg, ctx)
+	// Each phase gets its full configured timeout, applied right before the
+	// phase it bounds: dial via the dialer below, handshake and round trip via
+	// SetDeadline. The caller's context is enforced separately by watchConn, so
+	// no phase is silently shrunk by a window that began before it started.
+	dialTimeout := time.Duration(p.cfg.DialTimeoutSec) * time.Second
+	handshakeTimeout := time.Duration(p.cfg.HandshakeTimeoutSec) * time.Second
+	responseTimeout := time.Duration(p.cfg.ResponseTimeoutSec) * time.Second
 
 	p.log.Debugf("Client timeouts: dial=%v, handshake=%v, response=%v", dialTimeout, handshakeTimeout, responseTimeout)
 
@@ -278,6 +307,19 @@ func (p *connector) initSession(
 		return nil, fmt.Errorf("%s: failed to create PKI session: %v", peerInfo(), err)
 	}
 
+	// Watch the caller's context across the handshake and the subsequent round
+	// trip: cancelling ctx, or its upload-window deadline elapsing, closes the
+	// connection and unblocks the in-flight Read/Write. On any failure the
+	// deferred stop tears the watcher down; on success it is handed to the
+	// returned connection, whose Close stops it.
+	watch := watchConn(ctx, conn)
+	sessionReady := false
+	defer func() {
+		if !sessionReady {
+			watch.stop()
+		}
+	}()
+
 	conn.SetDeadline(time.Now().Add(handshakeTimeout))
 	handshakeStart := time.Now()
 	if err = s.Initialize(conn); err != nil {
@@ -327,7 +369,8 @@ func (p *connector) initSession(
 	handshakeinstrument.HandshakeDuration("outgoing", "success", handshakeElapsed)
 	p.log.Debugf("%s: Handshake completed in %v", peerInfo(), handshakeElapsed)
 	conn.SetDeadline(time.Now().Add(responseTimeout))
-	return &connection{conn: conn, session: s}, nil
+	sessionReady = true
+	return &connection{conn: conn, session: s, watch: watch}, nil
 }
 
 func (p *connector) initSessionWithRetry(
@@ -405,7 +448,7 @@ func (p *connector) allPeersRoundTrip(
 				responseCh <- PeerResponse{Peer: peer, Error: err}
 				return
 			}
-			defer conn.conn.Close()
+			defer conn.Close()
 
 			resp, err := p.roundTrip(conn.session, cmd)
 			if err != nil {
@@ -551,7 +594,7 @@ func (p *connector) postAuthorityOnce(
 			elapsed: elapsed,
 		}
 	}
-	defer conn.conn.Close()
+	defer conn.Close()
 
 	resp, err := p.roundTrip(conn.session, cmd)
 	if err != nil {
@@ -769,17 +812,6 @@ func remainingContextBudget(ctx context.Context) time.Duration {
 		return 0
 	}
 	return time.Until(deadline)
-}
-
-func clampTimeoutToContext(ctx context.Context, timeout time.Duration) time.Duration {
-	remaining := remainingContextBudget(ctx)
-	if remaining <= 0 {
-		return timeout
-	}
-	if remaining < timeout {
-		return remaining
-	}
-	return timeout
 }
 
 func logPostAttemptResult(
@@ -1058,7 +1090,7 @@ func (p *connector) fetchConsensus(
 	if err != nil {
 		return nil, fmt.Errorf("peer %s: connection failed: %v", auth.Identifier, err)
 	}
-	defer conn.conn.Close()
+	defer conn.Close()
 
 	cmd := &commands.GetConsensus{
 		Epoch:              epoch,

--- a/authority/voting/client/client_test.go
+++ b/authority/voting/client/client_test.go
@@ -737,7 +737,7 @@ func TestHandshakeDebugErrorOnEOF(t *testing.T) {
 	_, linkKey, err := testingScheme.GenerateKeyPair()
 	require.NoError(err)
 
-	_, err = conn.initSession(ctx, linkKey, nil, peer, time.Duration(cfg.HandshakeTimeoutSec)*time.Second)
+	_, err = conn.initSession(ctx, linkKey, nil, peer)
 	require.Error(err)
 
 	debugOutput := wire.GetDebugError(err)
@@ -1261,6 +1261,45 @@ func generateMixDescriptorForPostTest(
 	}
 
 	return desc, identityPrivateKey, identityPublicKey
+}
+
+func TestSessionTimeoutsClampToContext(t *testing.T) {
+	require := require.New(t)
+
+	cfg := &Config{
+		DialTimeoutSec:      10,
+		HandshakeTimeoutSec: 180,
+		ResponseTimeoutSec:  90,
+	}
+
+	// No deadline on the context: the configured values pass through unchanged.
+	// This is the consensus-fetch case.
+	dial, handshake, response := sessionTimeouts(cfg, context.Background())
+	require.Equal(10*time.Second, dial)
+	require.Equal(180*time.Second, handshake)
+	require.Equal(90*time.Second, response)
+
+	// A window shorter than every configured value clamps all three to what
+	// remains. This is a descriptor-post attempt late in the upload window.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	dial, handshake, response = sessionTimeouts(cfg, ctx)
+	require.LessOrEqual(dial, 5*time.Second)
+	require.LessOrEqual(handshake, 5*time.Second)
+	require.LessOrEqual(response, 5*time.Second)
+	require.Greater(dial, 4*time.Second) // clamped, not collapsed
+
+	// A window between the response and handshake timeouts clamps the larger
+	// handshake timeout but leaves response at its own configured value. This is
+	// the exact distinction the old timeoutOverride flattened, response must not
+	// inherit the handshake's clamped value.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel2()
+	dial, handshake, response = sessionTimeouts(cfg, ctx2)
+	require.Equal(10*time.Second, dial)          // 10s < 120s window: unchanged
+	require.LessOrEqual(handshake, 120*time.Second) // 180s clamped down to the window
+	require.Greater(handshake, 118*time.Second)
+	require.Equal(90*time.Second, response)      // 90s < 120s window: unchanged
 }
 
 func TestPostAcceptsQuorumSuccessWithFailingAuthorities(t *testing.T) {

--- a/authority/voting/client/client_test.go
+++ b/authority/voting/client/client_test.go
@@ -1263,43 +1263,82 @@ func generateMixDescriptorForPostTest(
 	return desc, identityPrivateKey, identityPublicKey
 }
 
-func TestSessionTimeoutsClampToContext(t *testing.T) {
+// TestInitSessionCancelledByContext verifies that cancelling the caller's
+// context interrupts an in-flight handshake promptly, rather than blocking for
+// the full configured handshake timeout. A black-hole server accepts the TCP
+// connection but never speaks the wire protocol, so the initiator would
+// otherwise block in io.ReadFull until HandshakeTimeoutSec, set very high here.
+func TestInitSessionCancelledByContext(t *testing.T) {
 	require := require.New(t)
 
-	cfg := &Config{
-		DialTimeoutSec:      10,
-		HandshakeTimeoutSec: 180,
-		ResponseTimeoutSec:  90,
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(err)
+	defer listener.Close()
+
+	// Accept connections and hold them open without ever responding.
+	go func() {
+		for {
+			c, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			defer c.Close()
+		}
+	}()
+
+	logBackend, err := log.New("", "DEBUG", false)
+	require.NoError(err)
+
+	_, clientLinkPrivKey, err := benchKEMScheme.GenerateKeyPair()
+	require.NoError(err)
+	serverLinkPubKey, _, err := benchKEMScheme.GenerateKeyPair()
+	require.NoError(err)
+	serverIDPubKey, _, err := benchSignScheme.GenerateKey()
+	require.NoError(err)
+
+	peer := &config.Authority{
+		Identifier:         "blackhole",
+		IdentityPublicKey:  serverIDPubKey,
+		LinkPublicKey:      config.LinkPublicKey{PublicKey: serverLinkPubKey},
+		PKISignatureScheme: benchSignScheme.Name(),
+		WireKEMScheme:      benchKEMScheme.Name(),
+		Addresses:          []string{fmt.Sprintf("tcp://%s", listener.Addr().String())},
 	}
 
-	// No deadline on the context: the configured values pass through unchanged.
-	// This is the consensus-fetch case.
-	dial, handshake, response := sessionTimeouts(cfg, context.Background())
-	require.Equal(10*time.Second, dial)
-	require.Equal(180*time.Second, handshake)
-	require.Equal(90*time.Second, response)
+	cfg := &Config{
+		KEMScheme:           benchKEMScheme,
+		PKISignatureScheme:  benchSignScheme,
+		LinkKey:             clientLinkPrivKey,
+		LogBackend:          logBackend,
+		Authorities:         []*config.Authority{peer},
+		Geo:                 benchGeometry,
+		DialTimeoutSec:      10,
+		HandshakeTimeoutSec: 3600, // would block ~forever absent ctx cancellation
+		ResponseTimeoutSec:  90,
+	}
+	conn := newConnector(cfg)
 
-	// A window shorter than every configured value clamps all three to what
-	// remains. This is a descriptor-post attempt late in the upload window.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 	defer cancel()
-	dial, handshake, response = sessionTimeouts(cfg, ctx)
-	require.LessOrEqual(dial, 5*time.Second)
-	require.LessOrEqual(handshake, 5*time.Second)
-	require.LessOrEqual(response, 5*time.Second)
-	require.Greater(dial, 4*time.Second) // clamped, not collapsed
 
-	// A window between the response and handshake timeouts clamps the larger
-	// handshake timeout but leaves response at its own configured value. This is
-	// the exact distinction the old timeoutOverride flattened, response must not
-	// inherit the handshake's clamped value.
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel2()
-	dial, handshake, response = sessionTimeouts(cfg, ctx2)
-	require.Equal(10*time.Second, dial)          // 10s < 120s window: unchanged
-	require.LessOrEqual(handshake, 120*time.Second) // 180s clamped down to the window
-	require.Greater(handshake, 118*time.Second)
-	require.Equal(90*time.Second, response)      // 90s < 120s window: unchanged
+	done := make(chan error, 1)
+	go func() {
+		c, err := conn.initSession(ctx, clientLinkPrivKey, nil, peer)
+		if c != nil {
+			c.Close()
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(err, "handshake should fail once the context is cancelled")
+		// The dial and session setup succeeded; the failure must come from the
+		// interrupted handshake, not a misconfiguration.
+		require.Contains(err.Error(), "handshake")
+	case <-time.After(10 * time.Second):
+		t.Fatal("initSession did not return after context cancellation: the watcher failed to interrupt the handshake")
+	}
 }
 
 func TestPostAcceptsQuorumSuccessWithFailingAuthorities(t *testing.T) {

--- a/core/wire/commands/commands.go
+++ b/core/wire/commands/commands.go
@@ -184,6 +184,12 @@ func (c *Commands) calcMaxMessageLenClientToServer() int {
 
 // padToMaxCommandSize takes a slice of bytes representing a serialized command and pads it to maxCommandSize.
 func (c *Commands) padToMaxCommandSize(data []byte, isUpstream bool) []byte {
+	// PKI sessions set shouldPad false: their MaxMessageLen is only an upper
+	// bound for the size check (Vote/Consensus may be large), not a padding
+	// target. Padding a NoOp to it would ship tens of megabytes per handshake.
+	if !c.shouldPad {
+		return data
+	}
 	var maxMessageLen int
 	if isUpstream {
 		maxMessageLen = c.MaxMessageLenClientToServer

--- a/core/wire/commands/pki_commands_test.go
+++ b/core/wire/commands/pki_commands_test.go
@@ -307,3 +307,22 @@ func TestSigStatus(t *testing.T) {
 	d := c.(*SigStatus)
 	require.Equal(d.ErrorCode, cmd.ErrorCode)
 }
+
+// TestPKINoOpUnpadded guards the fix for the 50 MB NoOp: PKI sessions set
+// shouldPad false, so a NoOp must serialize to its bare cmdOverhead rather than
+// being padded out to NewPKICommands' multi-megabyte MaxMessageLen, which is
+// only an upper bound for the size check, not a padding target.
+func TestPKINoOpUnpadded(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	cmds := NewPKICommands(testCertScheme)
+	b := (&NoOp{Cmds: cmds}).ToBytes()
+
+	require.Len(b, cmdOverhead, "PKI NoOp must not be padded")
+	require.Less(len(b), cmds.MaxMessageLenClientToServer)
+
+	c, err := cmds.FromBytes(b)
+	require.NoError(err, "PKI NoOp: FromBytes() failed")
+	require.IsType(&NoOp{}, c)
+}


### PR DESCRIPTION
A follow-up to #1044: with the ladder gone the override only served to flatten dial, handshake and response onto a single value, so a descriptor post's response wait wrongly took the window-clamped handshake figure rather than its own ResponseTimeoutSec. initSession now derives all three from config and clamps each to the context, so the post and fetch paths share one timeout discipline.