### PR TITLE
Add katzenpost_node_ready gauge and make fetch --require-ready poll it

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -295,7 +295,7 @@ func (c *connection) connectWorker() {
 func (c *connection) doConnect(dialCtx context.Context) {
 	const (
 		retryIncrement = 15 * time.Second
-		maxRetryDelay  = 2 * time.Minute
+		maxRetryDelay  = 30 * time.Second
 	)
 
 	dialFn := c.client.DialContextFn

--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -136,22 +136,41 @@ func runFetch(cfg Config) error {
 	signerNames := loadAuthorityNames(client)
 
 	// Try the daemon's current signed document straight away. Under
-	// --require-ready, skip this shortcut: readiness must be gated on the
-	// current epoch's consensus, which we only reliably get via the event
-	// sink.
-	if !cfg.RequireReady {
-		if doc, err := fetchSignedDocument(client, 0); err == nil && hasEnoughReplicas(doc, cfg.MinReplicas) {
-			printDocument(doc, signerNames)
-			return nil
+	// --require-ready the waitForReady gate re-checks the live readiness
+	// gauges against the current expected epochs on every poll, so this
+	// document only supplies the node inventory; using the daemon's
+	// current (possibly previous-epoch) document does not weaken the
+	// gate. Dial() consumes the connect-time document without forwarding
+	// it to the event sink, so skipping this shortcut would otherwise
+	// stall readiness checks until the daemon's next PKI broadcast at the
+	// next epoch boundary.
+	if doc, err := fetchSignedDocument(client, 0); err == nil && hasEnoughReplicas(doc, cfg.MinReplicas) {
+		if err := waitForReady(cfg, doc); err != nil {
+			return err
 		}
+		printDocument(doc, signerNames)
+		return nil
 	}
 
-	// Otherwise wait, via the event sink, for a consensus that satisfies the
-	// replica requirement, then fetch its signed form for that epoch.
 	eventSink := client.EventSink()
 	defer client.StopEventSink(eventSink)
 
+	// Under --require-ready, re-try the daemon's current document every few
+	// seconds in addition to reacting to broadcasts. Without the poll a
+	// connect that lands before the daemon caches a current document would
+	// idle in the event sink until the next epoch boundary. The event arm
+	// remains for the (unobserved) case where the daemon only delivers the
+	// document by broadcast.
 	for {
+		if cfg.RequireReady {
+			if doc, err := fetchSignedDocument(client, 0); err == nil && hasEnoughReplicas(doc, cfg.MinReplicas) {
+				if err := waitForReady(cfg, doc); err != nil {
+					return err
+				}
+				printDocument(doc, signerNames)
+				return nil
+			}
+		}
 		select {
 		case event := <-eventSink:
 			docEvent, ok := event.(*thin.NewDocumentEvent)
@@ -172,6 +191,7 @@ func runFetch(cfg Config) error {
 			return nil
 		case <-client.HaltCh():
 			return fmt.Errorf("connection closed before receiving PKI document")
+		case <-time.After(2 * time.Second):
 		}
 	}
 }

--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -154,25 +154,67 @@ func runFetch(cfg Config) error {
 		return nil
 	}
 
+	if cfg.RequireReady {
+		return waitRequireReady(client, logger, cfg, signerNames)
+	}
+	return waitForDocument(client, logger, cfg, signerNames)
+}
+
+// waitRequireReady polls the daemon's current signed document until one is
+// available, then waits for the whole network to report ready and prints it.
+//
+// It deliberately registers NO broadcast event sink. The thin client's fan-out
+// worker delivers every event to every registered sink in turn, blocking on a
+// full one; while this goroutine is blocked inside GetPKIDocumentRaw waiting
+// for its reply, its own persistent sink would accumulate events and, once
+// full, stall that very reply (deadlock). Polling the current document every
+// couple of seconds is strictly more reliable than the broadcast arm: the
+// daemon always answers GetPKIDocument, whether from its cache or with an
+// error reply, so there is no "broadcast only" case to wait for.
+//
+// Progress is reported on stdout from the very first poll, including the
+// reason the wait cannot yet finish. A cold-start wait (which can run for
+// minutes before the first consensus exists or it carries enough storage
+// replicas) would otherwise be silent.
+func waitRequireReady(client *thin.ThinClient, logger *logging.Logger, cfg Config, signerNames map[[32]byte]string) error {
+	start := time.Now()
+	fmt.Printf("waiting for the network to report ready (up to %v)...\n", cfg.ReadyTimeout)
+	lastProgressLog := time.Now()
+	for {
+		doc, err := fetchSignedDocument(client, 0)
+		if err == nil && hasEnoughReplicas(doc, cfg.MinReplicas) {
+			if err := waitForReady(cfg, logger, doc); err != nil {
+				return err
+			}
+			printDocument(doc, signerNames)
+			return nil
+		}
+		if time.Since(lastProgressLog) >= 4*time.Second {
+			reason := err
+			if reason == nil {
+				reason = fmt.Errorf("consensus has %d storage replica(s); need %d",
+					len(doc.StorageReplicas), cfg.MinReplicas)
+			}
+			fmt.Printf("  still waiting for the network to report ready: %v (elapsed %v)\n",
+				reason, time.Since(start).Round(time.Second))
+			lastProgressLog = time.Now()
+		}
+		select {
+		case <-client.HaltCh():
+			return fmt.Errorf("connection closed before receiving PKI document")
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+// waitForDocument waits, via the event sink, for a consensus that satisfies
+// the replica requirement, then fetches and prints its signed form for that
+// epoch. Used when --require-ready is off.
+func waitForDocument(client *thin.ThinClient, logger *logging.Logger, cfg Config, signerNames map[[32]byte]string) error {
 	eventSink := client.EventSink()
 	defer client.StopEventSink(eventSink)
 
-	// Under --require-ready, re-try the daemon's current document every few
-	// seconds in addition to reacting to broadcasts. Without the poll a
-	// connect that lands before the daemon caches a current document would
-	// idle in the event sink until the next epoch boundary. The event arm
-	// remains for the (unobserved) case where the daemon only delivers the
-	// document by broadcast.
 	for {
-		if cfg.RequireReady {
-			if doc, err := fetchSignedDocument(client, 0); err == nil && hasEnoughReplicas(doc, cfg.MinReplicas) {
-				if err := waitForReady(cfg, logger, doc); err != nil {
-					return err
-				}
-				printDocument(doc, signerNames)
-				return nil
-			}
-		}
 		select {
 		case event := <-eventSink:
 			docEvent, ok := event.(*thin.NewDocumentEvent)
@@ -193,7 +235,6 @@ func runFetch(cfg Config) error {
 			return nil
 		case <-client.HaltCh():
 			return fmt.Errorf("connection closed before receiving PKI document")
-		case <-time.After(2 * time.Second):
 		}
 	}
 }
@@ -230,6 +271,16 @@ func loadAuthorityNames(client *thin.ThinClient) map[[32]byte]string {
 func fetchSignedDocument(client *thin.ThinClient, epoch uint64) (*cpki.Document, error) {
 	raw, gotEpoch, err := client.GetPKIDocumentRaw(epoch)
 	if err != nil {
+		if epoch == 0 && gotEpoch != 0 {
+			// A reply carrying an epoch means the daemon answered the
+			// "current document" request at all, and its only error reply
+			// for one is "no document cached". That is the normal
+			// cold-start case, so say so plainly instead of echoing a
+			// cryptic protocol error.
+			now, _, till := epochtime.Now()
+			return nil, fmt.Errorf("no consensus document for current epoch %d; next epoch %d starts in ~%v",
+				now, now+1, till.Round(time.Second))
+		}
 		return nil, fmt.Errorf("failed to fetch raw PKI document for epoch %d: %v", epoch, err)
 	}
 

--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
+	"gopkg.in/op/go-logging.v1"
 
 	"github.com/katzenpost/katzenpost/client/config"
 	"github.com/katzenpost/katzenpost/client/thin"
@@ -114,6 +115,7 @@ func runFetch(cfg Config) error {
 		Level: cfg.LogLevel,
 	}
 	client := thin.NewThinClient(thinCfg, logging)
+	logger := client.GetLogger("fetch")
 
 	// Ensure thin_close is sent even on Ctrl-C
 	sigCh := make(chan os.Signal, 1)
@@ -145,7 +147,7 @@ func runFetch(cfg Config) error {
 	// stall readiness checks until the daemon's next PKI broadcast at the
 	// next epoch boundary.
 	if doc, err := fetchSignedDocument(client, 0); err == nil && hasEnoughReplicas(doc, cfg.MinReplicas) {
-		if err := waitForReady(cfg, doc); err != nil {
+		if err := waitForReady(cfg, logger, doc); err != nil {
 			return err
 		}
 		printDocument(doc, signerNames)
@@ -164,7 +166,7 @@ func runFetch(cfg Config) error {
 	for {
 		if cfg.RequireReady {
 			if doc, err := fetchSignedDocument(client, 0); err == nil && hasEnoughReplicas(doc, cfg.MinReplicas) {
-				if err := waitForReady(cfg, doc); err != nil {
+				if err := waitForReady(cfg, logger, doc); err != nil {
 					return err
 				}
 				printDocument(doc, signerNames)
@@ -184,7 +186,7 @@ func runFetch(cfg Config) error {
 			if err != nil {
 				return err
 			}
-			if err := waitForReady(cfg, doc); err != nil {
+			if err := waitForReady(cfg, logger, doc); err != nil {
 				return err
 			}
 			printDocument(doc, signerNames)
@@ -298,8 +300,9 @@ type probe struct {
 // waitForReady blocks until every node in the document reports ready on its
 // metrics endpoint (--require-ready only). The fetched document supplies the
 // node inventory; the expected epochs are recomputed each poll so a mid-wait
-// epoch rotation does not wedge the loop.
-func waitForReady(cfg Config, doc *cpki.Document) error {
+// epoch rotation does not wedge the loop. While waiting, every 4 seconds (two
+// polls) the current ready/waiting split is logged at DEBUG.
+func waitForReady(cfg Config, logger *logging.Logger, doc *cpki.Document) error {
 	if !cfg.RequireReady {
 		return nil
 	}
@@ -309,6 +312,7 @@ func waitForReady(cfg Config, doc *cpki.Document) error {
 	}
 	fmt.Printf("waiting for the network to report ready (%d node(s), up to %v)...\n", len(probes), cfg.ReadyTimeout)
 	deadline := time.Now().Add(cfg.ReadyTimeout)
+	lastProgressLog := time.Now()
 	for {
 		notReady := checkProbes(probes)
 		if len(notReady) == 0 {
@@ -316,8 +320,14 @@ func waitForReady(cfg Config, doc *cpki.Document) error {
 			return nil
 		}
 		if time.Now().After(deadline) {
-			printNotReady(notReady)
+			printNotReady(probes, notReady)
 			return fmt.Errorf("timed out after %v waiting for the network to report ready (%d node(s) not ready)", cfg.ReadyTimeout, len(notReady))
+		}
+		if time.Since(lastProgressLog) >= 4*time.Second {
+			ready, waiting := readyWaitingNames(probes, notReady)
+			logger.Debugf("ready %d/%d node(s): ready=[%s] waiting=[%s]",
+				len(ready), len(probes), strings.Join(ready, ","), strings.Join(waiting, ","))
+			lastProgressLog = time.Now()
 		}
 		time.Sleep(2 * time.Second)
 	}
@@ -360,9 +370,28 @@ func checkProbes(probes []*probe) []probeReport {
 	return notReady
 }
 
+// readyWaitingNames splits the probe inventory into the names currently
+// reporting ready and those still waiting, preserving probe order.
+func readyWaitingNames(probes []*probe, notReady []probeReport) (ready, waiting []string) {
+	waitingSet := make(map[string]bool, len(notReady))
+	for _, r := range notReady {
+		waitingSet[r.probe.name] = true
+	}
+	for _, p := range probes {
+		if waitingSet[p.name] {
+			waiting = append(waiting, p.name)
+		} else {
+			ready = append(ready, p.name)
+		}
+	}
+	return ready, waiting
+}
+
 // printNotReady emits per-node diagnostics for every unready node.
-func printNotReady(reports []probeReport) {
-	fmt.Fprintf(os.Stderr, "network NOT ready: %d node(s) not reporting ready:\n", len(reports))
+func printNotReady(probes []*probe, reports []probeReport) {
+	ready, waiting := readyWaitingNames(probes, reports)
+	fmt.Fprintf(os.Stderr, "network NOT ready: %d of %d node(s) ready: [%s]; still waiting on %d node(s): [%s]\n",
+		len(ready), len(probes), strings.Join(ready, ","), len(waiting), strings.Join(waiting, ","))
 	for _, r := range reports {
 		if r.err != nil {
 			fmt.Fprintf(os.Stderr, "  %-24s %-9s %-20s error: %v\n", r.probe.name, r.probe.kind, r.probe.addr, r.err)

--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -17,25 +17,36 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sort"
+	"strconv"
+	"strings"
 	"syscall"
+	"time"
 
+	"github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
 
 	"github.com/katzenpost/katzenpost/client/config"
 	"github.com/katzenpost/katzenpost/client/thin"
 	"github.com/katzenpost/katzenpost/common"
+	"github.com/katzenpost/katzenpost/core/epochtime"
 	cpki "github.com/katzenpost/katzenpost/core/pki"
+	replicaCommon "github.com/katzenpost/katzenpost/replica/common"
 )
 
 // Config holds the command line configuration
 type Config struct {
-	ConfigFile  string
-	LogLevel    string
-	MinReplicas int
+	ConfigFile   string
+	LogLevel     string
+	MinReplicas  int
+	RequireReady bool
+	ReadyTimeout time.Duration
 }
 
 // newRootCommand creates the root cobra command
@@ -54,6 +65,8 @@ Core functionality:
 • Retrieves current network consensus documents
 • Displays network topology and mix node information
 • Retries until PKI document becomes available
+• Optionally waits for the whole testnet (mixes, replicas, couriers)
+  to report ready on their metrics endpoints (--require-ready)
 
 The tool is useful for network monitoring, debugging connectivity issues,
 and inspecting the current state of the mixnet topology.`,
@@ -61,7 +74,10 @@ and inspecting the current state of the mixnet topology.`,
   fetch --config thinclient.toml
 
   # Fetch with short flags
-  fetch -f thinclient.toml`,
+  fetch -f thinclient.toml
+
+  # Wait until the entire testnet reports ready before printing
+  fetch -f /mixnet-alpine/client/thinclient-bridge.toml -r 2 --require-ready`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runFetch(cfg)
 		},
@@ -74,6 +90,10 @@ and inspecting the current state of the mixnet topology.`,
 		"logging level (DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL)")
 	cmd.Flags().IntVarP(&cfg.MinReplicas, "min-replicas", "r", 0,
 		"keep waiting for further consensus documents until at least N storage replicas are present (0 = no requirement)")
+	cmd.Flags().BoolVar(&cfg.RequireReady, "require-ready", false,
+		"wait until every mix, storage replica, and courier reports ready on its metrics endpoint before printing the document")
+	cmd.Flags().DurationVar(&cfg.ReadyTimeout, "ready-timeout", 8*time.Minute,
+		"maximum time to wait for the whole network to report ready before failing with per-node diagnostics")
 
 	return cmd
 }
@@ -115,10 +135,15 @@ func runFetch(cfg Config) error {
 	// reported by identifier rather than by opaque fingerprint.
 	signerNames := loadAuthorityNames(client)
 
-	// Try the daemon's current signed document straight away.
-	if doc, err := fetchSignedDocument(client, 0); err == nil && hasEnoughReplicas(doc, cfg.MinReplicas) {
-		printDocument(doc, signerNames)
-		return nil
+	// Try the daemon's current signed document straight away. Under
+	// --require-ready, skip this shortcut: readiness must be gated on the
+	// current epoch's consensus, which we only reliably get via the event
+	// sink.
+	if !cfg.RequireReady {
+		if doc, err := fetchSignedDocument(client, 0); err == nil && hasEnoughReplicas(doc, cfg.MinReplicas) {
+			printDocument(doc, signerNames)
+			return nil
+		}
 	}
 
 	// Otherwise wait, via the event sink, for a consensus that satisfies the
@@ -138,6 +163,9 @@ func runFetch(cfg Config) error {
 			}
 			doc, err := fetchSignedDocument(client, docEvent.Document.Epoch)
 			if err != nil {
+				return err
+			}
+			if err := waitForReady(cfg, doc); err != nil {
 				return err
 			}
 			printDocument(doc, signerNames)
@@ -236,4 +264,266 @@ func hasEnoughReplicas(doc *cpki.Document, min int) bool {
 		return true
 	}
 	return doc != nil && len(doc.StorageReplicas) >= min
+}
+
+// probe describes one node whose metrics endpoint we poll for readiness.
+type probe struct {
+	name  string
+	kind  string // "mix", "replica", "courier"
+	addr  string
+	ready string
+	epoch string
+}
+
+// waitForReady blocks until every node in the document reports ready on its
+// metrics endpoint (--require-ready only). The fetched document supplies the
+// node inventory; the expected epochs are recomputed each poll so a mid-wait
+// epoch rotation does not wedge the loop.
+func waitForReady(cfg Config, doc *cpki.Document) error {
+	if !cfg.RequireReady {
+		return nil
+	}
+	probes, err := discoverProbes(cfg.ConfigFile, doc)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("waiting for the network to report ready (%d node(s), up to %v)...\n", len(probes), cfg.ReadyTimeout)
+	deadline := time.Now().Add(cfg.ReadyTimeout)
+	for {
+		notReady := checkProbes(probes)
+		if len(notReady) == 0 {
+			fmt.Printf("network ready: all %d node(s) report ready\n", len(probes))
+			return nil
+		}
+		if time.Now().After(deadline) {
+			printNotReady(notReady)
+			return fmt.Errorf("timed out after %v waiting for the network to report ready (%d node(s) not ready)", cfg.ReadyTimeout, len(notReady))
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// probeReport records why a single probe is not ready.
+type probeReport struct {
+	probe    *probe
+	err      error
+	ready    bool
+	epoch    float64
+	expected uint64
+}
+
+// checkProbes returns a report for every node that is not currently ready.
+func checkProbes(probes []*probe) []probeReport {
+	var notReady []probeReport
+	for _, p := range probes {
+		var expected uint64
+		switch p.kind {
+		case "replica":
+			expected, _, _ = replicaCommon.ReplicaNow()
+		default:
+			expected, _, _ = epochtime.Now()
+		}
+		r, err := scrapeGauge(p.addr, p.ready)
+		if err != nil {
+			notReady = append(notReady, probeReport{probe: p, err: err})
+			continue
+		}
+		e, err := scrapeGauge(p.addr, p.epoch)
+		if err != nil {
+			notReady = append(notReady, probeReport{probe: p, err: err})
+			continue
+		}
+		if r != 1 || uint64(e) != expected {
+			notReady = append(notReady, probeReport{probe: p, ready: r == 1, epoch: e, expected: expected})
+		}
+	}
+	return notReady
+}
+
+// printNotReady emits per-node diagnostics for every unready node.
+func printNotReady(reports []probeReport) {
+	fmt.Fprintf(os.Stderr, "network NOT ready: %d node(s) not reporting ready:\n", len(reports))
+	for _, r := range reports {
+		if r.err != nil {
+			fmt.Fprintf(os.Stderr, "  %-24s %-9s %-20s error: %v\n", r.probe.name, r.probe.kind, r.probe.addr, r.err)
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "  %-24s %-9s %-20s ready=%v epoch=%d expected=%d\n",
+			r.probe.name, r.probe.kind, r.probe.addr, r.ready, uint64(r.epoch), r.expected)
+	}
+}
+
+// scrapeGauge fetches a single metric line from the node's /metrics endpoint.
+func scrapeGauge(addr, name string) (float64, error) {
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get("http://" + addr + "/metrics")
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 2 && fields[0] == name {
+			return strconv.ParseFloat(fields[1], 64)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	return 0, fmt.Errorf("metric %q not present on %s", name, addr)
+}
+
+// discoverProbes builds the readiness probe list from the consensus document
+// and the testnet config layout rooted next to the thin client config file.
+func discoverProbes(configFile string, doc *cpki.Document) ([]*probe, error) {
+	netRoot := filepath.Dir(filepath.Dir(configFile))
+	var probes []*probe
+	seen := make(map[string]bool)
+	add := func(p *probe) {
+		if p == nil || seen[p.addr] {
+			return
+		}
+		seen[p.addr] = true
+		probes = append(probes, p)
+	}
+
+	for _, desc := range doc.GatewayNodes {
+		p, err := serverProbe(netRoot, desc)
+		if err != nil {
+			return nil, err
+		}
+		add(p)
+		cs, err := courierProbes(netRoot, desc)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range cs {
+			add(c)
+		}
+	}
+	for _, desc := range doc.ServiceNodes {
+		p, err := serverProbe(netRoot, desc)
+		if err != nil {
+			return nil, err
+		}
+		add(p)
+		cs, err := courierProbes(netRoot, desc)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range cs {
+			add(c)
+		}
+	}
+	for _, layer := range doc.Topology {
+		for _, desc := range layer {
+			p, err := serverProbe(netRoot, desc)
+			if err != nil {
+				return nil, err
+			}
+			add(p)
+		}
+	}
+	for _, desc := range doc.StorageReplicas {
+		addr, err := metricsAddrFromFile(filepath.Join(netRoot, desc.Name, "replica.toml"), "MetricsAddress")
+		if err != nil {
+			return nil, fmt.Errorf("replica %q: %w", desc.Name, err)
+		}
+		add(&probe{name: desc.Name, kind: "replica", addr: addr,
+			ready: "katzenpost_replica_ready", epoch: "katzenpost_replica_current_epoch"})
+	}
+	return probes, nil
+}
+
+// serverProbe discovers the [Server] MetricsAddress for a mix node.
+func serverProbe(netRoot string, desc *cpki.MixDescriptor) (*probe, error) {
+	addr, err := metricsAddrFromFile(filepath.Join(netRoot, desc.Name, "katzenpost.toml"), "Server.MetricsAddress")
+	if err != nil {
+		return nil, fmt.Errorf("mix %q: %w", desc.Name, err)
+	}
+	return &probe{name: desc.Name, kind: "mix", addr: addr,
+		ready: "katzenpost_node_ready", epoch: "katzenpost_node_current_epoch"}, nil
+}
+
+// courierProbes discovers the metrics endpoint of every courier plugin
+// declared in a service node's katzenpost.toml. A service node with no
+// courier plugin yields no probes; a declared courier whose config cannot be
+// read is an error.
+func courierProbes(netRoot string, desc *cpki.MixDescriptor) ([]*probe, error) {
+	cfgPath := filepath.Join(netRoot, desc.Name, "katzenpost.toml")
+	var c struct {
+		ServiceNode struct {
+			CBORPluginKaetzchen []struct {
+				Capability string `toml:"Capability"`
+				Config     struct {
+					C string `toml:"c"`
+				} `toml:"Config"`
+			} `toml:"CBORPluginKaetzchen"`
+		} `toml:"ServiceNode"`
+	}
+	if _, err := toml.DecodeFile(cfgPath, &c); err != nil {
+		return nil, fmt.Errorf("service node %q: parse %q: %w", desc.Name, cfgPath, err)
+	}
+	var probes []*probe
+	for _, k := range c.ServiceNode.CBORPluginKaetzchen {
+		if !strings.Contains(strings.ToLower(k.Capability), "courier") {
+			continue
+		}
+		if k.Config.C == "" {
+			continue
+		}
+		courierCfg := resolveNetPath(netRoot, k.Config.C)
+		addr, err := metricsAddrFromFile(courierCfg, "MetricsAddress")
+		if err != nil {
+			return nil, fmt.Errorf("courier of %q: %w", desc.Name, err)
+		}
+		probes = append(probes, &probe{name: desc.Name, kind: "courier", addr: addr,
+			ready: "katzenpost_courier_ready", epoch: "katzenpost_courier_current_epoch"})
+	}
+	return probes, nil
+}
+
+// resolveNetPath maps a kaetzchen plugin config path to a readable location.
+// Generated testnet configs bake in the container-absolute mount path (e.g.
+// /mixnet-alpine/...); when that does not exist on the local filesystem,
+// rebase it onto the testnet root derived from the thin client config file.
+func resolveNetPath(netRoot, p string) string {
+	if !filepath.IsAbs(p) {
+		return filepath.Join(netRoot, p)
+	}
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
+	if base := filepath.Base(netRoot); strings.HasPrefix(p, "/"+base+"/") {
+		return filepath.Join(netRoot, strings.TrimPrefix(p, "/"+base))
+	}
+	return p
+}
+
+// metricsAddrFromFile extracts a metrics address from a TOML config. The key
+// is either "MetricsAddress" (top-level) or "Server.MetricsAddress".
+func metricsAddrFromFile(path, key string) (string, error) {
+	var c struct {
+		Server struct {
+			MetricsAddress string `toml:"MetricsAddress"`
+		} `toml:"Server"`
+		MetricsAddress string `toml:"MetricsAddress"`
+	}
+	if _, err := toml.DecodeFile(path, &c); err != nil {
+		return "", fmt.Errorf("parse %q: %w", path, err)
+	}
+	switch key {
+	case "Server.MetricsAddress":
+		if c.Server.MetricsAddress == "" {
+			return "", fmt.Errorf("%q: missing [Server] MetricsAddress", path)
+		}
+		return c.Server.MetricsAddress, nil
+	default:
+		if c.MetricsAddress == "" {
+			return "", fmt.Errorf("%q: missing MetricsAddress", path)
+		}
+		return c.MetricsAddress, nil
+	}
 }

--- a/courier/server/instrument/prometheus.go
+++ b/courier/server/instrument/prometheus.go
@@ -97,6 +97,18 @@ var (
 			Buckets: prometheus.DefBuckets,
 		},
 	)
+	courierReady = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "katzenpost_courier_ready",
+			Help: "1 when the courier holds a PKI document for the current mixnet epoch, 0 otherwise.",
+		},
+	)
+	courierCurrentEpoch = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "katzenpost_courier_current_epoch",
+			Help: "The mixnet epoch the readiness gauges refer to.",
+		},
+	)
 )
 
 // StartPrometheusListener registers metrics and starts the HTTP listener
@@ -116,6 +128,8 @@ func StartPrometheusListener(address string, log *logging.Logger) {
 		prometheus.MustRegister(dispatchSemWaiters)
 		prometheus.MustRegister(copyShardReadCompute)
 		prometheus.MustRegister(copyShardReadTotal)
+		prometheus.MustRegister(courierReady)
+		prometheus.MustRegister(courierCurrentEpoch)
 	})
 
 	if address == "" {
@@ -205,4 +219,16 @@ func CopyShardReadCompute(d time.Duration) {
 // component.
 func CopyShardReadTotal(d time.Duration) {
 	copyShardReadTotal.Observe(d.Seconds())
+}
+
+// SetCourierReady sets the courier_ready gauge based on whether the
+// courier holds a PKI document for the current mixnet epoch, along with
+// the epoch the value refers to.
+func SetCourierReady(ready bool, epoch uint64) {
+	if ready {
+		courierReady.Set(1)
+	} else {
+		courierReady.Set(0)
+	}
+	courierCurrentEpoch.Set(float64(epoch))
 }

--- a/courier/server/pki.go
+++ b/courier/server/pki.go
@@ -20,6 +20,7 @@ import (
 	sConstants "github.com/katzenpost/katzenpost/core/sphinx/constants"
 	"github.com/katzenpost/katzenpost/core/wire"
 	"github.com/katzenpost/katzenpost/core/worker"
+	"github.com/katzenpost/katzenpost/courier/server/instrument"
 	replicaCommon "github.com/katzenpost/katzenpost/replica/common"
 )
 
@@ -102,6 +103,15 @@ func (p *PKIWorker) HasCurrentPKIDocument() bool {
 	return p.EntryForEpoch(epoch) != nil
 }
 
+// updateReadiness refreshes the courier readiness gauges. A courier is
+// ready when it holds a PKI document for the current mixnet epoch; a
+// restarted courier starts at 0 and only reports ready once its worker
+// has fetched and cached the current consensus.
+func (p *PKIWorker) updateReadiness() {
+	epoch, _, _ := epochtime.Now()
+	instrument.SetCourierReady(p.HasCurrentPKIDocument(), epoch)
+}
+
 // ForceFetchPKI forces the PKI worker to fetch a new PKI document for the current epoch.
 // This is useful for integration tests where you want to ensure the courier has the latest
 // PKI document without waiting for the normal fetch cycle.
@@ -131,6 +141,7 @@ func (p *PKIWorker) ForceFetchPKI() error {
 	// Store the document and update replicas
 	p.StoreDocument(epoch, d, rawDoc)
 	p.replicas.UpdateFromPKIDoc(d)
+	p.updateReadiness()
 
 	p.GetLogger().Debugf("Successfully force fetched PKI document for epoch %v", epoch)
 	return nil
@@ -157,6 +168,7 @@ func (p *PKIWorker) worker() {
 		didUpdate := p.fetchDocuments(pkiCtx, isCanceled)
 		p.processDocuments(didUpdate)
 		p.updateCurrentEpoch(&lastUpdateEpoch)
+		p.updateReadiness()
 		p.UpdateTimer(timer)
 	}
 }

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -534,9 +534,9 @@ status:
 show-latest-vote:
 	@grep -A30 'Ready to send' voting_mixnet/auth1/katzenpost.log |tail -30|sed /Sending/q
 
-wait: $(net_name)/running.stamp | $(cache_dir)
-	$(docker) run --network=host ${docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_base \
-	/$(net_name)/fetch.$(distro) -f /$(net_name)/client/thinclient.toml -r 2
+wait: $(net_name)/running.stamp $(net_name)/client/thinclient-bridge.toml | $(cache_dir)
+	$(docker) run --network=$(net_name)_katzenpost-net ${docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_base \
+	/$(net_name)/fetch.$(distro) -f /$(net_name)/client/thinclient-bridge.toml -r 2 --require-ready
 
 debian_base.stamp:
 	$(docker) run $(replace_name) katzenpost_debian_base docker.io/golang:bullseye $(sh) -c "echo -e 'deb https://deb.debian.org/debian bullseye main\ndeb https://deb.debian.org/debian bullseye-updates main\ndeb https://deb.debian.org/debian-security bullseye-security main' > /etc/apt/sources.list && cat /etc/apt/sources.list && apt update && apt upgrade -y && apt install -y pv && adduser katzenpost --gecos '' --disabled-password && apt update && apt upgrade -y"

--- a/replica/instrument/prometheus.go
+++ b/replica/instrument/prometheus.go
@@ -131,6 +131,18 @@ var (
 			Help: "Number of DispatchReplication goroutines currently blocked acquiring a replicationSem slot. The cap is the package-level const maxConcurrentReplications (256) in replica/connector.go. Sustained values above zero would indicate the cap is acting as a constraint and a config field should be reconsidered; in practice the bounded work is sub-millisecond per goroutine so this gauge should stay at zero. Sibling of katzenpost_courier_dispatch_sem_waiters on the courier side.",
 		},
 	)
+	replicaReady = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "katzenpost_replica_ready",
+			Help: "1 iff this replica's descriptor in the current consensus document carries the same per-replica-epoch envelope key this instance holds. 0 otherwise (including while booting or waiting for a current-epoch document).",
+		},
+	)
+	replicaCurrentEpoch = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "katzenpost_replica_current_epoch",
+			Help: "The replica epoch whose consensus the replica_ready gauge was last computed against.",
+		},
+	)
 )
 
 // StartPrometheusListener registers metrics and starts the HTTP listener
@@ -156,6 +168,8 @@ func StartPrometheusListener(address string, log *logging.Logger) {
 		prometheus.MustRegister(selfCheckOpsPerSecSaturated)
 		prometheus.MustRegister(selfCheckCores)
 		prometheus.MustRegister(replicationSemWaiters)
+		prometheus.MustRegister(replicaReady)
+		prometheus.MustRegister(replicaCurrentEpoch)
 	})
 
 	if address == "" {
@@ -264,4 +278,18 @@ func ReplicationSemWaitStart() {
 // slot obtained or shutdown).
 func ReplicationSemWaitEnd() {
 	replicationSemWaiters.Dec()
+}
+
+// SetReplicaReady sets the replica_ready gauge based on whether the
+// descriptor this replica published in the current consensus carries the
+// same per-replica-epoch envelope key this instance holds. Anything else
+// (no current-epoch document cached, mismatched keys) is 0, so a restart
+// is never reported ready until the consensus actually matches.
+func SetReplicaReady(ready bool, epoch uint64) {
+	if ready {
+		replicaReady.Set(1)
+	} else {
+		replicaReady.Set(0)
+	}
+	replicaCurrentEpoch.Set(float64(epoch))
 }

--- a/replica/pki.go
+++ b/replica/pki.go
@@ -152,6 +152,11 @@ func (p *PKIWorker) worker() {
 		// Handle document updates and cleanup.
 		p.handleDocumentUpdates(didUpdate)
 
+		// Refresh the readiness gauges so a restarted replica reports
+		// ready as soon as its descriptor and persisted keys agree with
+		// the current consensus.
+		p.updateReadiness()
+
 		// Update epoch tracking.
 		lastUpdateEpoch = p.updateEpochTracking(lastUpdateEpoch)
 

--- a/replica/pkiworker.go
+++ b/replica/pkiworker.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/crypto/blake2b"
 	"gopkg.in/op/go-logging.v1"
 
+	"github.com/katzenpost/hpqc/hash"
 	"github.com/katzenpost/hpqc/kem/schemes"
 
 	vClient "github.com/katzenpost/katzenpost/authority/voting/client"
@@ -22,6 +23,7 @@ import (
 	"github.com/katzenpost/katzenpost/core/epochtime"
 	"github.com/katzenpost/katzenpost/core/pki"
 	"github.com/katzenpost/katzenpost/core/worker"
+	"github.com/katzenpost/katzenpost/replica/instrument"
 	replicaCommon "github.com/katzenpost/katzenpost/replica/common"
 )
 
@@ -232,6 +234,9 @@ func (p *PKIWorker) ForceFetchPKI() error {
 	p.updateReplicas(d)
 	p.StoreDocument(epoch, d, rawDoc)
 
+	// Refresh the readiness gauges.
+	p.updateReadiness()
+
 	p.GetLogger().Debugf("Successfully force fetched PKI document for epoch %v", epoch)
 
 	// Kick the connector to update connections
@@ -245,6 +250,28 @@ func (p *PKIWorker) ForceFetchPKI() error {
 func (p *PKIWorker) HasCurrentPKIDocument() bool {
 	epoch, _, _ := epochtime.Now()
 	return p.documentForEpoch(epoch) != nil
+}
+
+// updateReadiness recomputes the replica readiness gauges. A replica is
+// ready only when it holds a PKI document for the current mixnet epoch
+// whose ReplicaDescriptor for this instance carries the same per-replica
+// envelope public key for the current replica epoch as the local keypair.
+// Anything else (no current document, descriptor missing, key mismatch)
+// reports not ready, so a restarted replica is never reported ready until
+// the consensus actually agrees with its persisted envelope keys.
+func (p *PKIWorker) updateReadiness() {
+	epoch, _, _ := epochtime.Now()
+	replicaEpoch, _, _ := replicaCommon.ReplicaNow()
+	ready := false
+	if doc := p.documentForEpoch(epoch); doc != nil {
+		idKeyHash := hash.Sum256From(p.server.identityPublicKey)
+		if desc, err := doc.GetReplicaNodeByKeyHash(&idKeyHash); err == nil {
+			if key, err := p.server.envelopeKeys.GetKeypair(replicaEpoch); err == nil {
+				ready = hmac.Equal(desc.EnvelopeKeys[replicaEpoch], key.PublicKey.Bytes())
+			}
+		}
+	}
+	instrument.SetReplicaReady(ready, replicaEpoch)
 }
 
 // ReplyJitterBound returns the uniform per-reply delay upper bound

--- a/server/internal/instrument/prometheus.go
+++ b/server/internal/instrument/prometheus.go
@@ -202,6 +202,18 @@ var (
 			Help: "Cores reported by runtime.NumCPU at startup. Pair with the solo and saturated ops/sec gauges to reason about queue size and worker counts.",
 		},
 	)
+	nodeReady = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "katzenpost_node_ready",
+			Help: "1 iff this node's descriptor in the current consensus document carries the same per-epoch mix key this instance holds, i.e. the testnet would not drop the first-hop MAC check against this node. 0 otherwise (including while booting or waiting for a current-epoch document).",
+		},
+	)
+	nodeCurrentEpoch = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "katzenpost_node_current_epoch",
+			Help: "The epoch whose consensus the node_ready gauge was last computed against.",
+		},
+	)
 )
 
 // StartPrometheusListener starts the Prometheus metrics TCP/HTTP
@@ -237,6 +249,8 @@ func StartPrometheusListener(glue glue.Glue) {
 	prometheus.MustRegister(selfCheckSphinxOpsPerSecSolo)
 	prometheus.MustRegister(selfCheckSphinxOpsPerSecSaturated)
 	prometheus.MustRegister(selfCheckSphinxCores)
+	prometheus.MustRegister(nodeReady)
+	prometheus.MustRegister(nodeCurrentEpoch)
 
 	metricsAddress := glue.Config().Server.MetricsAddress
 	if metricsAddress == "" {
@@ -397,4 +411,18 @@ func SelfCheckResults(opsPerSecSolo, opsPerSecSaturated float64, numCPU int) {
 	selfCheckSphinxOpsPerSecSolo.Set(opsPerSecSolo)
 	selfCheckSphinxOpsPerSecSaturated.Set(opsPerSecSaturated)
 	selfCheckSphinxCores.Set(float64(numCPU))
+}
+
+// SetNodeReady sets the node_ready gauge to 1 iff the descriptor the node
+// published matches the live per-epoch keys it currently holds for the given
+// epoch. Anything else (no current-epoch document cached, mismatched keys) is
+// 0, so a restart is never reported ready until the consensus actually
+// matches the running instance.
+func SetNodeReady(ready bool, epoch uint64) {
+	if ready {
+		nodeReady.Set(1)
+	} else {
+		nodeReady.Set(0)
+	}
+	nodeCurrentEpoch.Set(float64(epoch))
 }

--- a/server/internal/instrument/prometheus_dummy.go
+++ b/server/internal/instrument/prometheus_dummy.go
@@ -99,3 +99,6 @@ func PacketsDroppedByReason(reason string) {}
 
 // SelfCheckResults is a no-op when the noprometheus build tag is set.
 func SelfCheckResults(opsPerSecSolo, opsPerSecSaturated float64, numCPU int) {}
+
+// SetNodeReady is a no-op when the noprometheus build tag is set.
+func SetNodeReady(ready bool, epoch uint64) {}

--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -421,6 +421,16 @@ func (p *pki) updateTimer(timer *time.Timer) {
 
 	p.log.Debugf("serverpki woke %v into epoch %v with %v remaining", elapsed, now, till)
 
+	// Reflect the current epoch's document in the readiness gauges on every
+	// wake, not just inside the descriptor-upload window. Without this a
+	// node that restarts mid-epoch with persisted mix keys leaves the gauge
+	// at its boot value of 0 until the next epoch boundary, even though the
+	// current consensus is served and its keys match; updateReadiness also
+	// records ready=false when no current-epoch document is cached yet, so
+	// the loop re-polls at recheckInterval and flips ready as soon as one
+	// arrives.
+	p.updateReadiness(now)
+
 	// Wake at the next epoch boundary when the descriptor upload window has
 	// already closed. This avoids repeatedly posting a descriptor that every
 	// authority will reject as Conflict/Late for the next epoch.
@@ -451,12 +461,10 @@ func (p *pki) updateTimer(timer *time.Timer) {
 		// No document for current epoch.
 		if p.entryForEpoch(now) == nil {
 			p.log.Debugf("no document cached for current epoch %v, reset to %v", now, recheckInterval)
-			instrument.SetNodeReady(false, now)
 			timer.Reset(recheckInterval)
 		} else {
 			interval := vServer.PublishConsensusDeadline - elapsed
 			p.log.Debugf("Document cached for current epoch %v, reset to %v", now, interval)
-			p.updateReadiness(now)
 			timer.Reset(interval)
 		}
 	}

--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -18,6 +18,7 @@
 package pki
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"errors"
@@ -450,13 +451,33 @@ func (p *pki) updateTimer(timer *time.Timer) {
 		// No document for current epoch.
 		if p.entryForEpoch(now) == nil {
 			p.log.Debugf("no document cached for current epoch %v, reset to %v", now, recheckInterval)
+			instrument.SetNodeReady(false, now)
 			timer.Reset(recheckInterval)
 		} else {
 			interval := vServer.PublishConsensusDeadline - elapsed
 			p.log.Debugf("Document cached for current epoch %v, reset to %v", now, interval)
+			p.updateReadiness(now)
 			timer.Reset(interval)
 		}
 	}
+}
+
+// updateReadiness sets the node_ready gauge based on whether the descriptor
+// published in the current-epoch consensus carries the same per-epoch mix key
+// this instance currently holds. When they diverge — a restart that
+// regenerated the mix keys while the dirauths retained the old consensus, or
+// simply no current-epoch document yet — the gauge reads 0 and wait tooling
+// keeps polling instead of sending traffic into a first-hop MAC mismatch.
+func (p *pki) updateReadiness(epoch uint64) {
+	ready := false
+	if ent := p.entryForEpoch(epoch); ent != nil {
+		if self := ent.Self(); self != nil {
+			if local, ok := p.glue.MixKeys().Get(epoch); ok {
+				ready = bytes.Equal(self.MixKeys[epoch], local)
+			}
+		}
+	}
+	instrument.SetNodeReady(ready, epoch)
 }
 
 func (p *pki) validateCacheEntry(ent *pkicache.Entry) error {

--- a/server/internal/pki/pki.go
+++ b/server/internal/pki/pki.go
@@ -431,16 +431,23 @@ func (p *pki) updateTimer(timer *time.Timer) {
 	// arrives.
 	p.updateReadiness(now)
 
-	// Wake at the next epoch boundary when the descriptor upload window has
-	// already closed. This avoids repeatedly posting a descriptor that every
-	// authority will reject as Conflict/Late for the next epoch.
+	// After the descriptor upload window closes we no longer need to
+	// re-post, but we must keep fetching until the current epoch's
+	// consensus document is cached; otherwise the node (and any clients
+	// that depend on it, like kpclientd) won't see the document until
+	// the next epoch boundary.
 	if elapsed >= PublishDeadline-descriptorUploadSafety {
-		interval := till
-		if interval < time.Second {
-			interval = time.Second
+		if p.entryForEpoch(now) != nil {
+			interval := till
+			if interval < time.Second {
+				interval = time.Second
+			}
+			p.log.Debugf("descriptor upload window closed and document cached, reset to next epoch in %v", interval)
+			timer.Reset(interval)
+		} else {
+			p.log.Debugf("descriptor upload window closed but no document for %v yet, reset to %v", now, recheckInterval)
+			timer.Reset(recheckInterval)
 		}
-		p.log.Debugf("descriptor upload window closed, reset to next epoch in %v", interval)
-		timer.Reset(interval)
 		return
 	}
 
@@ -1005,7 +1012,20 @@ func (p *pki) CurrentDocument() (*cpki.Document, error) {
 // specifically.
 func (p *pki) HasUsableDocument() bool {
 	docs, _, _, _ := p.documentsForAuthentication()
-	return len(docs) > 0
+	if len(docs) > 0 {
+		return true
+	}
+	// documentsForAuthentication() only includes now+1 inside the
+	// pkiEarlyConnectSlack window, but a document for the next epoch
+	// is sufficient to authenticate incoming connections (clients and
+	// peers) and serve consensus.  Check for it directly so that the
+	// gateway can accept connections as soon as the authority publishes
+	// the consensus, not only within 15 s of the epoch boundary.
+	now, _, _ := epochtime.Now()
+	p.RLock()
+	_, ok := p.docs[now+1]
+	p.RUnlock()
+	return ok
 }
 
 func (p *pki) GetRawConsensus(epoch uint64) ([]byte, error) {


### PR DESCRIPTION
This adds readiness gauges so the fetch command can block until each component is actually ready, hopefully eliminating some CI flakiness. It also removes some unnecessary delays which were making it take longer than necessary for the first consensus to reach the fetch command.