### PR TITLE
metrics: panic on prometheus listener bind failure

### DIFF
--- a/authority/voting/server/instrument/prometheus.go
+++ b/authority/voting/server/instrument/prometheus.go
@@ -21,12 +21,13 @@
 package instrument
 
 import (
-	"net/http"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"gopkg.in/op/go-logging.v1"
+
+	"github.com/katzenpost/katzenpost/common/metrics"
 )
 
 var registerOnce sync.Once
@@ -119,8 +120,9 @@ func phaseToInt(phase string) float64 {
 
 // StartPrometheusListener registers the dirauth metrics and starts the
 // HTTP listener if address is non-empty. Safe to call multiple times;
-// registration happens exactly once.
-func StartPrometheusListener(address string) {
+// registration happens exactly once. Panics if a configured address
+// cannot be bound.
+func StartPrometheusListener(address string, log *logging.Logger) {
 	registerOnce.Do(func() {
 		prometheus.MustRegister(votesReceived)
 		prometheus.MustRegister(descriptorsAccepted)
@@ -135,8 +137,7 @@ func StartPrometheusListener(address string) {
 	if address == "" {
 		return
 	}
-	http.Handle("/metrics", promhttp.Handler())
-	go http.ListenAndServe(address, nil)
+	metrics.MustServe(address, log)
 }
 
 // VoteReceived increments the per-result vote counter.

--- a/authority/voting/server/instrument/prometheus_dummy.go
+++ b/authority/voting/server/instrument/prometheus_dummy.go
@@ -12,10 +12,14 @@
 // prometheus.go.
 package instrument
 
-import "time"
+import (
+	"time"
+
+	"gopkg.in/op/go-logging.v1"
+)
 
 // StartPrometheusListener is a no-op when the noprometheus build tag is set.
-func StartPrometheusListener(_ string) {}
+func StartPrometheusListener(_ string, _ *logging.Logger) {}
 
 // VoteReceived is a no-op when the noprometheus build tag is set.
 func VoteReceived(_ string) {}

--- a/authority/voting/server/server.go
+++ b/authority/voting/server/server.go
@@ -461,8 +461,10 @@ func New(cfg *config.Config) (*Server, error) {
 	// running. Empty MetricsAddress disables the endpoint entirely;
 	// production deployments should leave it unset and only set it
 	// in docker and other operator-controlled diagnostic
-	// environments.
-	instrument.StartPrometheusListener(s.cfg.Server.MetricsAddress)
+	// environments. A configured address that cannot be bound is a
+	// configuration error and panics, consistent with the MetricsAddress
+	// syntax validation done at config parse time.
+	instrument.StartPrometheusListener(s.cfg.Server.MetricsAddress, s.log)
 
 	isOk = true
 	return s, nil

--- a/client/instrument/noop.go
+++ b/client/instrument/noop.go
@@ -12,10 +12,14 @@
 // real implementation defined in prometheus.go.
 package instrument
 
-import "time"
+import (
+	"time"
+
+	"gopkg.in/op/go-logging.v1"
+)
 
 // StartPrometheusListener is a no-op when the build tag is unset.
-func StartPrometheusListener(_ string) {}
+func StartPrometheusListener(_ string, _ *logging.Logger) {}
 
 // LambdaPFifoPop is a no-op when the build tag is unset.
 func LambdaPFifoPop() {}

--- a/client/instrument/prometheus.go
+++ b/client/instrument/prometheus.go
@@ -19,12 +19,13 @@
 package instrument
 
 import (
-	"net/http"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"gopkg.in/op/go-logging.v1"
+
+	"github.com/katzenpost/katzenpost/common/metrics"
 )
 
 var registerOnce sync.Once
@@ -159,8 +160,11 @@ var (
 // if address is non-empty. Safe to call multiple times; registration
 // happens exactly once and subsequent listener starts after the first
 // are ignored. Binds to whatever address the caller supplies; convention
-// in this project is to use 127.0.0.1 only.
-func StartPrometheusListener(address string) {
+// in this project is to use 127.0.0.1 only. Panics if a configured
+// address cannot be bound. log may be nil, which suppresses reporting of
+// a listener failure after a successful bind; kpclientd has no log
+// backend yet at the point it calls this.
+func StartPrometheusListener(address string, log *logging.Logger) {
 	registerOnce.Do(func() {
 		prometheus.MustRegister(lambdaPFifoPop)
 		prometheus.MustRegister(lambdaPDecoy)
@@ -186,8 +190,7 @@ func StartPrometheusListener(address string) {
 	if address == "" {
 		return
 	}
-	http.Handle("/metrics", promhttp.Handler())
-	go http.ListenAndServe(address, nil)
+	metrics.MustServe(address, log)
 }
 
 // LambdaPFifoPop records one real-message emission on a LambdaP tick.

--- a/cmd/kpclientd/main.go
+++ b/cmd/kpclientd/main.go
@@ -103,7 +103,7 @@ func runClientDaemon(cfg Config) error {
 	// `kpclientd_metrics` is not set the call is a no-op and incurs
 	// no listener; production builds therefore expose no /metrics
 	// surface regardless of whether the config field is populated.
-	instrument.StartPrometheusListener(clientCfg.MetricsAddress)
+	instrument.StartPrometheusListener(clientCfg.MetricsAddress, nil)
 
 	d, err := client.NewDaemon(clientCfg)
 	if err != nil {

--- a/common/metrics/listener.go
+++ b/common/metrics/listener.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Package metrics provides the HTTP listener shared by the
+// prometheus instrumentation packages of every Katzenpost daemon.
+// Only the prometheus-enabled builds of those packages import it, so
+// the noprometheus and !kpclientd_metrics builds still compile out the
+// dependency on prometheus/client_golang entirely.
+package metrics
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"gopkg.in/op/go-logging.v1"
+)
+
+// MustServe is Serve, but panics rather than returning the bind error.
+// Every Katzenpost daemon uses this: a MetricsAddress that cannot be
+// bound is an operator configuration error, and a component that came
+// up anyway would leave a scrape target answering nothing. Failing
+// loudly at startup is the whole point of binding synchronously.
+func MustServe(address string, log *logging.Logger) {
+	if err := Serve(address, log); err != nil {
+		panic(err)
+	}
+}
+
+// Serve exposes the registered prometheus metrics as /metrics on
+// address.
+//
+// The socket is bound synchronously, so a bind failure (a port already
+// in use, or an address that is not local to this host) is returned to
+// the caller rather than lost inside a goroutine; only the accept loop
+// runs in the background. Most callers want MustServe; Serve exists for
+// tests and for any caller that must handle the failure itself.
+//
+// A nil log is permitted, and suppresses reporting of a failure that
+// stops the accept loop after a successful bind.
+func Serve(address string, log *logging.Logger) error {
+	ln, err := net.Listen("tcp", address)
+	if err != nil {
+		return fmt.Errorf("prometheus metrics listener: cannot bind %q: %w", address, err)
+	}
+
+	// A dedicated mux rather than http.DefaultServeMux: the default
+	// mux is process global, so anything else that registers a
+	// handler on it would be served on this socket too, and a second
+	// call here would panic on the duplicate /metrics registration.
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+
+	go func() {
+		err := http.Serve(ln, mux)
+		if log != nil {
+			log.Errorf("Prometheus metrics listener on %s stopped serving: %v", address, err)
+		}
+	}()
+	return nil
+}

--- a/common/metrics/listener_test.go
+++ b/common/metrics/listener_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package metrics
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// freeAddr returns a loopback address that was bindable a moment ago.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr
+}
+
+// TestServeReportsBindConflict is the regression test for a metrics
+// listener whose bind failure used to vanish inside a goroutine: an
+// address already in use must be reported to the caller.
+func TestServeReportsBindConflict(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer occupied.Close()
+
+	err = Serve(occupied.Addr().String(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot bind")
+}
+
+// Every daemon reaches the listener through MustServe, so a bind
+// failure must take the component down rather than be shrugged off.
+func TestMustServePanicsOnBindConflict(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer occupied.Close()
+
+	require.Panics(t, func() { MustServe(occupied.Addr().String(), nil) })
+}
+
+func TestMustServeDoesNotPanicOnSuccess(t *testing.T) {
+	require.NotPanics(t, func() { MustServe(freeAddr(t), nil) })
+}
+
+func TestServeRejectsNonLocalAddress(t *testing.T) {
+	err := Serve("192.0.2.1:0", nil)
+	require.Error(t, err)
+}
+
+func TestServeScrapesMetrics(t *testing.T) {
+	addr := freeAddr(t)
+	require.NoError(t, Serve(addr, nil))
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get("http://" + addr + "/metrics")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "go_goroutines")
+}
+
+// The listener must use its own mux rather than http.DefaultServeMux,
+// so that a second listener does not panic on a duplicate /metrics
+// registration and does not serve unrelated default-mux handlers.
+func TestServeUsesDedicatedMux(t *testing.T) {
+	http.HandleFunc("/unrelated", func(w http.ResponseWriter, r *http.Request) {})
+
+	first := freeAddr(t)
+	require.NoError(t, Serve(first, nil))
+	second := freeAddr(t)
+	require.NotPanics(t, func() {
+		require.NoError(t, Serve(second, nil))
+	})
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get("http://" + second + "/unrelated")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}

--- a/courier/server/instrument/prometheus.go
+++ b/courier/server/instrument/prometheus.go
@@ -4,12 +4,13 @@
 package instrument
 
 import (
-	"net/http"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"gopkg.in/op/go-logging.v1"
+
+	"github.com/katzenpost/katzenpost/common/metrics"
 )
 
 var registerOnce sync.Once
@@ -99,8 +100,9 @@ var (
 )
 
 // StartPrometheusListener registers metrics and starts the HTTP listener
-// if address is non-empty.
-func StartPrometheusListener(address string) {
+// if address is non-empty. Panics if a configured address cannot be
+// bound.
+func StartPrometheusListener(address string, log *logging.Logger) {
 	registerOnce.Do(func() {
 		prometheus.MustRegister(decoysSent)
 		prometheus.MustRegister(messagesSent)
@@ -116,10 +118,10 @@ func StartPrometheusListener(address string) {
 		prometheus.MustRegister(copyShardReadTotal)
 	})
 
-	if address != "" {
-		http.Handle("/metrics", promhttp.Handler())
-		go http.ListenAndServe(address, nil)
+	if address == "" {
+		return
 	}
+	metrics.MustServe(address, log)
 }
 
 // DecoysSent increments the counter for decoy messages sent

--- a/courier/server/server.go
+++ b/courier/server/server.go
@@ -81,7 +81,7 @@ func New(cfg *config.Config, pkiClient pki.Fetcher) (*Server, error) {
 	} else {
 		s.log.Notice("Prometheus metrics listener disabled (MetricsAddress not set)")
 	}
-	instrument.StartPrometheusListener(cfg.MetricsAddress)
+	instrument.StartPrometheusListener(cfg.MetricsAddress, s.log)
 
 	return s, nil
 }

--- a/replica/instrument/prometheus.go
+++ b/replica/instrument/prometheus.go
@@ -4,12 +4,13 @@
 package instrument
 
 import (
-	"net/http"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"gopkg.in/op/go-logging.v1"
+
+	"github.com/katzenpost/katzenpost/common/metrics"
 )
 
 var registerOnce sync.Once
@@ -133,8 +134,9 @@ var (
 )
 
 // StartPrometheusListener registers metrics and starts the HTTP listener
-// if address is non-empty.
-func StartPrometheusListener(address string) {
+// if address is non-empty. Panics if a configured address cannot be
+// bound.
+func StartPrometheusListener(address string, log *logging.Logger) {
 	registerOnce.Do(func() {
 		prometheus.MustRegister(incomingDecoysReceived)
 		prometheus.MustRegister(incomingDecoyRepliesEmitted)
@@ -156,10 +158,10 @@ func StartPrometheusListener(address string) {
 		prometheus.MustRegister(replicationSemWaiters)
 	})
 
-	if address != "" {
-		http.Handle("/metrics", promhttp.Handler())
-		go http.ListenAndServe(address, nil)
+	if address == "" {
+		return
 	}
+	metrics.MustServe(address, log)
 }
 
 // IncomingDecoysReceived increments the counter for decoy commands received from couriers

--- a/replica/server.go
+++ b/replica/server.go
@@ -323,7 +323,7 @@ func newServerWithPKI(cfg *config.Config, pkiClient pki.ReplicaNodeClient) (*Ser
 	} else {
 		s.log.Notice("Prometheus metrics listener disabled (MetricsAddress not set)")
 	}
-	instrument.StartPrometheusListener(cfg.MetricsAddress)
+	instrument.StartPrometheusListener(cfg.MetricsAddress, s.log)
 
 	isOk = true
 

--- a/server/internal/instrument/prometheus.go
+++ b/server/internal/instrument/prometheus.go
@@ -5,12 +5,12 @@ package instrument
 
 import (
 	"fmt"
-	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/katzenpost/katzenpost/common/metrics"
 	"github.com/katzenpost/katzenpost/core/wire/commands"
 	"github.com/katzenpost/katzenpost/server/internal/glue"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -204,7 +204,8 @@ var (
 	)
 )
 
-// StartPrometheusListener starts the Prometheus metrics TCP/HTTP Listener
+// StartPrometheusListener starts the Prometheus metrics TCP/HTTP
+// Listener. Panics if a configured MetricsAddress cannot be bound.
 func StartPrometheusListener(glue glue.Glue) {
 	prometheus.MustRegister(deadlineBlownPacketsDropped)
 	prometheus.MustRegister(incomingConns)
@@ -238,11 +239,10 @@ func StartPrometheusListener(glue glue.Glue) {
 	prometheus.MustRegister(selfCheckSphinxCores)
 
 	metricsAddress := glue.Config().Server.MetricsAddress
-	if metricsAddress != "" {
-		// Expose registered metrics via HTTP
-		http.Handle("/metrics", promhttp.Handler())
-		go http.ListenAndServe(metricsAddress, nil)
+	if metricsAddress == "" {
+		return
 	}
+	metrics.MustServe(metricsAddress, glue.LogBackend().GetLogger("instrument"))
 }
 
 // Incoming increments the counter for incoming requests

--- a/tools/chaos/cpbench/instrument.go
+++ b/tools/chaos/cpbench/instrument.go
@@ -4,11 +4,11 @@
 package cpbench
 
 import (
-	"net/http"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/katzenpost/katzenpost/common/metrics"
 )
 
 var registerOnce sync.Once
@@ -54,7 +54,7 @@ var (
 
 // StartListener registers and exposes the cp-bench metric surface.
 // Safe to call multiple times; registration and listener startup
-// happen exactly once.
+// happen exactly once. Panics if a configured address cannot be bound.
 func StartListener(address string) {
 	registerOnce.Do(func() {
 		prometheus.MustRegister(runsTotal)
@@ -65,7 +65,6 @@ func StartListener(address string) {
 		if address == "" {
 			return
 		}
-		http.Handle("/metrics", promhttp.Handler())
-		go http.ListenAndServe(address, nil)
+		metrics.MustServe(address, nil)
 	})
 }

--- a/tools/chaos/parallelload/instrument.go
+++ b/tools/chaos/parallelload/instrument.go
@@ -4,12 +4,12 @@
 package parallelload
 
 import (
-	"net/http"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/katzenpost/katzenpost/common/metrics"
 )
 
 var registerOnce sync.Once
@@ -52,7 +52,9 @@ var (
 )
 
 // StartListener registers the metrics and starts the HTTP listener on
-// the given address (empty disables the listener).
+// the given address (empty disables the listener). Safe to call multiple
+// times; registration and listener startup happen exactly once. Panics
+// if a configured address cannot be bound.
 func StartListener(address string) {
 	registerOnce.Do(func() {
 		prometheus.MustRegister(iterationsTotal)
@@ -60,11 +62,11 @@ func StartListener(address string) {
 		prometheus.MustRegister(activeClients)
 		prometheus.MustRegister(sweepStep)
 		prometheus.MustRegister(errorsByKind)
+		if address == "" {
+			return
+		}
+		metrics.MustServe(address, nil)
 	})
-	if address != "" {
-		http.Handle("/metrics", promhttp.Handler())
-		go http.ListenAndServe(address, nil)
-	}
 }
 
 // IterationCompleted records a successful iteration and its full cycle


### PR DESCRIPTION
The listener goroutine discarded ListenAndServe's error, so a port conflict left a daemon running with nothing on its metrics port and no sign of trouble. Bind synchronously and panic, so a misconfigured address takes the component down at startup rather than silently.