### PR TITLE
replica: fix processRetryQueue self-deadlock that drops replicas from consensus

### DIFF
--- a/replica/connector.go
+++ b/replica/connector.go
@@ -211,37 +211,49 @@ func (co *Connector) pruneRetryQueueLocked() {
 
 // processRetryQueue attempts to dispatch queued commands when connections become available
 func (co *Connector) processRetryQueue() {
+	// Under retryQueueMu, take the commands whose peer now has a connection
+	// out of the queue, but DISPATCH them only after releasing the lock.
+	// Dispatching while holding retryQueueMu deadlocks: a full per-peer
+	// channel makes dispatchCommand fall through to QueueForRetry, which
+	// locks retryQueueMu again in this same goroutine (sync.Mutex is not
+	// reentrant), wedging the connector's retry path forever.
 	co.retryQueueMu.Lock()
-	defer co.retryQueueMu.Unlock()
-
 	co.pruneRetryQueueLocked()
 
 	if len(co.retryQueue) == 0 {
+		co.retryQueueMu.Unlock()
 		instrument.RetryQueueSize(0)
 		return
 	}
 
 	co.log.Debugf("Processing retry queue with %d commands", len(co.retryQueue))
 
-	// Process retry queue in reverse order to safely remove items
-	for i := len(co.retryQueue) - 1; i >= 0; i-- {
-		retryCmd := co.retryQueue[i]
-
-		// Check if connection is now available
+	type pendingRetry struct {
+		conn *outgoingConn
+		cmd  commands.Command
+	}
+	var ready []pendingRetry
+	kept := co.retryQueue[:0]
+	for _, retryCmd := range co.retryQueue {
 		co.RLock()
 		c, ok := co.conns[retryCmd.idHash]
 		co.RUnlock()
-
 		if ok {
-			// Connection available - dispatch the command
 			co.log.Debugf("Retrying %T for peer %x ident %x after %d attempts", retryCmd.cmd, retryCmd.idHash[:8], retryCmd.ident[:8], retryCmd.attempts)
-			c.dispatchCommand(retryCmd.cmd)
-
-			// Remove from retry queue
-			co.retryQueue = append(co.retryQueue[:i], co.retryQueue[i+1:]...)
+			ready = append(ready, pendingRetry{c, retryCmd.cmd})
+		} else {
+			kept = append(kept, retryCmd)
 		}
 	}
+	co.retryQueue = kept
 	instrument.RetryQueueSize(len(co.retryQueue))
+	co.retryQueueMu.Unlock()
+
+	// A command whose channel is still full is re-queued by
+	// dispatchCommand -> QueueForRetry, which can now take retryQueueMu.
+	for _, p := range ready {
+		p.conn.dispatchCommand(p.cmd)
+	}
 }
 
 func (co *Connector) DispatchReplication(cmd *commands.ReplicaWrite) {

--- a/replica/connector_test.go
+++ b/replica/connector_test.go
@@ -9,7 +9,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/katzenpost/hpqc/hash"
+
 	"github.com/katzenpost/katzenpost/core/log"
+	cpki "github.com/katzenpost/katzenpost/core/pki"
+	"github.com/katzenpost/katzenpost/core/sphinx/constants"
 	"github.com/katzenpost/katzenpost/core/wire/commands"
 )
 
@@ -165,4 +169,50 @@ func TestPruneRetryQueueDropsExpired(t *testing.T) {
 	// All expired entries pruned on the next QueueForRetry; only new entry remains.
 	require.Len(t, co.retryQueue, 1)
 	require.Equal(t, byte(3), co.retryQueue[0].ident[0])
+}
+
+// TestProcessRetryQueueFullChannelNoDeadlock is the regression guard for the
+// connector self-deadlock that took the namenlos replicas out of consensus.
+// processRetryQueue must not dispatch while holding retryQueueMu: when the
+// peer's per-peer channel is full, dispatchCommand falls through to
+// QueueForRetry, which re-locks retryQueueMu in the same goroutine. Holding
+// the lock across the dispatch wedged the connector's retry path forever, and
+// through the synchronous pki_change Rebalance it wedged the PKI worker, so the
+// replica stopped publishing its descriptor and aged out of the consensus.
+// On the buggy code this test times out; with the fix it returns promptly.
+func TestProcessRetryQueueFullChannelNoDeadlock(t *testing.T) {
+	co := newTestConnector(t)
+	co.conns = make(map[[constants.NodeIDLength]byte]*outgoingConn)
+
+	identityKey := []byte("peer-identity-key")
+	idHash := hash.Sum256(identityKey)
+
+	// A connected peer whose per-peer channel is already full, so any dispatch
+	// to it falls through to QueueForRetry.
+	c := &outgoingConn{
+		co:  co,
+		log: co.log,
+		dst: &cpki.ReplicaDescriptor{Name: "peer", IdentityKey: identityKey},
+		ch:  make(chan commands.Command, 1),
+	}
+	c.ch <- writeCmd(0xEE)
+	co.conns[idHash] = c
+
+	co.QueueForRetry(writeCmd(0x11), idHash)
+
+	done := make(chan struct{})
+	go func() {
+		co.processRetryQueue()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Returned without deadlocking.
+	case <-time.After(5 * time.Second):
+		t.Fatal("processRetryQueue deadlocked: it dispatched to a full peer channel while holding retryQueueMu")
+	}
+
+	// The channel was full, so the command must have been re-queued, not lost.
+	require.Len(t, co.retryQueue, 1)
 }


### PR DESCRIPTION
processRetryQueue dispatched while holding retryQueueMu; a full per-peer channel makes dispatchCommand re-enter QueueForRetry and re-lock the same mutex, wedging the retry path and, through the synchronous pki_change Rebalance, the PKI worker, so the replica stopped publishing its descriptor and fell out of consensus. Partition under the lock and dispatch after releasing it. Latent, but triggered by the session churn from a5b6c5de1c6f6375dd0b3191b80c877363d2f88b.