### PR TITLE
courier: fix dispatchMessage data race on the reconnect path

### DIFF
--- a/courier/server/dispatch_race_test.go
+++ b/courier/server/dispatch_race_test.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package server
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/katzenpost/core/log"
+	cpki "github.com/katzenpost/katzenpost/core/pki"
+	"github.com/katzenpost/katzenpost/core/wire/commands"
+)
+
+// dispatchMessage runs on the dispatch worker goroutines while the
+// connection worker rewrites c.dst on every reconnect
+// (validateAndUpdateDescriptor). Reading c.dst.Name from dispatchMessage
+// therefore races the descriptor pointer swap, which is exactly the
+// condition on a link that keeps churning. Under -race the pre-fix code
+// (c.dst.Name in dispatchMessage) trips the detector here; the fix reads
+// the immutable c.name captured at construction, so this is clean.
+func TestDispatchMessageNameNoRaceWithReconnect(t *testing.T) {
+	t.Parallel()
+
+	backendLog, err := log.New("", "ERROR", false)
+	require.NoError(t, err)
+
+	c := &outgoingConn{
+		log:    backendLog.GetLogger("test"),
+		dst:    &cpki.ReplicaDescriptor{Name: "storagereplica0"},
+		name:   "storagereplica0",
+		sender: &sender{in: make(chan *courierSenderRequest, 8)},
+	}
+
+	// The connection worker swapping the descriptor on reconnect.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; ; i++ {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			c.dst = &cpki.ReplicaDescriptor{Name: fmt.Sprintf("storagereplica%d", i%5)}
+		}
+	}()
+
+	// The dispatch workers enqueueing while the descriptor churns. Both
+	// the enqueue-success and the queue-full branches read the replica
+	// name, so draining intermittently exercises both.
+	for i := 0; i < 2000; i++ {
+		_ = c.dispatchMessage(&commands.ReplicaMessage{})
+		if i%2 == 0 {
+			select {
+			case <-c.sender.in:
+			default:
+			}
+		}
+	}
+	close(done)
+}

--- a/courier/server/outgoing_conn.go
+++ b/courier/server/outgoing_conn.go
@@ -53,7 +53,16 @@ type outgoingConn struct {
 	co         GenericConnector
 	log        *logging.Logger
 
-	dst    *cpki.ReplicaDescriptor
+	// dst is rewritten by the connection worker on every reconnect
+	// (validateAndUpdateDescriptor). It must only be read on that same
+	// goroutine. Cross-goroutine readers (dispatchMessage runs on the
+	// dispatch workers) use the immutable name below instead.
+	dst *cpki.ReplicaDescriptor
+
+	// name is the replica's stable identity name, captured once at
+	// construction so the concurrent dispatch path never reads dst.
+	name string
+
 	sender *sender
 
 	id         uint64
@@ -127,17 +136,17 @@ func (c *outgoingConn) dispatchMessage(mesg *commands.ReplicaMessage) error {
 	}
 	select {
 	case c.sender.in <- req:
-		instrument.EnqueueTotal(c.dst.Name)
-		instrument.QueueLength(c.dst.Name, len(c.sender.in))
+		instrument.EnqueueTotal(c.name)
+		instrument.QueueLength(c.name, len(c.sender.in))
 		return nil
 	case <-c.HaltCh():
-		return fmt.Errorf("dispatch to %s: halted", c.dst.Name)
+		return fmt.Errorf("dispatch to %s: halted", c.name)
 	default:
 		// A full queue to a disconnected peer must never block the
 		// caller: the synchronous copy path dispatches before it
 		// arms its own reply timeout.
 		instrument.DroppedByReason("dispatch_queue_full")
-		return fmt.Errorf("dispatch to %s: queue full", c.dst.Name)
+		return fmt.Errorf("dispatch to %s: queue full", c.name)
 	}
 }
 
@@ -750,6 +759,7 @@ func newOutgoingConn(co GenericConnector, dst *cpki.ReplicaDescriptor, cfg *conf
 		courier:    courier,
 		co:         co,
 		dst:        dst,
+		name:       dst.Name,
 		id:         atomic.AddUint64(&outgoingConnID, 1), // Diagnostic only, wrapping is fine.
 	}
 	c.log = co.Server().LogBackend().GetLogger(fmt.Sprintf("courier outgoing:%d", c.id))


### PR DESCRIPTION
dispatchMessage runs on the dispatch workers and read c.dst.Name while the connection worker rewrites c.dst on every reconnect, a data race exactly where a churning replica link lives. Capture the replica name once at construction and read that immutable field on the concurrent path. Adds a -race regression test that trips on the old code.