### PR TITLE
cmd/dirauth: reproducible build (-trimpath, stripped symbols)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ server:
 	cd cmd/server; go build
 
 dirauth:
-	cd cmd/dirauth; go build
+	cd cmd/dirauth; go build -trimpath -ldflags "-s -w"
 
 genconfig:
 	cd cmd/genconfig; go build


### PR DESCRIPTION
Plain 'go build' embeds absolute source paths in debug info / build ID, producing different binaries depending on the checkout path. Verified non-reproducibility by building from two different absolute paths and comparing sha256.

Add -trimpath and -ldflags "-s -w" to the dirauth Makefile target. Verified bit-for-bit identical output across different build paths, including with dirauth's CGO post-quantum crypto dependencies (highctidh, falcon, sqisign, sphincsplus/ref) in the import tree.