### PR TITLE
client: use previous epoch doc when current is missing

### DIFF
--- a/authority/voting/client/client.go
+++ b/authority/voting/client/client.go
@@ -415,13 +415,13 @@ func (p *connector) initSessionWithRetry(
 	return nil, lastErr
 }
 
-func (p *connector) roundTrip(s *wire.Session, cmd commands.Command) (commands.Command, error) {
+func (p *connector) roundTrip(ctx context.Context, s *wire.Session, cmd commands.Command) (commands.Command, error) {
 	sendStart := time.Now()
-	if err := s.SendCommand(context.Background(), cmd); err != nil {
+	if err := s.SendCommand(ctx, cmd); err != nil {
 		return nil, err
 	}
 	p.log.Debugf("Sent %s in %v", cmd, time.Since(sendStart))
-	return s.RecvCommand(context.Background())
+	return s.RecvCommand(ctx)
 }
 
 type PeerResponse struct {
@@ -455,7 +455,7 @@ func (p *connector) allPeersRoundTrip(
 			}
 			defer conn.Close()
 
-			resp, err := p.roundTrip(conn.session, cmd)
+			resp, err := p.roundTrip(ictx, conn.session, cmd)
 			if err != nil {
 				p.log.Errorf("allPeersRoundTrip: %s round trip failed: %v", peer.Identifier, err)
 				responseCh <- PeerResponse{Peer: peer, Error: err}
@@ -601,7 +601,7 @@ func (p *connector) postAuthorityOnce(
 	}
 	defer conn.Close()
 
-	resp, err := p.roundTrip(conn.session, cmd)
+	resp, err := p.roundTrip(ctx, conn.session, cmd)
 	if err != nil {
 		elapsed := time.Since(start)
 		p.log.Warningf(
@@ -1103,7 +1103,7 @@ func (p *connector) fetchConsensus(
 		MixnetTransmission: false,
 	}
 
-	resp, err := p.roundTrip(conn.session, cmd)
+	resp, err := p.roundTrip(ctx, conn.session, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("peer %s: round trip failed: %v", auth.Identifier, err)
 	}

--- a/client/pki.go
+++ b/client/pki.go
@@ -244,6 +244,19 @@ func (p *pki) currentRawSignedDocument() ([]byte, uint64) {
 		cached := d.(*CachedDoc)
 		return cached.RawSignedBlob, cached.Doc.Epoch
 	}
+
+	// Mirror the currentDocument fallback: around an epoch boundary, or
+	// across a skipped (dead) consensus epoch, the current epoch's
+	// document is not yet or never cached. Serve the previous epoch's
+	// raw payload so raw document requests (the fetch tool's
+	// GetPKIDocumentRaw(0)) keep getting an answer. The reply's epoch
+	// is that of the document actually returned.
+	if d, _ := p.docs.Load(now - 1); d != nil {
+		cached := d.(*CachedDoc)
+		p.log.Debugf("currentRawSignedDocument: epoch %d not yet cached, using previous epoch %d", now, now-1)
+		return cached.RawSignedBlob, cached.Doc.Epoch
+	}
+
 	return nil, now
 }
 
@@ -323,6 +336,30 @@ func (p *pki) worker() {
 				continue
 			}
 			didUpdate = true
+		}
+
+		// A restart that misses the dirauth vote window skips a whole
+		// consensus epoch: the current epoch will never receive a
+		// document, so the loop above can only mark it as failed. Cache
+		// the previous epoch's document in that case so the daemon keeps
+		// serving a current-or-previous document to thin clients
+		// (currentDocument and currentRawSignedDocument both fall back
+		// one epoch) instead of starving them for the entire gap. The
+		// previous epoch is still served by the authorities inside their
+		// retention window; once a real current consensus exists the
+		// loop fetches it as usual and the fallback stops being reached.
+		if _, ok := p.docs.Load(now); !ok {
+			if _, ok := p.docs.Load(now - 1); !ok {
+				p.log.Debugf("current epoch %d has no document (likely unserved), fetching previous epoch %d", now, now-1)
+				if err := p.updateDocument(now - 1); err != nil {
+					if err == cpki.ErrDocumentGone {
+						p.failedFetches[now-1] = err
+					}
+					p.log.Debugf("failed to fetch previous epoch %d: %v", now-1, err)
+				} else {
+					didUpdate = true
+				}
+			}
 		}
 		p.pruneFailures(now)
 		if didUpdate {

--- a/client/pki_test.go
+++ b/client/pki_test.go
@@ -276,6 +276,104 @@ func TestPKICurrentDocumentFallsBackToPreviousEpoch(t *testing.T) {
 	require.Equal(t, []byte("cur"), blob)
 }
 
+// TestPKICurrentRawSignedDocumentFallsBackToPreviousEpoch confirms the raw
+// signed document path serves the previous epoch's payload while the current
+// epoch is unserved, so thin-client raw document requests (the fetch tool's
+// GetPKIDocumentRaw(0)) keep getting an answer across a skipped consensus
+// epoch instead of returning nil.
+func TestPKICurrentRawSignedDocumentFallsBackToPreviousEpoch(t *testing.T) {
+	cfg, err := config.LoadFile("testdata/client.toml")
+	require.NoError(t, err)
+
+	logbackend, err := log.New("", "debug", false)
+	require.NoError(t, err)
+	c := &Client{
+		logbackend: logbackend,
+		cfg:        cfg,
+	}
+	p := newPKI(c)
+	c.pki = p
+
+	now, _, _ := epochtime.Now()
+
+	// Nothing cached for any epoch: there is nothing to fall back to.
+	raw, gotEpoch := p.currentRawSignedDocument()
+	require.Nil(t, raw)
+
+	prevDoc := &cpki.Document{Epoch: now - 1}
+	p.docs.Store(now-1, &CachedDoc{Doc: prevDoc, Blob: []byte("prev"), RawSignedBlob: []byte("prev-raw")})
+
+	// Current epoch absent: fall back to the previous epoch, reporting
+	// the previous epoch's document epoch.
+	raw, gotEpoch = p.currentRawSignedDocument()
+	require.Equal(t, []byte("prev-raw"), raw)
+	require.Equal(t, now-1, gotEpoch)
+
+	// Once the current epoch's document arrives it takes precedence.
+	curDoc := &cpki.Document{Epoch: now}
+	p.docs.Store(now, &CachedDoc{Doc: curDoc, Blob: []byte("cur"), RawSignedBlob: []byte("cur-raw")})
+	raw, gotEpoch = p.currentRawSignedDocument()
+	require.Equal(t, []byte("cur-raw"), raw)
+	require.Equal(t, now, gotEpoch)
+}
+
+// TestPKIWorkerFetchesPreviousEpochWhenCurrentUnserved exercises the PKI
+// worker's fallback: when the current epoch will never receive a document
+// (a consensus epoch skipped by a restart that missed the dirauth vote
+// window), the worker caches the previous epoch so the daemon keeps serving
+// a document to thin clients for the duration of the gap.
+func TestPKIWorkerFetchesPreviousEpochWhenCurrentUnserved(t *testing.T) {
+	cfg, err := config.LoadFile("testdata/client.toml")
+	require.NoError(t, err)
+
+	myMockPKIClient := new(mockPKIClient)
+	logbackend, err := log.New("", "debug", false)
+	require.NoError(t, err)
+	c := &Client{
+		logbackend: logbackend,
+		cfg:        cfg,
+		PKIClient:  myMockPKIClient,
+	}
+	cfg.Callbacks = &config.Callbacks{}
+
+	p := newPKI(c)
+	c.pki = p
+
+	now, _, _ := epochtime.Now()
+
+	// The current epoch is permanently unserved; the previous epoch is.
+	myMockPKIClient.doc = &cpki.Document{
+		Epoch:              now - 1,
+		SphinxGeometryHash: c.cfg.SphinxGeometry.Hash(),
+	}
+	p.consensusGetter = &mockConsensusGetter{
+		epochErrors: map[uint64]uint8{now: commands.ConsensusGone},
+	}
+
+	p.start()
+	defer func() {
+		p.Halt()
+		p.Wait()
+	}()
+
+	// The worker caches the previous epoch within its first wake.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, ok := p.docs.Load(now - 1); ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("PKI worker never cached the previous epoch")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The daemon serves the fallback document to raw-document requests.
+	raw, gotEpoch := p.currentRawSignedDocument()
+	require.NotNil(t, raw)
+	require.Equal(t, now-1, gotEpoch)
+}
+
 // TestPKIPruneRetainsPreviousEpoch confirms pruneDocuments keeps the
 // immediately previous epoch's document, so currentDocument can still
 // serve it as the last valid document while the current epoch's


### PR DESCRIPTION
Two dead-epoch bugs surfaced by timed restarts that landed a dead consensus epoch (a restart missing the dirauth vote deadline skips a whole epoch of consensus, so no document ever exists for it):

1. Daemon fetch starvation. The client PKI worker only fetches the current (and near-boundary next) epoch, so a daemon that boots into a dead epoch caches nothing at all: the dead epoch is permanently failed and the previous epoch is never fetched. thin-client raw document requests then fail forever (the fetch tool hung >10min even after the network recovered, because currentRawSignedDocument only looked at the current epoch). The worker now falls back to fetching the previous epoch when the current one has no document, and currentRawSignedDocument mirrors currentDocument's one-epoch fallback, so GetPKIDocumentRaw(0) keeps getting an answer through the gap. The previous epoch remains inside the authorities' retention window, and once a real current consensus exists the normal path takes over.

2. Courier/replica fetch-cycle stall. roundTrip sent and received with context.Background(), so a peer that accepted the connection but did not answer GetConsensus blocked the fetch cycle only up to the session read timeout, ignoring the FetchTimeout deadline that WorkerBase.FetchDocuments sets to cap the whole cycle. The courier's readiness gauge (and any caller that relies on FetchTimeout) therefore sat at 0 for minutes past when the recovery consensus was servable. roundTrip now honors the caller's context, so the cycle deadline genuinely bounds the send+receive.

Tests: new tests cover the raw signed document one-epoch fallback and the worker's previous-epoch fallback under a permanently-unserved current epoch. client, authority/voting/client, and core/pki suites pass.

(cherry picked from commit 6ba1df885d64cccadea28eb0fa2391d34a90be8b)