### PR TITLE
server: withdraw from consensus before shutdown

### DIFF
--- a/CONFIG_CHANGES.md
+++ b/CONFIG_CHANGES.md
@@ -138,6 +138,20 @@ None.
 
 Source: `server/config/config.go`.
 
+### `[Server]`
+
+- **Added** `WaitForConsensusExitOnShutdown` (bool, default `false`). When
+  enabled, SIGINT or SIGTERM stops new descriptor uploads while the node
+  continues serving traffic and fetching PKI documents. The daemon exits
+  after the last epoch in which it may still appear has ended. The wait is
+  conservative: an upload attempt counts even if it returned an error,
+  because enough directory authorities may already have accepted it. If the
+  next epoch's descriptor was uploaded before the signal, shutdown can take
+  almost two complete epochs. With the default 20-minute epoch, configure a
+  systemd `TimeoutStopSec` comfortably above 40 minutes, for example `45min`.
+  This option and `PersistMixKeysOnShutdown` are mutually exclusive; enabling
+  both is a configuration error.
+
 ### `[Server.Gateway]`
 
 - **Removed** `[Gateway.UserDB]` table (and its `[Gateway.UserDB.Bolt]`

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -182,7 +182,7 @@ func runServer(cfg Config) error {
 	// Halt the server gracefully on SIGINT/SIGTERM.
 	go func() {
 		<-haltCh
-		svr.Shutdown()
+		svr.ShutdownGracefully()
 	}()
 
 	// Rotate server logs upon SIGHUP.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -116,6 +116,19 @@ type Server struct {
 	// resolves them inside its local proxy, not via DNS.
 	AllowHostnameAddresses bool
 
+	// WaitForConsensusExitOnShutdown, when true, makes SIGINT and SIGTERM
+	// stop descriptor publication and wait until every epoch for which this
+	// node may have advertised has ended before shutting down. The node keeps
+	// serving traffic and fetching PKI documents while it waits, allowing it
+	// to leave the consensus without disrupting traffic assigned to it.
+	//
+	// With the default 20-minute epoch, the conservative wait can approach
+	// 40 minutes when the next epoch's descriptor was already uploaded.
+	// Service managers must allow enough stop time (for example, systemd's
+	// TimeoutStopSec) or they may kill the process before withdrawal completes.
+	// This option is mutually exclusive with PersistMixKeysOnShutdown.
+	WaitForConsensusExitOnShutdown bool
+
 	// PersistMixKeysOnShutdown, when true, writes every live mix key to
 	// the mix key store on clean shutdown and reloads it on the next
 	// boot. A clean restart (e.g. a software upgrade) then keeps the
@@ -202,6 +215,9 @@ func (sCfg *Server) validate() error {
 	}
 	if sCfg.PersistMixKeysOnShutdownDir != "" && !filepath.IsAbs(sCfg.PersistMixKeysOnShutdownDir) {
 		return fmt.Errorf("config: Server: PersistMixKeysOnShutdownDir '%v' is not an absolute path", sCfg.PersistMixKeysOnShutdownDir)
+	}
+	if sCfg.WaitForConsensusExitOnShutdown && sCfg.PersistMixKeysOnShutdown {
+		return errors.New("config: Server: WaitForConsensusExitOnShutdown and PersistMixKeysOnShutdown are mutually exclusive")
 	}
 	if sCfg.MetricsAddress != "" {
 		if _, _, err := net.SplitHostPort(sCfg.MetricsAddress); err != nil {

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -257,6 +257,15 @@ func TestPersistMixKeysOnShutdownDirValidation(t *testing.T) {
 		cfg.PersistMixKeysOnShutdownDir = filepath.Join(t.TempDir(), "mixkeys")
 		require.NoError(cfg.validate())
 	})
+
+	t.Run("consensus withdrawal and key persistence are mutually exclusive", func(t *testing.T) {
+		require := require.New(t)
+		cfg := base(t)
+		cfg.WaitForConsensusExitOnShutdown = true
+		cfg.PersistMixKeysOnShutdown = true
+		require.EqualError(cfg.validate(),
+			"config: Server: WaitForConsensusExitOnShutdown and PersistMixKeysOnShutdown are mutually exclusive")
+	})
 }
 
 func TestApplyRuntimeDefaults_SchedulerMaxBurst(t *testing.T) {

--- a/server/internal/glue/glue.go
+++ b/server/internal/glue/glue.go
@@ -66,6 +66,7 @@ type MixKeys interface {
 type PKI interface {
 	Halt()
 	StartWorker()
+	StopAdvertising() uint64
 	OutgoingDestinations() map[[constants.NodeIDLength]byte]*pki.MixDescriptor
 	AuthenticateConnection(*wire.PeerCredentials, bool) (*pki.MixDescriptor, bool, bool)
 	GetRawConsensus(uint64) ([]byte, error)

--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -99,6 +99,12 @@ type pki struct {
 	lastPublishedEpoch uint64
 	lastWarnedEpoch    uint64
 
+	publicationMu           sync.Mutex
+	advertising             bool
+	activePublicationCancel context.CancelFunc
+	activePublicationDone   chan struct{}
+	lastAdvertisedEpoch     uint64
+
 	// cachedAuthDocs stores a snapshot of documents for lock-free authentication.
 	// Updated atomically when documents change.
 	cachedAuthDocs atomic.Value // stores *authDocsCache
@@ -106,6 +112,84 @@ type pki struct {
 
 func (p *pki) StartWorker() {
 	p.Go(p.worker)
+}
+
+// beginDescriptorPublication registers a publication pass so
+// StopAdvertising can cancel it and wait for it to finish. Descriptor
+// construction is included in the pass to close the race where withdrawal
+// begins after the worker checks the flag but before it calls Post.
+func (p *pki) beginDescriptorPublication(parent context.Context) (context.Context, chan struct{}, bool) {
+	p.publicationMu.Lock()
+	defer p.publicationMu.Unlock()
+
+	if !p.advertising {
+		return nil, nil, false
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	done := make(chan struct{})
+	p.activePublicationCancel = cancel
+	p.activePublicationDone = done
+	return ctx, done, true
+}
+
+func (p *pki) endDescriptorPublication(done chan struct{}) {
+	p.publicationMu.Lock()
+	defer p.publicationMu.Unlock()
+
+	if p.activePublicationDone != done {
+		return
+	}
+	p.activePublicationCancel()
+	p.activePublicationCancel = nil
+	p.activePublicationDone = nil
+	close(done)
+}
+
+func (p *pki) recordDescriptorAdvertisement(epoch uint64) {
+	p.publicationMu.Lock()
+	defer p.publicationMu.Unlock()
+
+	if epoch > p.lastAdvertisedEpoch {
+		p.lastAdvertisedEpoch = epoch
+	}
+}
+
+// StopAdvertising prevents future descriptor uploads, cancels any upload in
+// progress, and waits until the active publication pass has returned. The
+// returned epoch is the last one in which this node may appear, based on both
+// attempted uploads and consensus documents already cached by the node.
+// Fetching and traffic service continue until the server performs its final
+// shutdown.
+func (p *pki) StopAdvertising() uint64 {
+	p.publicationMu.Lock()
+	p.advertising = false
+	cancel := p.activePublicationCancel
+	done := p.activePublicationDone
+	p.publicationMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+
+	p.publicationMu.Lock()
+	lastEpoch := p.lastAdvertisedEpoch
+	p.publicationMu.Unlock()
+
+	// A cached document proves that the node is present in that epoch even
+	// when the descriptor was uploaded by an earlier process invocation.
+	p.RLock()
+	for epoch := range p.docs {
+		if epoch > lastEpoch {
+			lastEpoch = epoch
+		}
+	}
+	p.RUnlock()
+
+	return lastEpoch
 }
 
 // updateAuthDocsCache rebuilds and atomically stores the auth docs cache.
@@ -452,6 +536,13 @@ func (p *pki) pruneDocuments() {
 }
 
 func (p *pki) publishDescriptorIfNeeded(pkiCtx context.Context) error {
+	publicationCtx, publicationDone, ok := p.beginDescriptorPublication(pkiCtx)
+	if !ok {
+		p.log.Debug("Descriptor advertising is disabled; skipping publication.")
+		return nil
+	}
+	defer p.endDescriptorPublication(publicationDone)
+
 	currentEpoch, elapsed, till := epochtime.Now()
 
 	uploadDeadline := PublishDeadline - descriptorUploadSafety
@@ -506,7 +597,7 @@ func (p *pki) publishDescriptorIfNeeded(pkiCtx context.Context) error {
 		budget,
 	)
 
-	uploadCtx, cancel := context.WithTimeout(pkiCtx, budget)
+	uploadCtx, cancel := context.WithTimeout(publicationCtx, budget)
 	defer cancel()
 
 	// Note: Why, yes I *could* cache the descriptor and save a trivial amount
@@ -615,6 +706,11 @@ func (p *pki) publishDescriptorIfNeeded(pkiCtx context.Context) error {
 	)
 	p.log.Noticef("🔄 DESCRIPTOR UPLOAD: Node details - IsGateway: %v, IsService: %v", desc.IsGatewayNode, desc.IsServiceNode)
 
+	// Record the epoch before calling Post. Even when Post returns an error, a
+	// subset of authorities may already have accepted the descriptor and may
+	// be sufficient to include it in a later vote. Waiting an extra epoch is
+	// safer than shutting down while the node may still be in consensus.
+	p.recordDescriptorAdvertisement(doPublishEpoch)
 	err = p.impl.Post(uploadCtx, doPublishEpoch, p.glue.IdentityKey(), p.glue.IdentityPublicKey(), desc, p.glue.Decoy().GetStats(doPublishEpoch))
 	switch err {
 	case nil:
@@ -915,6 +1011,7 @@ func New(glue glue.Glue) (glue.PKI, error) {
 		docs:          make(map[uint64]*pkicache.Entry),
 		rawDocs:       make(map[uint64][]byte),
 		failedFetches: make(map[uint64]error),
+		advertising:   true,
 	}
 
 	var err error

--- a/server/internal/pki/withdrawal_test.go
+++ b/server/internal/pki/withdrawal_test.go
@@ -1,0 +1,69 @@
+// withdrawal_test.go - Descriptor withdrawal tests.
+// Copyright (C) 2017  Yawning Angel.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package pki
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/katzenpost/server/internal/pkicache"
+)
+
+func TestStopAdvertisingCancelsAndWaitsForPublication(t *testing.T) {
+	require := require.New(t)
+	p := &pki{
+		advertising: true,
+		docs: map[uint64]*pkicache.Entry{
+			42: nil,
+		},
+	}
+
+	publicationCtx, publicationDone, ok := p.beginDescriptorPublication(context.Background())
+	require.True(ok)
+	p.recordDescriptorAdvertisement(41)
+
+	canceled := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		<-publicationCtx.Done()
+		close(canceled)
+		<-release
+		p.endDescriptorPublication(publicationDone)
+	}()
+
+	stopped := make(chan uint64, 1)
+	go func() {
+		stopped <- p.StopAdvertising()
+	}()
+
+	<-canceled
+	select {
+	case <-stopped:
+		t.Fatal("StopAdvertising returned before the active publication ended")
+	default:
+	}
+
+	close(release)
+	require.Equal(uint64(42), <-stopped,
+		"cached consensus epoch must extend the conservative withdrawal wait")
+
+	_, _, ok = p.beginDescriptorPublication(context.Background())
+	require.False(ok, "publication must remain disabled after withdrawal starts")
+	require.Equal(uint64(42), p.StopAdvertising(), "StopAdvertising must be idempotent")
+}

--- a/server/server.go
+++ b/server/server.go
@@ -41,6 +41,7 @@ import (
 	signSchemes "github.com/katzenpost/hpqc/sign/schemes"
 
 	kpcommon "github.com/katzenpost/katzenpost/common"
+	"github.com/katzenpost/katzenpost/core/epochtime"
 	"github.com/katzenpost/katzenpost/core/log"
 	"github.com/katzenpost/katzenpost/core/thwack"
 	"github.com/katzenpost/katzenpost/core/utils"
@@ -83,6 +84,7 @@ type Server struct {
 	periodic      *periodicTimer
 	mixKeys       glue.MixKeys
 	pki           glue.PKI
+	shutdownPKI   glue.PKI
 	listeners     []glue.Listener
 	connector     glue.Connector
 	gateway       glue.Gateway
@@ -90,9 +92,10 @@ type Server struct {
 	decoy         glue.Decoy
 	management    *thwack.Server
 
-	fatalErrCh chan error
-	haltedCh   chan interface{}
-	haltOnce   sync.Once
+	fatalErrCh   chan error
+	haltedCh     chan interface{}
+	haltOnce     sync.Once
+	gracefulOnce sync.Once
 }
 
 func (s *Server) initLogging() error {
@@ -135,6 +138,58 @@ func (s *Server) RotateLog() {
 // Shutdown cleanly shuts down a given Server instance.
 func (s *Server) Shutdown() {
 	s.haltOnce.Do(func() { s.halt() })
+}
+
+// ShutdownGracefully withdraws the node from future consensus documents
+// before shutting it down when WaitForConsensusExitOnShutdown is enabled.
+// Fatal-error paths continue to use Shutdown so a broken node is not kept
+// alive merely to complete an operator-requested drain.
+func (s *Server) ShutdownGracefully() {
+	s.gracefulOnce.Do(func() {
+		if s.cfg.Server.WaitForConsensusExitOnShutdown {
+			s.waitForConsensusExit()
+		}
+		s.Shutdown()
+	})
+	<-s.haltedCh
+}
+
+func (s *Server) waitForConsensusExit() {
+	if s.shutdownPKI == nil {
+		return
+	}
+
+	lastEpoch := s.shutdownPKI.StopAdvertising()
+	currentEpoch, _, till := epochtime.Now()
+	wait := consensusExitWait(lastEpoch, currentEpoch, till, epochtime.Period)
+	if wait <= 0 {
+		s.log.Noticef("Consensus withdrawal complete: node is not advertised in epoch %d.", currentEpoch)
+		return
+	}
+
+	s.log.Noticef(
+		"Consensus withdrawal started: descriptor advertising stopped; last potentially advertised epoch=%d current_epoch=%d; continuing to serve traffic for %v before shutdown.",
+		lastEpoch,
+		currentEpoch,
+		wait,
+	)
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		s.log.Noticef("Consensus withdrawal complete after epoch %d.", lastEpoch)
+	case <-s.haltedCh:
+		// An immediate shutdown, normally caused by a fatal error, won the
+		// race. Do not keep the graceful caller blocked.
+	}
+}
+
+func consensusExitWait(lastAdvertisedEpoch, currentEpoch uint64, tillNextEpoch, epochPeriod time.Duration) time.Duration {
+	if lastAdvertisedEpoch < currentEpoch {
+		return 0
+	}
+	return tillNextEpoch + time.Duration(lastAdvertisedEpoch-currentEpoch)*epochPeriod
 }
 
 // Wait waits till the server is terminated for any reason.
@@ -456,6 +511,9 @@ func New(cfg *config.Config) (*Server, error) {
 		s.log.Errorf("Failed to initialize PKI client: %v", err)
 		return nil, err
 	}
+	// Keep an immutable reference for a signal-triggered consensus withdrawal.
+	// The regular pki field is cleared during an immediate shutdown.
+	s.shutdownPKI = s.pki
 	logStartupStep("PKI client")
 
 	// Initialize the gateway backend.

--- a/server/server_shutdown_test.go
+++ b/server/server_shutdown_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,8 +35,10 @@ import (
 	signSchemes "github.com/katzenpost/hpqc/sign/schemes"
 
 	aconfig "github.com/katzenpost/katzenpost/authority/voting/server/config"
+	"github.com/katzenpost/katzenpost/core/log"
 	"github.com/katzenpost/katzenpost/core/sphinx/geo"
 	"github.com/katzenpost/katzenpost/server/config"
+	"github.com/katzenpost/katzenpost/server/internal/glue"
 )
 
 var testingSchemeName = "xwing"
@@ -148,4 +151,96 @@ func TestServerStartShutdown(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	defer s.Shutdown()
+}
+
+func TestConsensusExitWait(t *testing.T) {
+	const (
+		currentEpoch = uint64(100)
+		period       = 20 * time.Minute
+		tillBoundary = 7 * time.Minute
+	)
+
+	tests := []struct {
+		name                string
+		lastAdvertisedEpoch uint64
+		want                time.Duration
+	}{
+		{
+			name:                "already absent",
+			lastAdvertisedEpoch: currentEpoch - 1,
+			want:                0,
+		},
+		{
+			name:                "advertised in current epoch",
+			lastAdvertisedEpoch: currentEpoch,
+			want:                tillBoundary,
+		},
+		{
+			name:                "next epoch descriptor already attempted",
+			lastAdvertisedEpoch: currentEpoch + 1,
+			want:                tillBoundary + period,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, consensusExitWait(
+				test.lastAdvertisedEpoch,
+				currentEpoch,
+				tillBoundary,
+				period,
+			))
+		})
+	}
+}
+
+type shutdownTestPKI struct {
+	glue.PKI
+	stopCalls int
+	haltCalls int
+}
+
+func (p *shutdownTestPKI) StopAdvertising() uint64 {
+	p.stopCalls++
+	return 0
+}
+
+func (p *shutdownTestPKI) Halt() {
+	p.haltCalls++
+}
+
+func TestShutdownGracefullyHonorsConsensusWithdrawalOption(t *testing.T) {
+	newServer := func(t *testing.T, enabled bool) (*Server, *shutdownTestPKI) {
+		t.Helper()
+		logBackend, err := log.New("", "ERROR", false)
+		require.NoError(t, err)
+		fakePKI := new(shutdownTestPKI)
+		return &Server{
+			cfg: &config.Config{
+				Server: &config.Server{
+					WaitForConsensusExitOnShutdown: enabled,
+				},
+			},
+			logBackend:  logBackend,
+			log:         logBackend.GetLogger("shutdown_test"),
+			pki:         fakePKI,
+			shutdownPKI: fakePKI,
+			fatalErrCh:  make(chan error),
+			haltedCh:    make(chan interface{}),
+		}, fakePKI
+	}
+
+	t.Run("enabled", func(t *testing.T) {
+		s, fakePKI := newServer(t, true)
+		s.ShutdownGracefully()
+		require.Equal(t, 1, fakePKI.stopCalls)
+		require.Equal(t, 1, fakePKI.haltCalls)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		s, fakePKI := newServer(t, false)
+		s.ShutdownGracefully()
+		require.Zero(t, fakePKI.stopCalls)
+		require.Equal(t, 1, fakePKI.haltCalls)
+	})
 }


### PR DESCRIPTION
## Summary

- add `[Server] WaitForConsensusExitOnShutdown`, disabled by default
- stop future descriptor uploads and cancel/join an upload already in flight
- keep serving traffic and fetching PKI documents until the node is absent from consensus
- keep fatal-error shutdown immediate
- reject configurations that also enable `PersistMixKeysOnShutdown`

## Shutdown timing

The server advertises for the next epoch. A descriptor upload can also return an aggregate error after enough individual authorities have accepted it. The shutdown path therefore waits through the last epoch that was cached or potentially advertised, rather than assuming the current epoch is sufficient.

With the default 20-minute epoch, the conservative wait can approach 40 minutes. The configuration documentation recommends a systemd `TimeoutStopSec` above that, for example `45min`.

## Testing

- `go test ./server/config ./server/internal/pki`
- `go test ./server -run '^(TestConsensusExitWait|TestShutdownGracefullyHonorsConsensusWithdrawalOption)$'`
- `go test -race ./server/internal/pki`
- `go test -run '^$' ./cmd/server ./server/...`
- `go vet ./server/config ./server/internal/glue ./server/internal/pki`

This is stacked on #1081 so the two shutdown modes can be validated together. It should be rebased onto `main` after #1081 merges.

Closes #1086.
