### PR TITLE
Fix misleading "window closed" log for an already-posted epoch

### DIFF
--- a/server/internal/incoming/listener_gate_test.go
+++ b/server/internal/incoming/listener_gate_test.go
@@ -91,12 +91,17 @@ func TestListenerRefusesWithoutUsableDocument(t *testing.T) {
 		closeAllCh: make(chan interface{}),
 	}
 
-	go l.worker()
-	defer gl.Close()
-
+	// Set the read deadline before starting the gate. A fast rejection closes
+	// the pipe, and SetReadDeadline on a closed net.Pipe end returns an error;
+	// setting it first keeps that safety-net deadline from racing the close. The
+	// gate is expected to close the connection well before the deadline fires.
 	if err := clientConn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
 		t.Fatal(err)
 	}
+
+	go l.worker()
+	defer gl.Close()
+
 	if _, err := clientConn.Read(make([]byte, 1)); err == nil {
 		t.Fatal("expected the gate to close the connection when no usable document is cached")
 	}

--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -452,6 +452,15 @@ func (p *pki) publishDescriptorIfNeeded(pkiCtx context.Context) error {
 	}
 
 	doPublishEpoch := currentEpoch + 1
+
+	// Test "already published" before "window closed". Once the descriptor for
+	// this epoch is posted there is nothing left to do, and reporting the upload
+	// window as closed here would wrongly suggest it never went out.
+	if p.lastPublishedEpoch >= doPublishEpoch {
+		p.log.Debugf("publishDescriptorIfNeeded: not needed (published: %d target: %d current: %d)", p.lastPublishedEpoch, doPublishEpoch, currentEpoch)
+		return nil
+	}
+
 	if elapsed >= uploadDeadline {
 		p.log.Noticef(
 			"DESCRIPTOR UPLOAD: not posting descriptor for epoch=%d current_epoch=%d elapsed=%v deadline=%v safety=%v remaining=%v: upload window closed; waiting for next epoch",
@@ -462,11 +471,6 @@ func (p *pki) publishDescriptorIfNeeded(pkiCtx context.Context) error {
 			descriptorUploadSafety,
 			till,
 		)
-		return nil
-	}
-
-	if p.lastPublishedEpoch >= doPublishEpoch {
-		p.log.Debugf("publishDescriptorIfNeeded: not needed (published: %d target: %d current: %d)", p.lastPublishedEpoch, doPublishEpoch, currentEpoch)
 		return nil
 	}
 


### PR DESCRIPTION
publishDescriptorIfNeeded tested the upload window before the already-posted guard, so a periodic wake after the window had closed logged "upload window closed; waiting for next epoch" for an epoch whose descriptor had in fact already gone out, suggesting it never did. The already-posted guard now runs first, leaving the window-closed notice for when the descriptor was genuinely not posted.