### PR TITLE
cmd: reproducible builds for courier, echo-plugin, and kpclientd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ ping:
 	cd cmd/ping; go build -trimpath -ldflags "-s -w"
 
 courier:
-	cd cmd/courier; go build
+	cd cmd/courier; go build -trimpath -ldflags "-s -w"
 
 echo-plugin:
-	cd cmd/echo-plugin; go build
+	cd cmd/echo-plugin; go build -trimpath -ldflags "-s -w"
 
 fetch:
 	cd cmd/fetch; go build -trimpath -ldflags "-s -w"
@@ -48,7 +48,7 @@ http-proxy-server:
 	cd cmd/http-proxy-server; go build -trimpath -ldflags "-s -w"
 
 kpclientd:
-	cd cmd/kpclientd; go build
+	cd cmd/kpclientd; go build -trimpath -ldflags "-s -w"
 
 sphinx:
 	cd cmd/sphinx; go build -trimpath -ldflags "-s -w"


### PR DESCRIPTION
## Summary
- add `-trimpath -ldflags "-s -w"` to the `courier` Makefile target
- add `-trimpath -ldflags "-s -w"` to the `echo-plugin` Makefile target
- add `-trimpath -ldflags "-s -w"` to the `kpclientd` Makefile target

## Verification
Built the targets from separate Git worktrees rooted at different absolute paths.

Before this patch:
- `courier`: hashes differed across the two paths
- `echo-plugin`: hashes differed across the two paths
- `kpclientd`: hashes differed across the two paths

After this patch:
- `courier`: `be6c76d80139039bbcec407d2c6744a4fa4856d9433e70cd5b5c4580a743f74c` in both paths
- `echo-plugin`: `bd51f430e02842b23a429e7543a9cd7cc51be6167ba062b1dbd949eecde5d82e` in both paths
- `kpclientd`: `d987845ff55a829362f971e2d9d435fd3c8d4f85a4842f6d81ea12bf6f9406d6` in both paths