### PR TITLE
replica, server, dirauth: never close fatalErrCh

### DIFF
--- a/authority/voting/server/fatal_err_test.go
+++ b/authority/voting/server/fatal_err_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package server
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/katzenpost/core/log"
+)
+
+// Shutdown used to close fatalErrCh, so a reporter that lost the race
+// panicked on a send to a closed channel. Leaving it open is only safe
+// because the send is non-blocking: after Shutdown the watcher is gone
+// and nothing will ever drain it again.
+func TestReportFatalAfterShutdown(t *testing.T) {
+	logBackend, err := log.New("", "ERROR", false)
+	require.NoError(t, err)
+
+	s := &Server{
+		logBackend: logBackend,
+		log:        logBackend.GetLogger("fatal_err_test"),
+		fatalErrCh: make(chan error, 1),
+		haltedCh:   make(chan interface{}),
+	}
+	s.Shutdown()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.reportFatal(errors.New("first"))
+		s.reportFatal(errors.New("second"))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("reportFatal blocked after shutdown")
+	}
+}

--- a/authority/voting/server/server.go
+++ b/authority/voting/server/server.go
@@ -165,12 +165,29 @@ func (s *Server) IdentityKey() sign.PublicKey {
 	return s.identityPublicKey
 }
 
+// reportFatal hands err to the fatal error watcher, which shuts the
+// server down. The send is non-blocking and fatalErrCh is buffered,
+// so a caller never blocks: one queued error is enough to bring the
+// server down, and the watcher is gone once shutdown has begun. A
+// blocking send would deadlock the callers that halt() waits for, and
+// closing the channel to release them would panic any send that lost
+// the race.
+func (s *Server) reportFatal(err error) {
+	select {
+	case s.fatalErrCh <- err:
+	default:
+		if s.log != nil {
+			s.log.Warningf("Fatal error while already shutting down: %v", err)
+		}
+	}
+}
+
 // RotateLog rotates the log file
 // if logging to a file is enabled.
 func (s *Server) RotateLog() {
 	err := s.logBackend.Rotate()
 	if err != nil {
-		s.fatalErrCh <- fmt.Errorf("failed to rotate log file, shutting down server")
+		s.reportFatal(fmt.Errorf("failed to rotate log file, shutting down server"))
 	}
 	s.log.Notice("Log rotated.")
 }
@@ -238,8 +255,6 @@ func (s *Server) halt() {
 		s.state = nil
 	}
 
-	close(s.fatalErrCh)
-
 	s.log.Notice("Shutdown complete.")
 	close(s.haltedCh)
 }
@@ -251,7 +266,7 @@ func New(cfg *config.Config) (*Server, error) {
 	s.cfg = cfg
 	s.geo = cfg.SphinxGeometry
 
-	s.fatalErrCh = make(chan error)
+	s.fatalErrCh = make(chan error, 1)
 	s.haltedCh = make(chan interface{})
 
 	// Do the early initialization and bring up logging.
@@ -392,9 +407,11 @@ func New(cfg *config.Config) (*Server, error) {
 
 	// Start the fatal error watcher.
 	go func() {
-		err, ok := <-s.fatalErrCh
-		if !ok {
-			s.log.Debugf("Fatal error channel closed gracefully")
+		var err error
+		select {
+		case err = <-s.fatalErrCh:
+		case <-s.haltedCh:
+			s.log.Debugf("Fatal error watcher stopping, server halted")
 			return
 		}
 		s.log.Errorf("FATAL ERROR DETECTED - Authority shutting down immediately!")

--- a/authority/voting/server/state.go
+++ b/authority/voting/server/state.go
@@ -302,7 +302,7 @@ func (s *state) fsm() <-chan time.Time {
 			if !ok {
 				fatalErr := fmt.Errorf("FSM FATAL: Failed to find our signature for epoch %v in consensus document - this indicates a critical consensus building failure", s.votingEpoch)
 				s.log.Errorf("FSM: %v", fatalErr)
-				s.s.fatalErrCh <- fatalErr
+				s.s.reportFatal(fatalErr)
 				break
 			}
 			s.log.Debugf("FSM: Found our signature in consensus document for epoch %d", s.votingEpoch)
@@ -310,14 +310,14 @@ func (s *state) fsm() <-chan time.Time {
 			if err != nil {
 				fatalErr := fmt.Errorf("FSM FATAL: Failed to serialize our signature for epoch %v: %s - this indicates a critical cryptographic failure", s.votingEpoch, err)
 				s.log.Errorf("FSM: %v", fatalErr)
-				s.s.fatalErrCh <- fatalErr
+				s.s.reportFatal(fatalErr)
 				break
 			}
 			s.log.Debugf("FSM: Successfully serialized our signature for epoch %d", s.votingEpoch)
 			signed, err := cert.Sign(s.s.identityPrivateKey, s.s.identityPublicKey, serialized, s.votingEpoch)
 			if err != nil {
 				s.log.Errorf("FSM: Failed to sign our signature for epoch %v: %s", s.votingEpoch, err)
-				s.s.fatalErrCh <- err
+				s.s.reportFatal(err)
 				break
 			}
 			s.log.Debugf("FSM: Successfully signed our signature for epoch %d", s.votingEpoch)
@@ -389,7 +389,7 @@ func (s *state) persistDocument(epoch uint64, doc []byte) {
 		// Persistence failures are FATAL.
 		fatalErr := fmt.Errorf("PERSISTENCE FATAL: Failed to persist consensus document for epoch %d to database: %v - this indicates critical storage failure", epoch, err)
 		s.log.Errorf("persistDocument: %v", fatalErr)
-		s.s.fatalErrCh <- fatalErr
+		s.s.reportFatal(fatalErr)
 	}
 }
 
@@ -1567,7 +1567,7 @@ func (s *state) generateTopology(nodeList []*pki.MixDescriptor, doc *pki.Documen
 	rng, err := rand.NewDeterministicRandReader(srv[:])
 	if err != nil {
 		s.log.Errorf("DeterministicRandReader() failed to initialize: %v", err)
-		s.s.fatalErrCh <- err
+		s.s.reportFatal(err)
 	}
 	targetNodesPerLayer := len(nodeList) / s.s.cfg.Debug.Layers
 	topology := make([][]*pki.MixDescriptor, s.s.cfg.Debug.Layers)
@@ -1678,12 +1678,12 @@ func (s *state) generateRandomTopology(nodes []*pki.MixDescriptor, srv []byte) [
 	if len(srv) != 32 {
 		err := errors.New("SharedRandomValue too short")
 		s.log.Errorf("srv: %s", srv)
-		s.s.fatalErrCh <- err
+		s.s.reportFatal(err)
 	}
 	rng, err := rand.NewDeterministicRandReader(srv[:])
 	if err != nil {
 		s.log.Errorf("DeterministicRandReader() failed to initialize: %v", err)
-		s.s.fatalErrCh <- err
+		s.s.reportFatal(err)
 	}
 
 	nodeIndexes := rng.Perm(len(nodes))
@@ -2232,7 +2232,7 @@ func (s *state) onReplicaDescriptorUpload(rawDesc []byte, desc *pki.ReplicaDescr
 		return eBkt.Put(pk[:], rawDesc)
 	}); err != nil {
 		// Persistence failures are FATAL.
-		s.s.fatalErrCh <- err
+		s.s.reportFatal(err)
 		return err
 	}
 
@@ -2309,7 +2309,7 @@ func (s *state) onDescriptorUpload(rawDesc []byte, desc *pki.MixDescriptor, epoc
 		return eBkt.Put(pk[:], rawDesc)
 	}); err != nil {
 		// Persistence failures are FATAL.
-		s.s.fatalErrCh <- err
+		s.s.reportFatal(err)
 		return err
 	}
 
@@ -2837,7 +2837,7 @@ func (s *state) reveal(epoch uint64) []byte {
 		fatalErr := fmt.Errorf("REVEAL FATAL: reveal() called without commit for epoch %d - this indicates a critical SharedRandom protocol violation", epoch)
 		s.log.Errorf("reveal: %v", fatalErr)
 		s.log.Errorf("reveal: Available reveals for epoch %d: %d", epoch, len(s.reveals[epoch]))
-		s.s.fatalErrCh <- fatalErr
+		s.s.reportFatal(fatalErr)
 	}
 	s.log.Debugf("reveal: Successfully retrieved reveal for epoch %d", epoch)
 	return signed

--- a/authority/voting/server/state_test.go
+++ b/authority/voting/server/state_test.go
@@ -115,7 +115,7 @@ func testVoteWithAuthorities(t *testing.T, authNum int, expectedSuccessfulConsen
 			cfg:                cfg,
 			identityPrivateKey: peerKeys[i].idKey,
 			identityPublicKey:  peerKeys[i].idPubKey,
-			fatalErrCh:         make(chan error),
+			fatalErrCh:         make(chan error, 1),
 			haltedCh:           make(chan interface{}),
 		}
 		pk := hash.Sum256From(peerKeys[i].idPubKey)
@@ -902,7 +902,7 @@ func TestReplicaDescriptorConsensus(t *testing.T) {
 			cfg:                cfg,
 			identityPrivateKey: peerKeys[i].idKey,
 			identityPublicKey:  peerKeys[i].idPubKey,
-			fatalErrCh:         make(chan error),
+			fatalErrCh:         make(chan error, 1),
 			haltedCh:           make(chan interface{}),
 		}
 		pk := hash.Sum256From(peerKeys[i].idPubKey)
@@ -1372,7 +1372,7 @@ func TestConfiguredReplicaIdentityKeys(t *testing.T) {
 			cfg:                cfg,
 			identityPrivateKey: peerKeys[i].idKey,
 			identityPublicKey:  peerKeys[i].idPubKey,
-			fatalErrCh:         make(chan error),
+			fatalErrCh:         make(chan error, 1),
 			haltedCh:           make(chan interface{}),
 		}
 		pk := hash.Sum256From(peerKeys[i].idPubKey)
@@ -1690,7 +1690,7 @@ func TestNoReplicasAchieveConsensus(t *testing.T) {
 			cfg:                cfg,
 			identityPrivateKey: peerKeys[i].idKey,
 			identityPublicKey:  peerKeys[i].idPubKey,
-			fatalErrCh:         make(chan error),
+			fatalErrCh:         make(chan error, 1),
 			haltedCh:           make(chan interface{}),
 		}
 		pk := hash.Sum256From(peerKeys[i].idPubKey)
@@ -2083,7 +2083,7 @@ func TestMultipleEnvelopeKeysPerReplica(t *testing.T) {
 			cfg:                cfg,
 			identityPrivateKey: peerKeys[i].idKey,
 			identityPublicKey:  peerKeys[i].idPubKey,
-			fatalErrCh:         make(chan error),
+			fatalErrCh:         make(chan error, 1),
 			haltedCh:           make(chan interface{}),
 		}
 		pk := hash.Sum256From(peerKeys[i].idPubKey)
@@ -2468,7 +2468,7 @@ func TestEmptyEnvelopeKeysWithConfiguredReplicas(t *testing.T) {
 			cfg:                cfg,
 			identityPrivateKey: peerKeys[i].idKey,
 			identityPublicKey:  peerKeys[i].idPubKey,
-			fatalErrCh:         make(chan error),
+			fatalErrCh:         make(chan error, 1),
 			haltedCh:           make(chan interface{}),
 		}
 		pk := hash.Sum256From(peerKeys[i].idPubKey)
@@ -2755,7 +2755,7 @@ func TestEnvelopeKeyPartitionResolvedByMajority(t *testing.T) {
 			cfg:                cfg,
 			identityPrivateKey: peerKeys[i].idKey,
 			identityPublicKey:  peerKeys[i].idPubKey,
-			fatalErrCh:         make(chan error),
+			fatalErrCh:         make(chan error, 1),
 			haltedCh:           make(chan interface{}),
 		}
 		pk := hash.Sum256From(peerKeys[i].idPubKey)
@@ -3216,7 +3216,7 @@ func TestConsensusIdenticalAfterAuthorityRestart(t *testing.T) {
 			cfg:                cfg,
 			identityPrivateKey: peerKeys[i].idKey,
 			identityPublicKey:  peerKeys[i].idPubKey,
-			fatalErrCh:         make(chan error),
+			fatalErrCh:         make(chan error, 1),
 			haltedCh:           make(chan interface{}),
 		}
 		go func() {

--- a/replica/fatal_err_test.go
+++ b/replica/fatal_err_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package replica
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/katzenpost/core/log"
+)
+
+// Shutdown used to close fatalErrCh, so a reporter that lost the race
+// panicked on a send to a closed channel. Leaving it open is only safe
+// because the send is non-blocking: after Shutdown the watcher is gone
+// and nothing will ever drain it again.
+func TestReportFatalAfterShutdown(t *testing.T) {
+	logBackend, err := log.New("", "ERROR", false)
+	require.NoError(t, err)
+
+	s := &Server{
+		logBackend: logBackend,
+		log:        logBackend.GetLogger("fatal_err_test"),
+		fatalErrCh: make(chan error, 1),
+		haltedCh:   make(chan interface{}),
+	}
+	s.Shutdown()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.reportFatal(errors.New("first"))
+		s.reportFatal(errors.New("second"))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("reportFatal blocked after shutdown")
+	}
+}

--- a/replica/server.go
+++ b/replica/server.go
@@ -186,9 +186,25 @@ func (s *Server) halt() {
 		s.envelopeKeys.Halt()
 	}
 
-	close(s.fatalErrCh)
 	s.log.Noticef("Shutdown complete.")
 	close(s.haltedCh)
+}
+
+// reportFatal hands err to the fatal error watcher, which shuts the
+// server down. The send is non-blocking and fatalErrCh is buffered,
+// so a caller never blocks: one queued error is enough to bring the
+// server down, and the watcher is gone once shutdown has begun. A
+// blocking send would deadlock the callers that halt() waits for, and
+// closing the channel to release them would panic any send that lost
+// the race.
+func (s *Server) reportFatal(err error) {
+	select {
+	case s.fatalErrCh <- err:
+	default:
+		if s.log != nil {
+			s.log.Warningf("Fatal error while already shutting down: %v", err)
+		}
+	}
 }
 
 // RotateLog rotates the log file
@@ -196,7 +212,7 @@ func (s *Server) halt() {
 func (s *Server) RotateLog() {
 	err := s.logBackend.Rotate()
 	if err != nil {
-		s.fatalErrCh <- fmt.Errorf("failed to rotate log file, shutting down server")
+		s.reportFatal(fmt.Errorf("failed to rotate log file, shutting down server"))
 	}
 }
 
@@ -236,7 +252,7 @@ func newServerWithPKI(cfg *config.Config, pkiClient pki.ReplicaNodeClient) (*Ser
 	s.state.startGCWorker()
 	s.state.startStorageWatcher()
 
-	s.fatalErrCh = make(chan error)
+	s.fatalErrCh = make(chan error, 1)
 	s.haltedCh = make(chan interface{})
 
 	s.log.Notice("Starting Katzenpost Pigeonhole Storage Replica")
@@ -498,12 +514,12 @@ func (s *Server) initEnvelopeKeys() error {
 func (s *Server) startServices(pkiClient pki.ReplicaNodeClient) error {
 	// Start the fatal error watcher.
 	go func() {
-		err, ok := <-s.fatalErrCh
-		if !ok {
-			return
+		select {
+		case err := <-s.fatalErrCh:
+			s.log.Warningf("Shutting down due to error: %v", err)
+			s.Shutdown()
+		case <-s.haltedCh:
 		}
-		s.log.Warningf("Shutting down due to error: %v", err)
-		s.Shutdown()
 	}()
 
 	var addresses []string

--- a/server/server.go
+++ b/server/server.go
@@ -126,12 +126,29 @@ func (s *Server) IdentityKey() sign.PublicKey {
 	return s.identityPublicKey
 }
 
+// reportFatal hands err to the fatal error watcher, which shuts the
+// server down. The send is non-blocking and fatalErrCh is buffered,
+// so a caller never blocks: one queued error is enough to bring the
+// server down, and the watcher is gone once shutdown has begun. A
+// blocking send would deadlock the callers that halt() waits for, and
+// closing the channel to release them would panic any send that lost
+// the race.
+func (s *Server) reportFatal(err error) {
+	select {
+	case s.fatalErrCh <- err:
+	default:
+		if s.log != nil {
+			s.log.Warningf("Fatal error while already shutting down: %v", err)
+		}
+	}
+}
+
 // RotateLog rotates the log file
 // if logging to a file is enabled.
 func (s *Server) RotateLog() {
 	err := s.logBackend.Rotate()
 	if err != nil {
-		s.fatalErrCh <- fmt.Errorf("failed to rotate log file, shutting down server")
+		s.reportFatal(fmt.Errorf("failed to rotate log file, shutting down server"))
 	}
 }
 
@@ -277,8 +294,6 @@ func (s *Server) halt() {
 		close(s.inboundPackets)
 	}
 
-	close(s.fatalErrCh)
-
 	s.log.Noticef("Shutdown complete.")
 	close(s.haltedCh)
 }
@@ -291,7 +306,7 @@ func New(cfg *config.Config) (*Server, error) {
 
 	s := &Server{
 		cfg:        cfg,
-		fatalErrCh: make(chan error),
+		fatalErrCh: make(chan error, 1),
 		haltedCh:   make(chan interface{}),
 	}
 	goo := &serverGlue{s}
@@ -463,13 +478,13 @@ func New(cfg *config.Config) (*Server, error) {
 
 	// Start the fatal error watcher.
 	go func() {
-		err, ok := <-s.fatalErrCh
-		if !ok {
+		select {
+		case err := <-s.fatalErrCh:
+			s.log.Warningf("Shutting down due to error: %v", err)
+			s.Shutdown()
+		case <-s.haltedCh:
 			// Graceful termination.
-			return
 		}
-		s.log.Warningf("Shutting down due to error: %v", err)
-		s.Shutdown()
 	}()
 	logStartupStep("fatal error watcher")
 
@@ -480,7 +495,7 @@ func New(cfg *config.Config) (*Server, error) {
 		s.log.Warningf("Warning: management socket file '%s' already exists, deleting it.", s.cfg.Management.Path)
 		err := os.Remove(s.cfg.Management.Path)
 		if err != nil {
-			s.fatalErrCh <- fmt.Errorf("failed to delete mgmt socket file, shutting down now")
+			s.reportFatal(fmt.Errorf("failed to delete mgmt socket file, shutting down now"))
 			return nil, err
 		}
 	}

--- a/server/server_shutdown_test.go
+++ b/server/server_shutdown_test.go
@@ -18,6 +18,7 @@
 package server
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -225,7 +226,7 @@ func TestShutdownGracefullyHonorsConsensusWithdrawalOption(t *testing.T) {
 			log:         logBackend.GetLogger("shutdown_test"),
 			pki:         fakePKI,
 			shutdownPKI: fakePKI,
-			fatalErrCh:  make(chan error),
+			fatalErrCh:  make(chan error, 1),
 			haltedCh:    make(chan interface{}),
 		}, fakePKI
 	}
@@ -243,4 +244,34 @@ func TestShutdownGracefullyHonorsConsensusWithdrawalOption(t *testing.T) {
 		require.Zero(t, fakePKI.stopCalls)
 		require.Equal(t, 1, fakePKI.haltCalls)
 	})
+}
+
+// Shutdown used to close fatalErrCh, so a reporter that lost the race
+// panicked on a send to a closed channel. Leaving it open is only safe
+// because the send is non-blocking: after Shutdown the watcher is gone
+// and nothing will ever drain it again.
+func TestReportFatalAfterShutdown(t *testing.T) {
+	logBackend, err := log.New("", "ERROR", false)
+	require.NoError(t, err)
+
+	s := &Server{
+		logBackend: logBackend,
+		log:        logBackend.GetLogger("fatal_err_test"),
+		fatalErrCh: make(chan error, 1),
+		haltedCh:   make(chan interface{}),
+	}
+	s.Shutdown()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.reportFatal(errors.New("first"))
+		s.reportFatal(errors.New("second"))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("reportFatal blocked after shutdown")
+	}
 }


### PR DESCRIPTION
Shutdown closed the channel that RotateLog and the dirauth state worker report on, so any reporter losing that race panicked on a send to a closed channel, and an unbuffered send with the watcher already gone wedged the very goroutines halt() waits for. The channel is now buffered by one and never closed, and the send is non-blocking.