### PR TITLE
Makefile: fix replica target ldflags again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ sphinx:
 	cd cmd/sphinx; go build -trimpath -ldflags "-s -w"
 
 replica:
-	cd cmd/replica; go build -v -trimpath -ldflags "-X github.com/carlmjohnson/versioninfo.Revision=$$(git rev-parse --short HEAD)"
+	cd cmd/replica; go build -v -trimpath -ldflags "-s -w"
 
 clean:
 	rm -f cmd/server/server cmd/dirauth/dirauth cmd/genconfig/genconfig cmd/ping/ping \


### PR DESCRIPTION
the versioninfo part was recently removed in https://github.com/katzenpost/katzenpost/pull/1085 but the removal got reverted by the commit merging main in
https://github.com/katzenpost/katzenpost/pull/1084

this time i'm also adding the -s -w options which other targets here are using, to strip the symbol table and debugging information to make smaller binaries.