### PR TITLE
cmd/ping: exit non-zero unless all pings succeed

### DIFF
--- a/cmd/ping/main.go
+++ b/cmd/ping/main.go
@@ -125,7 +125,10 @@ full client mode where this ping tool starts it's own client daemon.`,
 				os.Exit(0)
 			}()
 
-			executePing(thinClient, cfg.Service, cfg.Count, cfg.Concurrency, cfg.PrintDiff)
+			failed := executePing(thinClient, cfg.Service, cfg.Count, cfg.Concurrency, cfg.PrintDiff)
+			if failed > 0 {
+				return fmt.Errorf("ping success rate below 100%%: %d/%d pings failed", failed, cfg.Count)
+			}
 			return nil
 		},
 	}
@@ -210,14 +213,14 @@ func initializeFullClient(configFile string, logPath string, logLevel string) (*
 	return thinClient, daemon
 }
 
-// executePing performs the ping operation
-func executePing(thinClient *thin.ThinClient, service string, count, concurrency int, printDiff bool) {
+// executePing performs the ping operation and returns how many pings failed.
+func executePing(thinClient *thin.ThinClient, service string, count, concurrency int, printDiff bool) uint64 {
 	desc, err := thinClient.GetService(service)
 	if err != nil {
 		panic(err)
 	}
 
-	sendPings(thinClient, desc, count, concurrency, printDiff)
+	return sendPings(thinClient, desc, count, concurrency, printDiff)
 }
 
 // cleanup closes the thin client connection and shuts down the daemon if running

--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -151,7 +151,10 @@ func sendPing(session *thin.ThinClient, serviceDesc *common.ServiceDescriptor, t
 	}
 }
 
-func sendPings(session *thin.ThinClient, serviceDesc *common.ServiceDescriptor, count int, concurrency int, printDiff bool) {
+// sendPings sends count pings and returns how many failed. Callers use the
+// return value to set a non-zero process exit code so the ping can be used
+// as a smoke-test gate.
+func sendPings(session *thin.ThinClient, serviceDesc *common.ServiceDescriptor, count int, concurrency int, printDiff bool) uint64 {
 	// Extract service name from RecipientQueueID (remove leading '+' if present)
 	serviceName := string(serviceDesc.RecipientQueueID)
 	nodeName := serviceDesc.MixDescriptor.Name
@@ -205,4 +208,6 @@ func sendPings(session *thin.ThinClient, serviceDesc *common.ServiceDescriptor, 
 	} else {
 		fmt.Printf("%s\n", failureStyle.Render(successMsg))
 	}
+
+	return failed
 }


### PR DESCRIPTION
sendPings now returns the failed count, executePing propagates it, and the cobra RunE returns an error on any failure, so the shared fang wrapper exits 1. Previously the process always exited 0 regardless of dropped pings, making run-ping useless as a smoke-test gate.

(cherry picked from commit dfde000dfaf8539724bc627a122896da2775d101)