### PR TITLE
docker/Makefile: restore bridge networking for fetch --require-ready

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -125,6 +125,11 @@ wirekem=xwing
 # (e.g. mixnet-alpine), so `make distro=foo start` targets mixnet-foo just
 # like the test-distros legs. A custom net_name= still overrides it.
 net_name=mixnet-$(distro)
+# docker-compose normalizes the project name (directory name) by stripping
+# dots; compute the actual network name the same way so --network= matches
+# the bridge compose creates.  Only the wait target uses this (fetch
+# --require-ready probes per-node metrics endpoints via container DNS).
+compose_network_name = $(subst .,,$(net_name))_katzenpost-net
 base_port=30000
 bind_addr=127.0.0.1
 docker_compose_yml=$(net_name)/docker-compose.yml
@@ -345,7 +350,7 @@ endif
 
 # Recursive `$(MAKE)` invocations inherit these instead of re-deriving
 # them from a hardcoded argument list.
-export docker docker_user docker_args distro sh warped net_name cache_dir mount_net_name
+export docker docker_user docker_args distro sh warped net_name compose_network_name cache_dir mount_net_name
 export no_decoy no_client_decoy no_courier_replica_decoy no_mixdecoy no_gatewaydecoy
 export no_metrics pyroscope_dirauth pyroscope_kpclientd kpclientd_metrics
 export wirekem nike kem mixes auths gateways serviceNodes storageNodes
@@ -608,9 +613,21 @@ status:
 show-latest-vote:
 	@grep -A30 'Ready to send' $(net_name)/auth1/katzenpost.log |tail -30|sed /Sending/q
 
-wait: $(net_name)/running.stamp | $(cache_dir)
-	$(docker) run --network=host ${docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_base \
-	/$(net_name)/fetch.$(distro) -f /$(net_name)/client/thinclient.toml -r 2 --require-ready
+# Generate the bridge-network thinclient config.  The host-network
+# thinclient.toml (used by run-ping, run-parallel-load, run-cp-bench)
+# dials localhost:base_port+2000 via the compose port forward; this
+# variant uses the compose service name kpclientd:64331 directly.
+# wait needs it because fetch --require-ready probes per-node metrics
+# endpoints via container DNS, which is only available on the bridge.
+$(net_name)/client/thinclient-bridge.toml: | $(net_name)/client
+	@echo '[Dial]'                                       >  $@
+	@echo '  [Dial.Tcp]'                                 >> $@
+	@echo '    Address = "kpclientd:64331"'              >> $@
+	@echo '    Network = "tcp"'                          >> $@
+
+wait: $(net_name)/running.stamp $(net_name)/client/thinclient-bridge.toml | $(cache_dir)
+	$(docker) run --network=$(compose_network_name) ${docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_base \
+	/$(net_name)/fetch.$(distro) -f /$(net_name)/client/thinclient-bridge.toml -r 2 --require-ready
 
 $(distro)_base.stamp: $(base_dockerfile)
 	$(docker) build -t katzenpost-$(distro)_base \


### PR DESCRIPTION
The #1095 switched the wait target to --network=host + thinclient.toml, but fetch --require-ready probes per-node Prometheus /metrics endpoints via container DNS (gateway1:40000, auth1:40001, etc.), which is only resolvable on the compose bridge network.

Restore thinclient-bridge.toml (dials kpclientd:64331 on the bridge) and --network=$(compose_network_name) for the wait target.

run-parallel-load and run-cp-bench stay on --network=host with thinclient.toml — they only talk to kpclientd, which is reachable via the host port forward.