### PR TITLE
Remap courier envelope errors out of the replica code range

### DIFF
--- a/authority/voting/client/client_test.go
+++ b/authority/voting/client/client_test.go
@@ -1200,9 +1200,14 @@ func TestPostReplicaAcceptsQuorumSuccessWithFailingAuthorities(t *testing.T) {
 		Authorities:         peers,
 		DialContextFn:       dialFn,
 		Geo:                 mygeo,
-		DialTimeoutSec:      5,
-		HandshakeTimeoutSec: 5,
-		ResponseTimeoutSec:  5,
+		// Generous deadlines: the succeeding peers run a real post-quantum
+		// Noise handshake over an in-memory pipe, which under a loaded CI
+		// runner can exceed a few seconds. The failing peers fail instantly
+		// (dial error, below), so this does not slow the test; it only keeps a
+		// slow handshake from dropping the quorum and flaking the assertion.
+		DialTimeoutSec:      30,
+		HandshakeTimeoutSec: 30,
+		ResponseTimeoutSec:  30,
 		RetryMaxAttempts:    0,
 	}
 	require.NoError(cfg.validate())
@@ -1216,7 +1221,7 @@ func TestPostReplicaAcceptsQuorumSuccessWithFailingAuthorities(t *testing.T) {
 	epoch, _, _ := epochtime.Now()
 	desc := generateReplicaDescriptorForPostReplicaTest(t, epoch, replicaIdentityPublicKey)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	err = client.PostReplica(ctx, epoch, replicaIdentityPrivateKey, replicaIdentityPublicKey, desc)
@@ -1404,9 +1409,13 @@ func TestPostAcceptsQuorumSuccessWithFailingAuthorities(t *testing.T) {
 		Authorities:         peers,
 		DialContextFn:       dialFn,
 		Geo:                 mygeo,
-		DialTimeoutSec:      5,
-		HandshakeTimeoutSec: 5,
-		ResponseTimeoutSec:  5,
+		// Generous deadlines: see TestPostReplicaAcceptsQuorumSuccessWithFailingAuthorities.
+		// The succeeding peers run a real PQ Noise handshake over a pipe, which
+		// can exceed a few seconds under CI load; the failing peers fail
+		// instantly, so this only prevents a slow handshake from flaking.
+		DialTimeoutSec:      30,
+		HandshakeTimeoutSec: 30,
+		ResponseTimeoutSec:  30,
 		RetryMaxAttempts:    0,
 	}
 	require.NoError(cfg.validate())
@@ -1417,7 +1426,7 @@ func TestPostAcceptsQuorumSuccessWithFailingAuthorities(t *testing.T) {
 	epoch, _, _ := epochtime.Now()
 	desc, signingPrivateKey, signingPublicKey := generateMixDescriptorForPostTest(t, epoch, 66000)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	err = client.Post(ctx, epoch, signingPrivateKey, signingPublicKey, desc, nil)

--- a/client/pigeonhole.go
+++ b/client/pigeonhole.go
@@ -1406,6 +1406,31 @@ func (d *Daemon) finishARQMessage(arqMessage *ARQMessage, conn *incomingConn, er
 	})
 }
 
+// courierEnvelopeErrorToThinError maps a courier EnvelopeError code (see
+// pigeonhole/errors.go) into the thin-client error namespace. The courier's
+// codes 1-4 share wire values with the replica error codes the client reads in
+// the same reply field, so passing them through unmapped would surface a
+// courier rejection as, for example, a replica database failure. The
+// thin-client targets all sit at >= 12, clear of the replica range (1-11).
+func courierEnvelopeErrorToThinError(code uint8) uint8 {
+	switch code {
+	case pigeonhole.EnvelopeErrorSuccess:
+		return thin.ThinClientSuccess
+	case pigeonhole.EnvelopeErrorInvalidEnvelope:
+		return thin.ThinClientErrorCourierInvalidEnvelope
+	case pigeonhole.EnvelopeErrorCacheCorruption:
+		return thin.ThinClientErrorCourierCacheCorruption
+	case pigeonhole.EnvelopeErrorPropagationError:
+		return thin.ThinClientPropagationError
+	case pigeonhole.EnvelopeErrorInvalidEpoch:
+		return thin.ThinClientErrorCourierInvalidEpoch
+	default:
+		// An unknown courier code must still stay out of the replica range so it
+		// cannot be misread as a replica error; flag it as a malformed envelope.
+		return thin.ThinClientErrorCourierInvalidEnvelope
+	}
+}
+
 func (d *Daemon) handlePigeonholeARQReply(arqMessage *ARQMessage, reply *sphinxReply) {
 	conn := d.listener.getConnection(arqMessage.AppID)
 	if conn == nil {
@@ -1452,15 +1477,22 @@ func (d *Daemon) handlePigeonholeARQReply(arqMessage *ARQMessage, reply *sphinxR
 
 	courierEnvelopeReply := courierQueryReply.EnvelopeReply
 
+	// The courier reports failures in its own EnvelopeError namespace, whose
+	// values 1-4 collide with the replica error codes the client interprets in
+	// this same field (e.g. EnvelopeErrorInvalidEpoch == ReplicaErrorDatabaseFailure
+	// == 4). Remap into the thin-client namespace (>= 12) so a courier rejection
+	// is never mistaken for a replica error.
+	thinErrorCode := courierEnvelopeErrorToThinError(courierEnvelopeReply.ErrorCode)
+
 	// Log all state for debugging
-	d.log.Debugf("handlePigeonholeARQReply: EnvelopeHash=%x, State=%d, ReplyType=%d, PayloadLen=%d, ErrorCode=%d, IsRead=%v",
-		arqMessage.EnvelopeHash[:], arqMessage.State, courierEnvelopeReply.ReplyType, courierEnvelopeReply.PayloadLen, courierEnvelopeReply.ErrorCode, arqMessage.IsRead)
+	d.log.Debugf("handlePigeonholeARQReply: EnvelopeHash=%x, State=%d, ReplyType=%d, PayloadLen=%d, CourierErrorCode=%d, ThinErrorCode=%d, IsRead=%v",
+		arqMessage.EnvelopeHash[:], arqMessage.State, courierEnvelopeReply.ReplyType, courierEnvelopeReply.PayloadLen, courierEnvelopeReply.ErrorCode, thinErrorCode, arqMessage.IsRead)
 
 	// Use the pure FSM to determine the action
 	transition := computeARQStateTransition(
 		arqMessage.State,
 		courierEnvelopeReply.ReplyType,
-		courierEnvelopeReply.ErrorCode,
+		thinErrorCode,
 		arqMessage.IsRead,
 		arqMessage.NoIdempotentBoxAlreadyExists,
 	)

--- a/client/pigeonhole_arq_test.go
+++ b/client/pigeonhole_arq_test.go
@@ -8,8 +8,34 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/katzenpost/katzenpost/client/thin"
 	"github.com/katzenpost/katzenpost/pigeonhole"
 )
+
+func TestCourierEnvelopeErrorToThinError(t *testing.T) {
+	// Every courier envelope error must map clear of the replica error range
+	// (1-11), so a courier rejection is never read as a replica error.
+	cases := map[uint8]uint8{
+		pigeonhole.EnvelopeErrorSuccess:          thin.ThinClientSuccess,
+		pigeonhole.EnvelopeErrorInvalidEnvelope:  thin.ThinClientErrorCourierInvalidEnvelope,
+		pigeonhole.EnvelopeErrorCacheCorruption:  thin.ThinClientErrorCourierCacheCorruption,
+		pigeonhole.EnvelopeErrorPropagationError: thin.ThinClientPropagationError,
+		pigeonhole.EnvelopeErrorInvalidEpoch:     thin.ThinClientErrorCourierInvalidEpoch,
+	}
+	for courierCode, want := range cases {
+		got := courierEnvelopeErrorToThinError(courierCode)
+		require.Equal(t, want, got, "courier code %d", courierCode)
+		if courierCode != pigeonhole.EnvelopeErrorSuccess {
+			require.Greater(t, got, uint8(11), "courier code %d mapped into replica range", courierCode)
+		}
+	}
+	// The collision we are guarding against: courier InvalidEpoch and replica
+	// DatabaseFailure share source value 4, but must not share the wire code.
+	require.NotEqual(t, pigeonhole.ReplicaErrorDatabaseFailure,
+		courierEnvelopeErrorToThinError(pigeonhole.EnvelopeErrorInvalidEpoch))
+	// Unknown courier codes also stay out of the replica range.
+	require.Greater(t, courierEnvelopeErrorToThinError(200), uint8(11))
+}
 
 func TestComputeARQStateTransition(t *testing.T) {
 	tests := []struct {

--- a/client/thin/pigeonhole.go
+++ b/client/thin/pigeonhole.go
@@ -53,6 +53,14 @@ func thinClientErrorCodeToSentinel(errorCode uint8) error {
 		return ErrCopyCommandFailed
 	case ThinClientErrorPayloadTooLarge:
 		return ErrPayloadTooLarge
+	case ThinClientErrorCourierCacheCorruption:
+		return ErrCacheCorruption
+	case ThinClientPropagationError:
+		return ErrPropagationError
+	case ThinClientErrorCourierInvalidEnvelope:
+		return ErrInvalidEnvelope
+	case ThinClientErrorCourierInvalidEpoch:
+		return ErrCourierInvalidEpoch
 	default:
 		return errors.New(ThinClientErrorToString(errorCode))
 	}
@@ -146,6 +154,17 @@ func errorCodeToSentinel(errorCode uint8) error {
 		return ErrInvalidTombstoneSignature
 	case ThinClientErrorPayloadTooLarge:
 		return ErrPayloadTooLarge
+
+	// Courier envelope error codes (remapped into the thin-client namespace by
+	// the daemon so they no longer collide with replica codes 1-4).
+	case ThinClientErrorCourierCacheCorruption:
+		return ErrCacheCorruption
+	case ThinClientPropagationError:
+		return ErrPropagationError
+	case ThinClientErrorCourierInvalidEnvelope:
+		return ErrInvalidEnvelope
+	case ThinClientErrorCourierInvalidEpoch:
+		return ErrCourierInvalidEpoch
 
 	default:
 		// For other error codes (thin client errors, etc.), return a generic error

--- a/client/thin/pigeonhole_test.go
+++ b/client/thin/pigeonhole_test.go
@@ -89,6 +89,12 @@ func TestErrorCodeToSentinel(t *testing.T) {
 		{"BACAPDecryptionFailed", ThinClientErrorBACAPDecryptionFailed, ErrBACAPDecryptionFailed, false, true},
 		{"StartResendingCancelled", ThinClientErrorStartResendingCancelled, ErrStartResendingCancelled, false, true},
 		{"InvalidTombstoneSig", ThinClientErrorInvalidTombstoneSig, ErrInvalidTombstoneSignature, false, true},
+		// Courier envelope errors live above the replica range so they never
+		// collide with replica codes 1-4 (e.g. CourierInvalidEpoch != DatabaseFailure).
+		{"CourierCacheCorruption", ThinClientErrorCourierCacheCorruption, ErrCacheCorruption, false, true},
+		{"CourierPropagationError", ThinClientPropagationError, ErrPropagationError, false, true},
+		{"CourierInvalidEnvelope", ThinClientErrorCourierInvalidEnvelope, ErrInvalidEnvelope, false, true},
+		{"CourierInvalidEpoch", ThinClientErrorCourierInvalidEpoch, ErrCourierInvalidEpoch, false, true},
 	}
 
 	for _, tt := range tests {

--- a/client/thin/thin.go
+++ b/client/thin/thin.go
@@ -163,14 +163,23 @@ var (
 	// Pigeonhole writes are immutable - once a box has been written, it cannot be overwritten.
 	ErrBoxAlreadyExists = errors.New("box already exists")
 
-	// ErrInvalidEnvelope indicates that the courier envelope format is invalid.
-	ErrInvalidEnvelope = errors.New("invalid envelope")
+	// ErrInvalidEnvelope indicates that the courier rejected the envelope as
+	// malformed. This is a courier-side condition, distinct from any replica error.
+	ErrInvalidEnvelope = errors.New("courier rejected envelope as malformed")
 
-	// ErrCacheCorruption indicates that cache data corruption was detected.
-	ErrCacheCorruption = errors.New("cache corruption")
+	// ErrCacheCorruption indicates that the courier detected cache corruption.
+	ErrCacheCorruption = errors.New("courier cache corruption")
 
-	// ErrPropagationError indicates an error propagating the request to replicas.
-	ErrPropagationError = errors.New("propagation error")
+	// ErrPropagationError indicates the courier could not propagate the request
+	// to the replicas. This is a courier-side condition, not a replica error.
+	ErrPropagationError = errors.New("courier propagation error")
+
+	// ErrCourierInvalidEpoch indicates that the courier rejected the envelope
+	// because its declared replica epoch was outside the courier's tolerance
+	// window. This is a courier staleness signal, NOT a replica database failure
+	// (the two collide on wire value 4 in their source namespaces, which is why
+	// the daemon remaps courier errors into the thin-client namespace).
+	ErrCourierInvalidEpoch = errors.New("courier rejected envelope: replica epoch outside tolerance window")
 
 	// ErrInternalError indicates an internal client error.
 	ErrInternalError = errors.New("internal error")

--- a/client/thin/thin_messages.go
+++ b/client/thin/thin_messages.go
@@ -151,6 +151,20 @@ const (
 	// ThinClientErrorVoucherSealOpenFailed indicates that a sealed Contact
 	// Voucher reply could not be opened with the joiner's voucher secret key.
 	ThinClientErrorVoucherSealOpenFailed uint8 = 30
+
+	// ThinClientErrorCourierInvalidEnvelope indicates that the courier rejected
+	// the CourierEnvelope as malformed (pigeonhole.EnvelopeErrorInvalidEnvelope).
+	// It lives in the thin-client namespace, deliberately above the replica
+	// error range (1-11), so it cannot be confused with a replica error: the
+	// courier and the replica are different components with different stores.
+	ThinClientErrorCourierInvalidEnvelope uint8 = 31
+
+	// ThinClientErrorCourierInvalidEpoch indicates that the courier rejected the
+	// CourierEnvelope because its declared replica epoch fell outside the
+	// courier's tolerance window (pigeonhole.EnvelopeErrorInvalidEpoch). This is
+	// a courier-side staleness signal, NOT a replica database failure, even
+	// though the two share wire value 4 in their respective source namespaces.
+	ThinClientErrorCourierInvalidEpoch uint8 = 32
 )
 
 // ThinClientErrorToString converts a thin client error code to a human-readable string.
@@ -226,6 +240,10 @@ func ThinClientErrorToString(errorCode uint8) string {
 		return "Voucher signed please-add did not verify"
 	case ThinClientErrorVoucherSealOpenFailed:
 		return "Voucher sealed reply could not be opened"
+	case ThinClientErrorCourierInvalidEnvelope:
+		return "Courier rejected the envelope as malformed"
+	case ThinClientErrorCourierInvalidEpoch:
+		return "Courier rejected the envelope: replica epoch outside tolerance window"
 	default:
 		return fmt.Sprintf("Unknown thin client error code: %d", errorCode)
 	}


### PR DESCRIPTION
The courier EnvelopeError codes 1-4 collided with replica error codes 1-4 in the shared reply field, so a courier rejection (notably stale epoch) surfaced to the client as a replica error (database failure). The daemon now translates them into the thin-client namespace (>= 12), and the sentinel mappers gained the courier cases.