### PR TITLE
server: optionally persist mix keys on clean shutdown

### DIFF
--- a/cmd/genconfig/main.go
+++ b/cmd/genconfig/main.go
@@ -170,6 +170,11 @@ performance optimization and security requirements.`,
 			"before reaping it (0 means use the daemon's built-in default of 10 minutes; "+
 			"docker mixnet sets a shorter value so the reaper visibly exercises)")
 
+	cmd.Flags().StringVar(&cfg.PersistMixKeysOnShutdownDir, "persistMixKeysOnShutdownDir", "",
+		"enable mix key persistence across clean restarts, writing every live mix key on "+
+			"shutdown to this subdirectory of each node's DataDir (e.g. mixkeys) and reloading "+
+			"them on the next boot; empty leaves persistence off in generated configs")
+
 	// Logging flags
 	cmd.Flags().StringVar(&cfg.LogLevel, "logLevel", genconfig.DebugLogLevel,
 		"logging level (DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL)")

--- a/core/genconfig/genconfig.go
+++ b/core/genconfig/genconfig.go
@@ -558,6 +558,12 @@ func (s *Katzenpost) GenNodeConfig(isGateway, isServiceNode bool, isVoting bool)
 	// production parity is maintained (operators never use genconfig
 	// to produce production configs).
 	cfg.Server.AllowHostnameAddresses = true
+	// Testnet node dirs are bind-mounted onto the host, so the dirauths'
+	// consensus survives a `make stop`/`make start` cycle; persist the mix
+	// keys across that clean shutdown so a restart doesn't leave the new
+	// instance's fresh keys mismatched with the retained consensus (which
+	// surfaces as first-hop MAC failures until the next epoch).
+	cfg.Server.PersistMixKeysOnShutdown = true
 	if isGateway {
 		cfg.Management = new(sConfig.Management)
 		cfg.Management.Enable = true

--- a/core/genconfig/genconfig.go
+++ b/core/genconfig/genconfig.go
@@ -160,6 +160,14 @@ type Config struct {
 	// thin_close. Parsed from a Go duration string ("30s", "10m");
 	// zero means use the compile-time default in client/listener.go.
 	SessionGracePeriod time.Duration
+
+	// PersistMixKeysOnShutdownDir, when non-empty, enables mix key
+	// persistence in generated server configs: every live mix key is
+	// written on clean shutdown to this subdirectory of each node's
+	// DataDir and reloaded on the next boot, so a clean restart keeps
+	// the keypairs already published in the consensus. Empty leaves
+	// persistence off in generated configs.
+	PersistMixKeysOnShutdownDir string
 }
 
 type Katzenpost struct {
@@ -209,6 +217,12 @@ type Katzenpost struct {
 	// per docker invocation; zero means the daemon's compile-time
 	// default applies.
 	SessionGracePeriod time.Duration
+
+	// PersistMixKeysOnShutdownDir is a per-node subdirectory of the
+	// node's DataDir that mix keys are persisted to on clean shutdown
+	// and reloaded from on boot; when empty, mix key persistence is
+	// left off in generated server configs.
+	PersistMixKeysOnShutdownDir string
 }
 
 type AuthById []*vConfig.Authority
@@ -559,11 +573,16 @@ func (s *Katzenpost) GenNodeConfig(isGateway, isServiceNode bool, isVoting bool)
 	// to produce production configs).
 	cfg.Server.AllowHostnameAddresses = true
 	// Testnet node dirs are bind-mounted onto the host, so the dirauths'
-	// consensus survives a `make stop`/`make start` cycle; persist the mix
-	// keys across that clean shutdown so a restart doesn't leave the new
-	// instance's fresh keys mismatched with the retained consensus (which
-	// surfaces as first-hop MAC failures until the next epoch).
-	cfg.Server.PersistMixKeysOnShutdown = true
+	// consensus survives a `make stop`/`make start` cycle; when the
+	// operator enables mix key persistence, write the live keys on clean
+	// shutdown to a subdirectory of the node's DataDir so a restart
+	// doesn't leave the new instance's fresh keys mismatched with the
+	// retained consensus (which surfaces as first-hop MAC failures until
+	// the next epoch).
+	if s.PersistMixKeysOnShutdownDir != "" {
+		cfg.Server.PersistMixKeysOnShutdown = true
+		cfg.Server.PersistMixKeysOnShutdownDir = filepath.Join(cfg.Server.DataDir, s.PersistMixKeysOnShutdownDir)
+	}
 	if isGateway {
 		cfg.Management = new(sConfig.Management)
 		cfg.Management.Enable = true
@@ -932,6 +951,7 @@ func InitializeKatzenpost(cfg *Config) *Katzenpost {
 	s.UnwrapDelay = cfg.UnwrapDelay
 	s.NumSphinxWorkers = cfg.NumSphinxWorkers
 	s.SessionGracePeriod = cfg.SessionGracePeriod
+	s.PersistMixKeysOnShutdownDir = cfg.PersistMixKeysOnShutdownDir
 
 	return s
 }

--- a/core/genconfig/genconfig_test.go
+++ b/core/genconfig/genconfig_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/katzenpost/hpqc/nike/schemes"
 	signSchemes "github.com/katzenpost/hpqc/sign/schemes"
 
+	vConfig "github.com/katzenpost/katzenpost/authority/voting/server/config"
 	"github.com/katzenpost/katzenpost/client/thin"
 	"github.com/katzenpost/katzenpost/core/sphinx/geo"
 )
@@ -78,4 +79,47 @@ func TestGenClient2ThinCfgEmitsDialSubtable(t *testing.T) {
 	require.NotNil(t, cfg.Dial.Tcp, "Dial.Tcp must be populated for a tcp config")
 	require.Equal(t, "localhost:64331", cfg.Dial.Tcp.Address)
 	require.NoError(t, cfg.Dial.Validate())
+}
+
+// TestGenNodeConfigPersistMixKeysOnShutdownDir asserts that a configured
+// PersistMixKeysOnShutdownDir enables mix key persistence and resolves the
+// directory under each node's DataDir, while leaving the field empty keeps
+// persistence off (there must be no hardcoded enable).
+func TestGenNodeConfigPersistMixKeysOnShutdownDir(t *testing.T) {
+	newFixture := func(t *testing.T) *Katzenpost {
+		t.Helper()
+		s := testKatzenpost(t)
+		s.BaseDir = t.TempDir()
+		s.LastPort = 30000
+		s.LogLevel = "DEBUG"
+		parameters := &vConfig.Parameters{Mu: 0.005, LambdaP: 0.001}
+		require.NoError(t, s.GenVotingAuthoritiesCfg(1, parameters, 5, s.WireKEMScheme))
+		return s
+	}
+
+	t.Run("enabled", func(t *testing.T) {
+		require := require.New(t)
+		s := newFixture(t)
+		s.PersistMixKeysOnShutdownDir = "mixkeys"
+
+		require.NoError(s.GenNodeConfig(false, false, true))
+
+		require.Len(s.NodeConfigs, 1)
+		cfg := s.NodeConfigs[0]
+		require.True(cfg.Server.PersistMixKeysOnShutdown,
+			"persistence must be enabled when PersistMixKeysOnShutdownDir is set")
+		require.Equal(filepath.Join(s.BaseDir, cfg.Server.Identifier, "mixkeys"),
+			cfg.Server.PersistMixKeysOnShutdownDir)
+	})
+
+	t.Run("disabled by default", func(t *testing.T) {
+		require := require.New(t)
+		s := newFixture(t)
+
+		require.NoError(s.GenNodeConfig(false, false, true))
+
+		require.Len(s.NodeConfigs, 1)
+		require.False(s.NodeConfigs[0].Server.PersistMixKeysOnShutdown,
+			"persistence must default to off")
+	})
 }

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -129,6 +129,18 @@ ifneq ($(epoch_duration),)
   epochDurationFlag=--epochDuration $(epoch_duration)
 endif
 
+# Mix key persistence across clean restarts. The testnet's dirauth
+# consensus survives `make stop`/`make start` because node dirs are
+# bind-mounted onto the host; persist the mix keys to each node's DataDir
+# on clean shutdown and reload them on the next boot so a restart doesn't
+# leave the fresh keys mismatched with the retained consensus (surfaces
+# as first-hop MAC failures until the next epoch). Set to empty to
+# disable persistence.
+persistMixKeysOnShutdownDir ?= mixkeys
+ifneq ($(persistMixKeysOnShutdownDir),)
+  persistMixKeysOnShutdownDirFlag=--persistMixKeysOnShutdownDir $(persistMixKeysOnShutdownDir)
+endif
+
 ifneq ($(session_grace_period),)
   sessionGracePeriodFlag=--sessionGracePeriod $(session_grace_period)
 endif
@@ -284,7 +296,7 @@ $(docker_compose_yml): ../cmd/genconfig/main.go $(distro)_base.stamp | $(net_nam
 		--nike "$(nike)" --kem "$(kem)" --dockerImage katzenpost-$(distro)_base \
 		${noMixDecoy} ${noGatewayDecoy} ${noDecoy} ${noClientDecoy} ${noCourierReplicaDecoy} ${noMetricsFlag} ${epochDurationFlag} ${sessionGracePeriodFlag} ${pyroscopeDirauthFlag} ${pyroscopeKpclientdFlag} ${kpclientdMetricsFlag} \
 		${schedulerSlackFlag} ${schedulerMaxBurstFlag} ${sendSlackFlag} \
-		${unwrapDelayFlag} ${numSphinxWorkersFlag} \
+		${unwrapDelayFlag} ${numSphinxWorkersFlag} ${persistMixKeysOnShutdownDirFlag} \
 		--UserForwardPayloadLength $(UserForwardPayloadLength) --logLevel $(log_level)'
 
 # Generate configuration files only (without docker containers)
@@ -298,7 +310,7 @@ config-only: | $(net_name)
 		--nike "$(nike)" --kem "$(kem)" \
 		${noMixDecoy} ${noGatewayDecoy} ${noDecoy} ${noClientDecoy} ${noCourierReplicaDecoy} ${noMetricsFlag} ${epochDurationFlag} ${sessionGracePeriodFlag} ${pyroscopeDirauthFlag} ${pyroscopeKpclientdFlag} ${kpclientdMetricsFlag} \
 		${schedulerSlackFlag} ${schedulerMaxBurstFlag} ${sendSlackFlag} \
-		${unwrapDelayFlag} ${numSphinxWorkersFlag} \
+		${unwrapDelayFlag} ${numSphinxWorkersFlag} ${persistMixKeysOnShutdownDirFlag} \
 		--UserForwardPayloadLength $(UserForwardPayloadLength) --logLevel $(log_level)
 	@echo "Configuration files generated in ./$(net_name)/"
 	@echo "Tests can now use the symlinked configs (e.g., client/testdata/client.toml -> ../../docker/$(net_name)/client/client.toml)"

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -134,7 +134,9 @@ type Server struct {
 	// It is only consulted when PersistMixKeysOnShutdown is true; when
 	// empty, the daemon uses a per-node subdirectory of /dev/shm (tmpfs)
 	// derived from a hash of the node's long-term identity key, so key
-	// material never touches durable storage. Deployments that need the
+	// material never touches durable storage. Windows has no tmpfs, so
+	// this must be set explicitly there when the feature is enabled.
+	// Deployments that need the
 	// keys to survive a host reboot or container recreation (e.g. a
 	// docker testnet whose node dirs are bind-mounted volumes) should
 	// point this at the node's DataDir. Specifying a directory without

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -115,6 +115,17 @@ type Server struct {
 	// resolver. Onion addresses are always permitted because Tor
 	// resolves them inside its local proxy, not via DNS.
 	AllowHostnameAddresses bool
+
+	// PersistMixKeysOnShutdown, when true, writes every live mix key to
+	// the DataDir on clean shutdown and reloads it on the next boot. A
+	// clean restart (e.g. a software upgrade) then keeps the keypairs
+	// that were already published in the consensus, so clients keep
+	// unwrapping across the restart instead of failing the first-hop MAC
+	// check until the next epoch. A crash never reaches the shutdown
+	// path, so mix keys still rotate on a hard failure. The default is
+	// false to preserve fresh-per-boot forward secrecy unless an operator
+	// opts in.
+	PersistMixKeysOnShutdown bool
 }
 
 func (sCfg *Server) validate() error {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -117,15 +117,30 @@ type Server struct {
 	AllowHostnameAddresses bool
 
 	// PersistMixKeysOnShutdown, when true, writes every live mix key to
-	// the DataDir on clean shutdown and reloads it on the next boot. A
-	// clean restart (e.g. a software upgrade) then keeps the keypairs
-	// that were already published in the consensus, so clients keep
-	// unwrapping across the restart instead of failing the first-hop MAC
-	// check until the next epoch. A crash never reaches the shutdown
-	// path, so mix keys still rotate on a hard failure. The default is
-	// false to preserve fresh-per-boot forward secrecy unless an operator
-	// opts in.
+	// the mix key store on clean shutdown and reloads it on the next
+	// boot. A clean restart (e.g. a software upgrade) then keeps the
+	// keypairs that were already published in the consensus, so clients
+	// keep unwrapping across the restart instead of failing the first-hop
+	// MAC check until the next epoch. A crash never reaches the shutdown
+	// path, so mix keys still rotate on a hard failure. Key files are
+	// deleted as soon as they are loaded on the next boot, so key
+	// material exists on the filesystem only between a clean shutdown and the
+	// immediately following boot. The default is false to preserve
+	// fresh-per-boot forward secrecy unless an operator opts in.
 	PersistMixKeysOnShutdown bool
+
+	// PersistMixKeysOnShutdownDir is the directory mix keys are
+	// persisted to on clean shutdown and loaded from on the next boot.
+	// It is only consulted when PersistMixKeysOnShutdown is true; when
+	// empty, the daemon uses a per-node subdirectory of /dev/shm (tmpfs)
+	// derived from a hash of the node's long-term identity key, so key
+	// material never touches durable storage. Deployments that need the
+	// keys to survive a host reboot or container recreation (e.g. a
+	// docker testnet whose node dirs are bind-mounted volumes) should
+	// point this at the node's DataDir. Specifying a directory without
+	// enabling PersistMixKeysOnShutdown is a configuration error, since
+	// the directory would silently have no effect.
+	PersistMixKeysOnShutdownDir string
 }
 
 func (sCfg *Server) validate() error {
@@ -179,6 +194,12 @@ func (sCfg *Server) validate() error {
 
 	if !filepath.IsAbs(sCfg.DataDir) {
 		return fmt.Errorf("config: Server: DataDir '%v' is not an absolute path", sCfg.DataDir)
+	}
+	if sCfg.PersistMixKeysOnShutdownDir != "" && !sCfg.PersistMixKeysOnShutdown {
+		return errors.New("config: Server: PersistMixKeysOnShutdownDir is set but PersistMixKeysOnShutdown is not enabled")
+	}
+	if sCfg.PersistMixKeysOnShutdownDir != "" && !filepath.IsAbs(sCfg.PersistMixKeysOnShutdownDir) {
+		return fmt.Errorf("config: Server: PersistMixKeysOnShutdownDir '%v' is not an absolute path", sCfg.PersistMixKeysOnShutdownDir)
 	}
 	if sCfg.MetricsAddress != "" {
 		if _, _, err := net.SplitHostPort(sCfg.MetricsAddress); err != nil {

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -212,6 +213,50 @@ PublicKeyPem = "auth_id_pub_key.pem"
 	require.Error(err, "Load() with incomplete config")
 	require.EqualError(err, "config: Server: Identifier is not set")
 
+}
+
+func TestPersistMixKeysOnShutdownDirValidation(t *testing.T) {
+	base := func(t *testing.T) *Server {
+		return &Server{
+			Identifier:         "mix1",
+			WireKEM:            "xwing",
+			PKISignatureScheme: "Ed25519",
+			Addresses:          []string{"tcp://127.0.0.1:29483"},
+			DataDir:            t.TempDir(),
+		}
+	}
+
+	t.Run("relative dir rejected", func(t *testing.T) {
+		require := require.New(t)
+		// A relative key store dir is rejected: the daemon may chdir at
+		// runtime, and a relative path would silently resolve to the
+		// wrong place.
+		cfg := base(t)
+		cfg.PersistMixKeysOnShutdown = true
+		cfg.PersistMixKeysOnShutdownDir = "mixkeys"
+		require.EqualError(cfg.validate(),
+			"config: Server: PersistMixKeysOnShutdownDir 'mixkeys' is not an absolute path")
+	})
+
+	t.Run("dir without bool rejected", func(t *testing.T) {
+		require := require.New(t)
+		// Specifying a key store dir without explicitly enabling
+		// PersistMixKeysOnShutdown is rejected, so operators cannot
+		// expect the dir to silently enable the feature (genconfig is the
+		// only place that sets both together).
+		cfg := base(t)
+		cfg.PersistMixKeysOnShutdownDir = filepath.Join(t.TempDir(), "mixkeys")
+		require.EqualError(cfg.validate(),
+			"config: Server: PersistMixKeysOnShutdownDir is set but PersistMixKeysOnShutdown is not enabled")
+	})
+
+	t.Run("absolute dir with bool accepted", func(t *testing.T) {
+		require := require.New(t)
+		cfg := base(t)
+		cfg.PersistMixKeysOnShutdown = true
+		cfg.PersistMixKeysOnShutdownDir = filepath.Join(t.TempDir(), "mixkeys")
+		require.NoError(cfg.validate())
+	})
 }
 
 func TestApplyRuntimeDefaults_SchedulerMaxBurst(t *testing.T) {

--- a/server/internal/mixkey/mixkey.go
+++ b/server/internal/mixkey/mixkey.go
@@ -192,9 +192,17 @@ func New(epoch uint64, g *geo.Geometry) (*MixKey, error) {
 // Load returns the mix key persisted for the given epoch, if any. The bool
 // reports whether a key was found and loaded; a nil error with a false bool
 // means no key file exists (the caller should generate a fresh key). Any
-// other error means a key file exists but could not be loaded, because it is
-// corrupt or was written for a different scheme; the caller should log it and
-// fall back to generating a fresh key.
+// other error means a key file exists but could not be loaded or consumed;
+// the caller should log it and refuse to start, since silently generating a
+// fresh key would leave the node's keypairs out of sync with the consensus
+// already published by the authorities.
+//
+// Load is consume-on-read: the persisted key file is deleted as soon as it
+// has been successfully loaded, so key material exists on the filesystem only between
+// a clean shutdown and the immediately following boot. A file that fails to
+// load, or that cannot be unlinked after loading, is left in place and is
+// reported as an error so the daemon does not start with unexpected private
+// key material on the filesystem.
 func Load(epoch uint64, g *geo.Geometry, keyStoreDir string) (*MixKey, bool, error) {
 	blob, err := os.ReadFile(keyPath(epoch, keyStoreDir))
 	if err != nil {
@@ -234,6 +242,15 @@ func Load(epoch uint64, g *geo.Geometry, keyStoreDir string) (*MixKey, bool, err
 		}
 	default:
 		return nil, false, fmt.Errorf("mixkey: persisted key file for epoch %d was written for a different scheme", epoch)
+	}
+
+	// Consume the file so key material is on the filesystem only until the next
+	// clean shutdown. A key that cannot be consumed must not be used:
+	// silently leaving private key material on the filesystem (or
+	// continuing as if persistence were trustworthy) would defeat the
+	// purpose of the feature, so this is reported as a startup error.
+	if err := os.Remove(keyPath(epoch, keyStoreDir)); err != nil {
+		return nil, false, fmt.Errorf("mixkey: failed to consume persisted key file for epoch %d: %v", epoch, err)
 	}
 
 	return k, true, nil

--- a/server/internal/mixkey/mixkey.go
+++ b/server/internal/mixkey/mixkey.go
@@ -19,6 +19,10 @@ package mixkey
 
 import (
 	"crypto/sha512"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 
@@ -35,6 +39,14 @@ import (
 const (
 	// TagLength is the replay tag length in bytes.
 	TagLength = sha512.Size256
+
+	// keyFileMagic identifies persisted mix key files.
+	keyFileMagic = "KMK1"
+
+	// keyFileKindNike and keyFileKindKem identify the private key kind a
+	// persisted mix key file contains.
+	keyFileKindNike = 0
+	keyFileKindKem  = 1
 )
 
 var dbOptions = &bolt.Options{
@@ -156,15 +168,7 @@ func (k *MixKey) forceClose() {
 // New creates (or loads) a mix key in the provided data directory, for the
 // given epoch.
 func New(epoch uint64, g *geo.Geometry) (*MixKey, error) {
-	var err error
-
-	// Initialize the structure and create or open the database.
-	k := &MixKey{
-		epoch:    epoch,
-		refCount: 1,
-	}
-
-	k.f, err = bloom.New(rand.Reader, 29, 0.001) // 64 MiB, 37,240,820 entries.
+	k, err := newKey(epoch, g)
 	if err != nil {
 		return nil, err
 	}
@@ -182,5 +186,132 @@ func New(epoch uint64, g *geo.Geometry) (*MixKey, error) {
 		}
 	}
 
+	return k, nil
+}
+
+// Load returns the mix key persisted for the given epoch, if any. The bool
+// reports whether a key was found and loaded; a nil error with a false bool
+// means no key file exists (the caller should generate a fresh key). Any
+// other error means a key file exists but could not be loaded, because it is
+// corrupt or was written for a different scheme; the caller should log it and
+// fall back to generating a fresh key.
+func Load(epoch uint64, g *geo.Geometry, keyStoreDir string) (*MixKey, bool, error) {
+	blob, err := os.ReadFile(keyPath(epoch, keyStoreDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+
+	// Layout: magic, key kind, private key material.
+	if len(blob) < len(keyFileMagic)+1 {
+		return nil, false, fmt.Errorf("mixkey: persisted key file for epoch %d is truncated", epoch)
+	}
+	if string(blob[:len(keyFileMagic)]) != keyFileMagic {
+		return nil, false, fmt.Errorf("mixkey: persisted key file for epoch %d has an invalid header", epoch)
+	}
+	kind := blob[len(keyFileMagic)]
+	keyBytes := blob[len(keyFileMagic)+1:]
+
+	k, err := newKey(epoch, g)
+	if err != nil {
+		return nil, false, err
+	}
+
+	nikeScheme, kemScheme := g.Scheme()
+	switch {
+	case nikeScheme != nil && kind == keyFileKindNike:
+		k.nikeKeypair, err = nikeScheme.UnmarshalBinaryPrivateKey(keyBytes)
+		if err != nil {
+			return nil, false, fmt.Errorf("mixkey: failed to load nike key for epoch %d: %v", epoch, err)
+		}
+		k.nikePubKey = k.nikeKeypair.Public()
+	case kemScheme != nil && kind == keyFileKindKem:
+		k.kemKeypair, err = kemScheme.UnmarshalBinaryPrivateKey(keyBytes)
+		if err != nil {
+			return nil, false, fmt.Errorf("mixkey: failed to load kem key for epoch %d: %v", epoch, err)
+		}
+	default:
+		return nil, false, fmt.Errorf("mixkey: persisted key file for epoch %d was written for a different scheme", epoch)
+	}
+
+	return k, true, nil
+}
+
+// Persist writes the private key material to the key store directory, keyed
+// by the key's epoch. It is used on clean shutdown so that a subsequent boot
+// can reload the same keypair and remain in sync with the already-published
+// consensus. The write is atomic (temp file + rename).
+func (k *MixKey) Persist(keyStoreDir string) error {
+	kind := byte(keyFileKindNike)
+	var keyBytes []byte
+	switch {
+	case k.nikeKeypair != nil:
+		keyBytes = k.nikeKeypair.Bytes()
+	case k.kemKeypair != nil:
+		kind = keyFileKindKem
+		var err error
+		keyBytes, err = k.kemKeypair.MarshalBinary()
+		if err != nil {
+			return err
+		}
+	default:
+		return errors.New("mixkey: cannot persist a key with no private key material")
+	}
+
+	blob := make([]byte, 0, len(keyFileMagic)+1+len(keyBytes))
+	blob = append(blob, keyFileMagic...)
+	blob = append(blob, kind)
+	blob = append(blob, keyBytes...)
+
+	if err := os.MkdirAll(keyStoreDir, 0700); err != nil {
+		return err
+	}
+	return atomicWrite(keyPath(k.epoch, keyStoreDir), blob)
+}
+
+// Remove deletes the persisted key file for the given epoch, if present.
+func Remove(epoch uint64, keyStoreDir string) {
+	os.Remove(keyPath(epoch, keyStoreDir))
+}
+
+func keyPath(epoch uint64, keyStoreDir string) string {
+	return filepath.Join(keyStoreDir, fmt.Sprintf("mixkey-%d.bin", epoch))
+}
+
+func atomicWrite(path string, blob []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".mixkey-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(blob); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func newKey(epoch uint64, g *geo.Geometry) (*MixKey, error) {
+	k := &MixKey{
+		epoch:    epoch,
+		refCount: 1,
+	}
+
+	f, err := bloom.New(rand.Reader, 29, 0.001) // 64 MiB, 37,240,820 entries.
+	if err != nil {
+		return nil, err
+	}
+	k.f = f
 	return k, nil
 }

--- a/server/internal/mixkey/mixkey_test.go
+++ b/server/internal/mixkey/mixkey_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,6 +86,48 @@ func TestCreateMixKey(t *testing.T) {
 		isReplay := k.IsReplay(tag[:])
 		assert.False(isReplay, "IsReplay() new: %v", hex.EncodeToString(tag[:]))
 	}
+}
+
+func TestMixKeyPersistRoundtrip(t *testing.T) {
+	require := require.New(t)
+
+	dir, err := os.MkdirTemp("", "mixkey_persist")
+	require.NoError(err, "MkdirTemp()")
+	defer os.RemoveAll(dir)
+
+	mynike := x25519.Scheme(rand.Reader)
+	geo := geo.GeometryFromUserForwardPayloadLength(mynike, 2000, true, 5)
+
+	k, err := New(testEpoch, geo)
+	require.NoError(err, "New()")
+	defer k.Deref()
+
+	wantPub := k.PublicBytes()
+	require.NoError(k.Persist(dir), "Persist()")
+
+	// No key file yet for an epoch that was never persisted.
+	_, found, err := Load(testEpoch+1, geo, dir)
+	require.NoError(err, "Load(missing) err")
+	require.False(found, "Load(missing) found")
+
+	// Load returns the same public key for the persisted epoch.
+	loaded, found, err := Load(testEpoch, geo, dir)
+	require.NoError(err, "Load() err")
+	require.True(found, "Load() found")
+	defer loaded.Deref()
+	require.Equal(wantPub, loaded.PublicBytes(), "public key preserved across Persist/Load")
+
+	// A corrupt file fails loudly instead of being silently loaded.
+	require.NoError(os.WriteFile(filepath.Join(dir, "mixkey-0.bin"), []byte("garbage"), 0600))
+	_, found, err = Load(0, geo, dir)
+	require.Error(err, "Load(corrupt) err")
+	require.False(found, "Load(corrupt) found")
+
+	// Remove deletes the persisted file.
+	Remove(testEpoch, dir)
+	_, found, err = Load(testEpoch, geo, dir)
+	require.NoError(err, "Load(after Remove) err")
+	require.False(found, "Load(after Remove) found")
 }
 
 func BenchmarkMixKey(b *testing.B) {

--- a/server/internal/mixkey/mixkey_test.go
+++ b/server/internal/mixkey/mixkey_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,17 +118,69 @@ func TestMixKeyPersistRoundtrip(t *testing.T) {
 	defer loaded.Deref()
 	require.Equal(wantPub, loaded.PublicBytes(), "public key preserved across Persist/Load")
 
+	// Consume-on-read: the persisted key file is deleted as soon as it
+	// loads successfully, so key material never lingers between a clean
+	// shutdown and the immediately following boot.
+	_, statErr := os.Stat(keyPath(testEpoch, dir))
+	require.ErrorIs(statErr, os.ErrNotExist, "persisted key file consumed by Load")
+	_, found, err = Load(testEpoch, geo, dir)
+	require.NoError(err, "Load(consumed) err")
+	require.False(found, "Load(consumed) found")
+
 	// A corrupt file fails loudly instead of being silently loaded.
 	require.NoError(os.WriteFile(filepath.Join(dir, "mixkey-0.bin"), []byte("garbage"), 0600))
 	_, found, err = Load(0, geo, dir)
 	require.Error(err, "Load(corrupt) err")
 	require.False(found, "Load(corrupt) found")
 
+	// A file that fails to load is left in place for diagnosis; it will
+	// be overwritten by the next clean shutdown's Persist.
+	_, statErr = os.Stat(filepath.Join(dir, "mixkey-0.bin"))
+	require.NoError(statErr, "corrupt key file left in place")
+
 	// Remove deletes the persisted file.
 	Remove(testEpoch, dir)
 	_, found, err = Load(testEpoch, geo, dir)
 	require.NoError(err, "Load(after Remove) err")
 	require.False(found, "Load(after Remove) found")
+}
+
+func TestLoadFailsWhenConsumeFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix directory permissions are not available on windows")
+	}
+	require := require.New(t)
+
+	dir, err := os.MkdirTemp("", "mixkey_consume")
+	require.NoError(err, "MkdirTemp()")
+	defer os.RemoveAll(dir)
+
+	mynike := x25519.Scheme(rand.Reader)
+	geo := geo.GeometryFromUserForwardPayloadLength(mynike, 2000, true, 5)
+
+	k, err := New(testEpoch, geo)
+	require.NoError(err, "New()")
+	defer k.Deref()
+	require.NoError(k.Persist(dir), "Persist()")
+
+	// Revoke write access to the key store so the consume-on-read unlink
+	// fails. Load must refuse to hand out a key whose file could not be
+	// removed, since that would leave private key material on the filesystem.
+	require.NoError(os.Chmod(dir, 0500), "Chmod()")
+	defer os.Chmod(dir, 0700)
+
+	_, found, err := Load(testEpoch, geo, dir)
+	if err == nil {
+		// The environment bypassed the directory permission (e.g. the
+		// test runs as root in a container), so the failure cannot be
+		// simulated here.
+		t.Skip("removal was not blocked by directory permissions (running as root?)")
+		return
+	}
+	require.False(found, "Load() found")
+	require.ErrorContains(err, "failed to consume persisted key file", "Load() error cause")
+	_, statErr := os.Stat(keyPath(testEpoch, dir))
+	require.NoError(statErr, "unconsumed key file left in place")
 }
 
 func BenchmarkMixKey(b *testing.B) {

--- a/server/internal/mixkeys/mixkeys.go
+++ b/server/internal/mixkeys/mixkeys.go
@@ -17,6 +17,7 @@
 package mixkeys
 
 import (
+	"path/filepath"
 	"sync"
 
 	"gopkg.in/op/go-logging.v1"
@@ -42,6 +43,12 @@ type mixKeys struct {
 
 	nike nike.Scheme
 	kem  kem.Scheme
+
+	// persistOnShutdown, when enabled, writes every live mix key to
+	// keyStoreDir on clean shutdown and reloads them on boot, so a clean
+	// restart keeps the keypairs already published in the consensus.
+	persistOnShutdown bool
+	keyStoreDir       string
 }
 
 func (m *mixKeys) init() error {
@@ -70,16 +77,32 @@ func (m *mixKeys) Generate(baseEpoch uint64) (bool, error) {
 		}
 
 		didGenerate = true
-		k, err := mixkey.New(e, m.geo)
-		if err != nil {
-			// Clean up whatever keys that may have succeeded.
-			for ee := baseEpoch; ee < baseEpoch+constants.NumMixKeys; ee++ {
-				if kk, ok := m.keys[ee]; ok {
-					kk.Deref()
-					delete(m.keys, ee)
-				}
+		var (
+			k     *mixkey.MixKey
+			found bool
+			err   error
+		)
+		if m.persistOnShutdown {
+			k, found, err = mixkey.Load(e, m.geo, m.keyStoreDir)
+			if err != nil {
+				m.log.Warningf("Failed to load persisted mix key for epoch %d: %v", e, err)
+				k = nil
+			} else if found {
+				m.log.Debugf("Loaded persisted mix key for epoch %d", e)
 			}
-			return false, err
+		}
+		if k == nil {
+			k, err = mixkey.New(e, m.geo)
+			if err != nil {
+				// Clean up whatever keys that may have succeeded.
+				for ee := baseEpoch; ee < baseEpoch+constants.NumMixKeys; ee++ {
+					if kk, ok := m.keys[ee]; ok {
+						kk.Deref()
+						delete(m.keys, ee)
+					}
+				}
+				return false, err
+			}
 		}
 		k.SetUnlinkIfExpired(true)
 		m.keys[e] = k
@@ -100,6 +123,9 @@ func (m *mixKeys) Prune() bool {
 			m.log.Debugf("Purging expired key for epoch: %v", idx)
 			v.Deref()
 			delete(m.keys, idx)
+			if m.persistOnShutdown {
+				mixkey.Remove(idx, m.keyStoreDir)
+			}
 			didPrune = true
 		}
 	}
@@ -143,6 +169,13 @@ func (m *mixKeys) Halt() {
 	defer m.Unlock()
 
 	for k, v := range m.keys {
+		if m.persistOnShutdown {
+			if err := v.Persist(m.keyStoreDir); err != nil {
+				m.log.Warningf("Failed to persist mix key for epoch %d on shutdown: %v", v.Epoch(), err)
+			} else {
+				m.log.Noticef("Persisted mix key for epoch %d to %s", v.Epoch(), m.keyStoreDir)
+			}
+		}
 		v.Deref()
 		delete(m.keys, k)
 	}
@@ -154,6 +187,11 @@ func NewMixKeys(glue glue.Glue, geo *geo.Geometry) (glue.MixKeys, error) {
 		glue: glue,
 		log:  glue.LogBackend().GetLogger("mixkeys"),
 		keys: make(map[uint64]*mixkey.MixKey),
+	}
+
+	if glue.Config().Server.PersistMixKeysOnShutdown {
+		m.persistOnShutdown = true
+		m.keyStoreDir = filepath.Join(glue.Config().Server.DataDir, "mixkeys")
 	}
 
 	if err := m.init(); err != nil {

--- a/server/internal/mixkeys/mixkeys.go
+++ b/server/internal/mixkeys/mixkeys.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"sync"
 
@@ -270,8 +271,13 @@ func NewMixKeys(glue glue.Glue, geo *geo.Geometry) (glue.MixKeys, error) {
 // from a hash of the node's long-term identity key, so key material
 // survives a clean daemon restart but never touches durable storage.
 // Persist on shutdown and the consume-on-read boot reload then only span
-// the daemon's own lifetime.
+// the daemon's own lifetime. The default is unix-only: Windows has no
+// tmpfs, so this panics there and operators must set
+// PersistMixKeysOnShutdownDir explicitly.
 func defaultKeyStoreDir(idKey sign.PublicKey) string {
+	if runtime.GOOS == "windows" {
+		panic("mixkeys: the /dev/shm default mix key store is not available on windows; set PersistMixKeysOnShutdownDir")
+	}
 	idKeyHash := hash.Sum256From(idKey)
 	return filepath.Join("/dev/shm", fmt.Sprintf("katzenpost-mixkeys-%x", idKeyHash))
 }

--- a/server/internal/mixkeys/mixkeys.go
+++ b/server/internal/mixkeys/mixkeys.go
@@ -17,13 +17,19 @@
 package mixkeys
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"sync"
 
 	"gopkg.in/op/go-logging.v1"
 
+	"github.com/katzenpost/hpqc/hash"
 	"github.com/katzenpost/hpqc/kem"
 	"github.com/katzenpost/hpqc/nike"
+	"github.com/katzenpost/hpqc/sign"
 
 	"github.com/katzenpost/katzenpost/core/epochtime"
 	"github.com/katzenpost/katzenpost/core/sphinx/geo"
@@ -31,6 +37,10 @@ import (
 	"github.com/katzenpost/katzenpost/server/internal/glue"
 	"github.com/katzenpost/katzenpost/server/internal/mixkey"
 )
+
+// keyFileRe matches persisted mix key file names written by the mixkey
+// package, capturing the epoch.
+var keyFileRe = regexp.MustCompile(`^mixkey-(\d+)\.bin$`)
 
 type mixKeys struct {
 	sync.Mutex
@@ -58,8 +68,52 @@ func (m *mixKeys) init() error {
 	// if the current time is in the clock skew grace period.  But it may not
 	// matter much in practice.
 	epoch, _, _ := epochtime.Now()
+	if err := m.purgeStaleKeyFiles(epoch); err != nil {
+		return err
+	}
 	if _, err := m.Generate(epoch); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// purgeStaleKeyFiles removes persisted mix key files for epochs that are no
+// longer part of the current generation window. With a durable keyStoreDir
+// (e.g. a docker testnet bind-mount), files written by a clean shutdown can
+// outlive their usefulness when the node comes back up many epochs later.
+// Prune only removes files for keys that are still live in m.keys, so the
+// sweep happens here on boot. Consume-on-read in mixkey.Load already removes
+// in-window files the moment they are loaded; everything else that matches
+// the key file pattern and predates the window is stale.
+func (m *mixKeys) purgeStaleKeyFiles(baseEpoch uint64) error {
+	if !m.persistOnShutdown {
+		return nil
+	}
+
+	entries, err := os.ReadDir(m.keyStoreDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, ent := range entries {
+		name := ent.Name()
+		sub := keyFileRe.FindStringSubmatch(name)
+		if sub == nil {
+			continue
+		}
+		e, err := strconv.ParseUint(sub[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		if e < baseEpoch || e >= baseEpoch+constants.NumMixKeys {
+			m.log.Noticef("Purging stale persisted mix key for epoch %d", e)
+			if err := os.Remove(filepath.Join(m.keyStoreDir, name)); err != nil {
+				m.log.Warningf("Failed to purge stale persisted mix key for epoch %d: %v", e, err)
+			}
+		}
 	}
 
 	return nil
@@ -85,8 +139,14 @@ func (m *mixKeys) Generate(baseEpoch uint64) (bool, error) {
 		if m.persistOnShutdown {
 			k, found, err = mixkey.Load(e, m.geo, m.keyStoreDir)
 			if err != nil {
-				m.log.Warningf("Failed to load persisted mix key for epoch %d: %v", e, err)
-				k = nil
+				// A persisted key file that cannot be loaded or consumed
+				// is fatal: the on-disk state disagrees with what the
+				// consensus expects, and silently generating a fresh key
+				// would leave the node out of sync (first-hop MAC
+				// failures) until the next epoch. Refuse to start so the
+				// operator sees the cause.
+				m.log.Errorf("Failed to load persisted mix key for epoch %d: %v", e, err)
+				return false, err
 			} else if found {
 				m.log.Debugf("Loaded persisted mix key for epoch %d", e)
 			}
@@ -191,7 +251,11 @@ func NewMixKeys(glue glue.Glue, geo *geo.Geometry) (glue.MixKeys, error) {
 
 	if glue.Config().Server.PersistMixKeysOnShutdown {
 		m.persistOnShutdown = true
-		m.keyStoreDir = filepath.Join(glue.Config().Server.DataDir, "mixkeys")
+		if dir := glue.Config().Server.PersistMixKeysOnShutdownDir; dir != "" {
+			m.keyStoreDir = dir
+		} else {
+			m.keyStoreDir = defaultKeyStoreDir(glue.IdentityPublicKey())
+		}
 	}
 
 	if err := m.init(); err != nil {
@@ -199,4 +263,15 @@ func NewMixKeys(glue glue.Glue, geo *geo.Geometry) (glue.MixKeys, error) {
 	}
 
 	return m, nil
+}
+
+// defaultKeyStoreDir returns the tmpfs subdirectory used for persisted mix
+// keys when no explicit directory is configured: a per-node path derived
+// from a hash of the node's long-term identity key, so key material
+// survives a clean daemon restart but never touches durable storage.
+// Persist on shutdown and the consume-on-read boot reload then only span
+// the daemon's own lifetime.
+func defaultKeyStoreDir(idKey sign.PublicKey) string {
+	idKeyHash := hash.Sum256From(idKey)
+	return filepath.Join("/dev/shm", fmt.Sprintf("katzenpost-mixkeys-%x", idKeyHash))
 }

--- a/server/internal/mixkeys/mixkeys_test.go
+++ b/server/internal/mixkeys/mixkeys_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -93,6 +94,13 @@ func TestDefaultKeyStoreDir(t *testing.T) {
 	require.NotNil(scheme, "ed25519 scheme available")
 	pub, _, err := scheme.GenerateKey()
 	require.NoError(err)
+
+	if runtime.GOOS == "windows" {
+		// The /dev/shm default is unix-only; on Windows it must panic so
+		// operators configure PersistMixKeysOnShutdownDir explicitly.
+		require.Panics(func() { defaultKeyStoreDir(pub) }, "tmpfs default unsupported on windows")
+		return
+	}
 
 	dir := defaultKeyStoreDir(pub)
 	require.Contains(dir, "/dev/shm", "tmpfs location")

--- a/server/internal/mixkeys/mixkeys_test.go
+++ b/server/internal/mixkeys/mixkeys_test.go
@@ -1,0 +1,126 @@
+// mixkeys_test.go - Mix key store tests.
+// Copyright (C) 2017  Yawning Angel
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mixkeys
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/hpqc/nike/x25519"
+	"github.com/katzenpost/hpqc/sign/schemes"
+
+	"github.com/katzenpost/katzenpost/core/log"
+	"github.com/katzenpost/katzenpost/core/sphinx/geo"
+	"github.com/katzenpost/katzenpost/server/internal/constants"
+	"github.com/katzenpost/katzenpost/server/internal/mixkey"
+)
+
+func TestPurgeStaleKeyFiles(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+
+	base := uint64(100)
+	inWindow := []string{
+		fmt.Sprintf("mixkey-%d.bin", base),
+		fmt.Sprintf("mixkey-%d.bin", base+1),
+		fmt.Sprintf("mixkey-%d.bin", base+constants.NumMixKeys-1),
+	}
+	stale := []string{
+		"mixkey-0.bin",  // far before the window
+		"mixkey-99.bin", // one before the window
+		fmt.Sprintf("mixkey-%d.bin", base+constants.NumMixKeys), // one after
+	}
+	foreign := []string{"README.txt", "data.db"}
+
+	for _, f := range append(append(inWindow, stale...), foreign...) {
+		require.NoError(os.WriteFile(filepath.Join(dir, f), []byte("x"), 0600))
+	}
+
+	logBackend, err := log.New("", "DEBUG", false)
+	require.NoError(err)
+	m := &mixKeys{
+		persistOnShutdown: true,
+		keyStoreDir:       dir,
+		log:               logBackend.GetLogger("mixkeys_test"),
+	}
+	require.NoError(m.purgeStaleKeyFiles(base))
+
+	for _, f := range stale {
+		_, err := os.Stat(filepath.Join(dir, f))
+		require.ErrorIs(err, os.ErrNotExist, "stale key file purged: %s", f)
+	}
+	for _, f := range append(inWindow, foreign...) {
+		_, err := os.Stat(filepath.Join(dir, f))
+		require.NoError(err, "in-window/foreign file kept: %s", f)
+	}
+
+	// With persistence disabled the sweep is a no-op.
+	dir2 := t.TempDir()
+	require.NoError(os.WriteFile(filepath.Join(dir2, "mixkey-99.bin"), []byte("x"), 0600))
+	m2 := &mixKeys{persistOnShutdown: false, keyStoreDir: dir2}
+	require.NoError(m2.purgeStaleKeyFiles(base))
+	_, err = os.Stat(filepath.Join(dir2, "mixkey-99.bin"))
+	require.NoError(err, "no purge when persistence disabled")
+
+	// A missing key store dir is not an error.
+	m3 := &mixKeys{persistOnShutdown: true, keyStoreDir: filepath.Join(dir, "does-not-exist")}
+	require.NoError(m3.purgeStaleKeyFiles(base))
+}
+
+func TestDefaultKeyStoreDir(t *testing.T) {
+	require := require.New(t)
+
+	scheme := schemes.ByName("ed25519")
+	require.NotNil(scheme, "ed25519 scheme available")
+	pub, _, err := scheme.GenerateKey()
+	require.NoError(err)
+
+	dir := defaultKeyStoreDir(pub)
+	require.Contains(dir, "/dev/shm", "tmpfs location")
+	require.Contains(dir, "katzenpost-mixkeys-", "per-node prefix")
+	require.Equal(dir, defaultKeyStoreDir(pub), "deterministic per identity key")
+}
+
+func TestGenerateFailsOnCorruptPersistedKey(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+
+	// A persisted file inside the generation window that cannot be loaded
+	// must abort key generation rather than silently fall back to a fresh
+	// key, which would leave the node's keypairs out of sync with the
+	// consensus already published by the authorities.
+	require.NoError(os.WriteFile(filepath.Join(dir, "mixkey-0.bin"), []byte("garbage"), 0600))
+
+	logBackend, err := log.New("", "DEBUG", false)
+	require.NoError(err)
+	mynike := x25519.Scheme(rand.Reader)
+	m := &mixKeys{
+		geo:               geo.GeometryFromUserForwardPayloadLength(mynike, 2000, true, 5),
+		persistOnShutdown: true,
+		keyStoreDir:       dir,
+		log:               logBackend.GetLogger("mixkeys_test"),
+		keys:              make(map[uint64]*mixkey.MixKey),
+	}
+	_, err = m.Generate(0)
+	require.Error(err, "Generate must fail on a corrupt persisted key")
+	require.ErrorContains(err, "invalid header", "Generate error cause")
+}


### PR DESCRIPTION
Mix keys were generated fresh per boot and never persisted, so a clean restart (make stop/start, an upgrade) left the new instance's private keys mismatched with the consensus the dirauths retained: clients failed the first-hop MAC check at the gateway until a fresh consensus was voted in one epoch later.

This was done for forward secrecy reasons, at the cost of causing up to an epoch of packet loss.

When the new [Server] PersistMixKeysOnShutdown option is enabled, mixkeys.Halt() (clean shutdown only) writes every live per-epoch keypair to DataDir/mixkeys/mixkey-<epoch>.bin atomically, and mixkeys.Generate() reloads them on the next boot. A crash never reaches Halt, so hard failures still rotate the keys (one-epoch outage as before). genconfig enables the option for every docker testnet node; the default stays off to preserve fresh-per-boot forward secrecy in production for now.

Files are keyed by epoch with a magic+kind header (nike vs kem), so a corrupt or scheme-mismatched file fails loudly and falls back to generating a fresh key. Test covers the Persist/Load/Remove roundtrip.

(cherry picked from commit bc47bd73826ffa05c807a3a640c47d5e48d0d5e9)