### PR TITLE
client/thin: restore GetAllCouriers

### DIFF
--- a/client/thin/pigeonhole.go
+++ b/client/thin/pigeonhole.go
@@ -1226,6 +1226,37 @@ func (t *ThinClient) CreateCourierEnvelopesFromMultiPayload(destinations []Desti
 	}
 }
 
+// CourierDescriptor identifies a courier service by its identity-key hash
+// and recipient queue ID.
+type CourierDescriptor struct {
+	IdentityHash *[32]byte
+	QueueID      []byte
+}
+
+// GetAllCouriers returns every courier service advertised in the current PKI
+// document, each described by an (identity-hash, queue-id) pair. The list
+// reflects only the couriers that the current consensus regards as serving.
+func (t *ThinClient) GetAllCouriers() (couriers []CourierDescriptor, err error) {
+	services, err := t.GetServices("courier")
+	if err != nil {
+		return nil, err
+	}
+	couriers = make([]CourierDescriptor, len(services))
+	for i, svc := range services {
+		idHash := hashIdentityKey(svc.MixDescriptor.IdentityKey)
+		couriers[i] = CourierDescriptor{
+			IdentityHash: &idHash,
+			QueueID:      svc.RecipientQueueID,
+		}
+	}
+	return couriers, nil
+}
+
+// hashIdentityKey computes the hash of an identity key.
+func hashIdentityKey(key []byte) [32]byte {
+	return hash.Sum256(key)
+}
+
 type TombstoneEnvelope struct {
 	MessageCiphertext  []byte
 	EnvelopeDescriptor []byte

--- a/client/thin/pigeonhole_test.go
+++ b/client/thin/pigeonhole_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 
 	"github.com/katzenpost/hpqc/bacap"
+	"github.com/katzenpost/hpqc/hash"
 	"github.com/katzenpost/hpqc/nike/schemes"
 	"github.com/katzenpost/hpqc/rand"
 
@@ -150,6 +151,37 @@ func setupTestThinClient(t *testing.T) *ThinClient {
 		drainRemove: make(chan chan Event),
 		pkiDocCache: make(map[uint64]*cpki.Document),
 	}
+}
+
+func TestGetAllCouriers(t *testing.T) {
+	tc := setupTestThinClient(t)
+	tc.pkidocMutex.Lock()
+	tc.pkidoc = &cpki.Document{
+		Epoch: 1,
+		ServiceNodes: []*cpki.MixDescriptor{
+			{
+				IdentityKey: []byte("courier-identity-1"),
+				Kaetzchen: map[string]map[string]interface{}{
+					"courier": {"endpoint": "courier-queue-1"},
+				},
+			},
+			{
+				IdentityKey: []byte("courier-identity-2"),
+				Kaetzchen: map[string]map[string]interface{}{
+					"courier": {"endpoint": "courier-queue-2"},
+				},
+			},
+		},
+	}
+	tc.pkidocMutex.Unlock()
+
+	couriers, err := tc.GetAllCouriers()
+	require.NoError(t, err)
+	require.Len(t, couriers, 2)
+
+	expectedHash1 := hash.Sum256([]byte("courier-identity-1"))
+	require.Equal(t, expectedHash1, *couriers[0].IdentityHash)
+	require.Equal(t, []byte("courier-queue-1"), couriers[0].QueueID)
 }
 
 func TestNewKeypairSeedValidation(t *testing.T) {


### PR DESCRIPTION
Commit 4d96c6980abdfa08975e0488728e0817ac4b0516 removed it alongside the genuinely superfluous GetDistinctCouriers and StartResendingCopyCommandWithCourier, but the Python binding's katzenqt caller still needs it to check that a resend's target courier remains in the PKI. Restore GetAllCouriers, with the CourierDescriptor type and hashIdentityKey helper it needs and its unit test; the other two stay removed.