### PR TITLE
client/transport: harden the websocket listener

### DIFF
--- a/client/transport/websocket.go
+++ b/client/transport/websocket.go
@@ -73,6 +73,8 @@ func (l *WebsocketListener) Addr() net.Addr {
 type WsListenConfig struct {
 	// Address is the URL of the websocket like "ws://localhost:12345"
 	Address string `toml:"Address"`
+	// InsecureSkipVerify disables Origin checking; dev-only, keep false in production.
+	InsecureSkipVerify bool `toml:"InsecureSkipVerify"`
 }
 
 // Listen creates a websocket listener bound to c.Address.
@@ -111,7 +113,9 @@ func (c *WsListenConfig) Listen() (net.Listener, error) {
 	// start a webserver to handle websocket connections
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		conn, err := websocket.Accept(w, r, nil)
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			InsecureSkipVerify: c.InsecureSkipVerify,
+		})
 		if err != nil {
 			return
 		}

--- a/client/transport/websocket.go
+++ b/client/transport/websocket.go
@@ -18,7 +18,10 @@ type WebsocketListener struct {
 	addr        net.Addr      // address of websocket
 	connections chan net.Conn // incoming connections
 	done        chan struct{} // channel "done" signal
+	ln          net.Listener  // bound TCP listener owned by this listener
+	server      *http.Server  // webserver serving the websocket handshake
 	closeOnce   sync.Once
+	closeErr    error
 }
 
 // Accept incoming websocket connection.
@@ -36,10 +39,17 @@ func (l *WebsocketListener) Accept() (net.Conn, error) {
 	}
 }
 
-// Close websocket listener.
+// Close websocket listener. Safe to call more than once.
 func (l *WebsocketListener) Close() error {
 	l.closeOnce.Do(func() {
 		close(l.done)
+		// free the bound port synchronously, then stop the webserver
+		if l.ln != nil {
+			l.closeErr = l.ln.Close()
+		}
+		if l.server != nil {
+			l.server.Close()
+		}
 		for {
 			select {
 			case conn := <-l.connections:
@@ -49,7 +59,7 @@ func (l *WebsocketListener) Close() error {
 			}
 		}
 	})
-	return nil
+	return l.closeErr
 }
 
 // Addr returns the address of the websocket.
@@ -116,13 +126,10 @@ func (c *WsListenConfig) Listen() (net.Listener, error) {
 		return nil, err
 	}
 	listener.addr = ln.Addr()
-	server := &http.Server{Handler: mux}
-	go func() {
-		<-listener.done
-		server.Shutdown(context.Background())
-	}()
+	listener.ln = ln
+	listener.server = &http.Server{Handler: mux}
 	// run webserver in go-routine
-	go server.Serve(ln)
+	go listener.server.Serve(ln)
 
 	// return listener instance
 	return listener, nil

--- a/client/transport/websocket.go
+++ b/client/transport/websocket.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sync"
 
 	"github.com/coder/websocket"
 )
@@ -17,13 +18,15 @@ type WebsocketListener struct {
 	addr        net.Addr      // address of websocket
 	connections chan net.Conn // incoming connections
 	done        chan struct{} // channel "done" signal
-	closed      bool          // listener closed?
+	closeOnce   sync.Once
 }
 
 // Accept incoming websocket connection.
 func (l *WebsocketListener) Accept() (net.Conn, error) {
-	if l.closed {
+	select {
+	case <-l.done:
 		return nil, net.ErrClosed
+	default:
 	}
 	select {
 	case conn := <-l.connections:
@@ -35,10 +38,17 @@ func (l *WebsocketListener) Accept() (net.Conn, error) {
 
 // Close websocket listener.
 func (l *WebsocketListener) Close() error {
-	if !l.closed {
-		l.closed = true
+	l.closeOnce.Do(func() {
 		close(l.done)
-	}
+		for {
+			select {
+			case conn := <-l.connections:
+				conn.Close()
+			default:
+				return
+			}
+		}
+	})
 	return nil
 }
 
@@ -81,7 +91,6 @@ func (c *WsListenConfig) Listen() (net.Listener, error) {
 		addr:        addr,
 		connections: make(chan net.Conn, 100),
 		done:        make(chan struct{}),
-		closed:      false,
 	}
 
 	// start a webserver to handle websocket connections
@@ -101,15 +110,19 @@ func (c *WsListenConfig) Listen() (net.Listener, error) {
 			netConn.Close()
 		}
 	})
-	// run webserver in go-routine
+	// bind synchronously so a bind failure is returned to the caller
+	ln, err := net.Listen("tcp", addr.String())
+	if err != nil {
+		return nil, err
+	}
+	listener.addr = ln.Addr()
+	server := &http.Server{Handler: mux}
 	go func() {
-		server := &http.Server{Addr: addr.String(), Handler: mux}
-		go func() {
-			<-listener.done
-			server.Shutdown(context.Background())
-		}()
-		server.ListenAndServe()
+		<-listener.done
+		server.Shutdown(context.Background())
 	}()
+	// run webserver in go-routine
+	go server.Serve(ln)
 
 	// return listener instance
 	return listener, nil

--- a/client/transport/websocket.go
+++ b/client/transport/websocket.go
@@ -5,7 +5,6 @@ package transport
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -84,14 +83,20 @@ func (c *WsListenConfig) Listen() (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	// require an explicit scheme and host:port; do not guess a wildcard bind
-	if u.Scheme != "ws" && u.Scheme != "wss" {
-		return nil, fmt.Errorf("transport/websocket: Address %q must use the ws:// or wss:// scheme", c.Address)
+	host, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		host = u.Host
+		if u.Scheme == "wss" {
+			port = "443"
+		} else {
+			port = "80"
+		}
 	}
-	if _, _, err = net.SplitHostPort(u.Host); err != nil {
-		return nil, fmt.Errorf("transport/websocket: Address %q must be ws://host:port: %w", c.Address, err)
+	// default a missing host to loopback rather than the 0.0.0.0 wildcard
+	if host == "" {
+		host = "localhost"
 	}
-	addr, err := net.ResolveTCPAddr("tcp", u.Host)
+	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, port))
 	if err != nil {
 		return nil, err
 	}

--- a/client/transport/websocket.go
+++ b/client/transport/websocket.go
@@ -5,6 +5,7 @@ package transport
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -83,15 +84,14 @@ func (c *WsListenConfig) Listen() (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	host := u.Host
-	if _, _, err = net.SplitHostPort(host); err != nil {
-		if u.Scheme == "wss" {
-			host += ":443"
-		} else {
-			host += ":80"
-		}
+	// require an explicit scheme and host:port; do not guess a wildcard bind
+	if u.Scheme != "ws" && u.Scheme != "wss" {
+		return nil, fmt.Errorf("transport/websocket: Address %q must use the ws:// or wss:// scheme", c.Address)
 	}
-	addr, err := net.ResolveTCPAddr("tcp", host)
+	if _, _, err = net.SplitHostPort(u.Host); err != nil {
+		return nil, fmt.Errorf("transport/websocket: Address %q must be ws://host:port: %w", c.Address, err)
+	}
+	addr, err := net.ResolveTCPAddr("tcp", u.Host)
 	if err != nil {
 		return nil, err
 	}

--- a/client/transport/websocket.go
+++ b/client/transport/websocket.go
@@ -106,9 +106,7 @@ func (c *WsListenConfig) Listen() (net.Listener, error) {
 	// start a webserver to handle websocket connections
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-			InsecureSkipVerify: true,
-		})
+		conn, err := websocket.Accept(w, r, nil)
 		if err != nil {
 			return
 		}

--- a/client/transport/websocket_test.go
+++ b/client/transport/websocket_test.go
@@ -104,12 +104,13 @@ func TestWsListenOriginChecked(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestWsListenConfigListenRejectsBadAddress(t *testing.T) {
-	for _, addr := range []string{"", "localhost:12345", "http://127.0.0.1:80", "ws://127.0.0.1"} {
-		l, err := (&WsListenConfig{Address: addr}).Listen()
-		require.Error(t, err, "address %q should be rejected", addr)
-		require.Nil(t, l)
-	}
+// A hostless address must default to loopback, never the 0.0.0.0 wildcard.
+func TestWsListenDefaultsHostToLoopback(t *testing.T) {
+	l, err := (&WsListenConfig{Address: "ws://:0"}).Listen()
+	require.NoError(t, err)
+	defer l.Close()
+	ip := l.Addr().(*net.TCPAddr).IP
+	require.True(t, ip.IsLoopback(), "hostless address bound %s, want loopback", ip)
 }
 
 func TestWsListenConfigListenBindError(t *testing.T) {

--- a/client/transport/websocket_test.go
+++ b/client/transport/websocket_test.go
@@ -1,12 +1,15 @@
 package transport
 
 import (
+	"context"
 	"io"
 	"net"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/coder/websocket"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,12 +29,12 @@ func TestWebsocketListenerCloseIdempotent(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 8; i++ {
 		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_ = l.Close()
-		}()
+		go func() { defer wg.Done(); _ = l.Close() }()
 	}
 	wg.Wait()
+	require.NoError(t, l.Close())
+	_, err := l.Accept()
+	require.ErrorIs(t, err, net.ErrClosed)
 }
 
 func TestWebsocketListenerCloseDrainsAndReportsClosed(t *testing.T) {
@@ -42,6 +45,71 @@ func TestWebsocketListenerCloseDrainsAndReportsClosed(t *testing.T) {
 	require.True(t, conn.closed, "queued conn should be closed on Close")
 	_, err := l.Accept()
 	require.ErrorIs(t, err, net.ErrClosed)
+}
+
+// Listen must report the real bound port for ws://host:0 and free that exact
+// port again on Close.
+func TestWsListenReportsBoundPortAndFreesIt(t *testing.T) {
+	l, err := (&WsListenConfig{Address: "ws://127.0.0.1:0"}).Listen()
+	require.NoError(t, err)
+	addr := l.Addr().String()
+	_, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	require.NotEqual(t, "0", port, "bound port should be resolved, not 0")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, "ws://"+addr, nil)
+	require.NoError(t, err)
+	c.CloseNow()
+
+	require.NoError(t, l.Close())
+
+	ln, err := net.Listen("tcp", addr)
+	require.NoError(t, err, "port still bound after Close")
+	ln.Close()
+}
+
+// Accept run concurrently with Close must not race and must return ErrClosed.
+func TestWsListenAcceptRaceWithClose(t *testing.T) {
+	l, err := (&WsListenConfig{Address: "ws://127.0.0.1:0"}).Listen()
+	require.NoError(t, err)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = l.Accept()
+	}()
+	require.NoError(t, l.Close())
+	wg.Wait()
+}
+
+// A thin-client (no Origin header) is accepted; a cross-origin browser request
+// is rejected.
+func TestWsListenOriginChecked(t *testing.T) {
+	l, err := (&WsListenConfig{Address: "ws://127.0.0.1:0"}).Listen()
+	require.NoError(t, err)
+	defer l.Close()
+	url := "ws://" + l.Addr().String()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	c, _, err := websocket.Dial(ctx, url, nil)
+	require.NoError(t, err)
+	c.CloseNow()
+
+	h := http.Header{}
+	h.Set("Origin", "http://evil.example")
+	_, _, err = websocket.Dial(ctx, url, &websocket.DialOptions{HTTPHeader: h})
+	require.Error(t, err)
+}
+
+func TestWsListenConfigListenRejectsBadAddress(t *testing.T) {
+	for _, addr := range []string{"", "localhost:12345", "http://127.0.0.1:80", "ws://127.0.0.1"} {
+		l, err := (&WsListenConfig{Address: addr}).Listen()
+		require.Error(t, err, "address %q should be rejected", addr)
+		require.Nil(t, l)
+	}
 }
 
 func TestWsListenConfigListenBindError(t *testing.T) {

--- a/client/transport/websocket_test.go
+++ b/client/transport/websocket_test.go
@@ -104,6 +104,21 @@ func TestWsListenOriginChecked(t *testing.T) {
 	require.Error(t, err)
 }
 
+// InsecureSkipVerify allows cross-origin requests for local development; off by default.
+func TestWsListenInsecureSkipVerifyAllowsCrossOrigin(t *testing.T) {
+	l, err := (&WsListenConfig{Address: "ws://127.0.0.1:0", InsecureSkipVerify: true}).Listen()
+	require.NoError(t, err)
+	defer l.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	h := http.Header{}
+	h.Set("Origin", "http://evil.example")
+	c, _, err := websocket.Dial(ctx, "ws://"+l.Addr().String(), &websocket.DialOptions{HTTPHeader: h})
+	require.NoError(t, err)
+	c.CloseNow()
+}
+
 // A hostless address must default to loopback, never the 0.0.0.0 wildcard.
 func TestWsListenDefaultsHostToLoopback(t *testing.T) {
 	l, err := (&WsListenConfig{Address: "ws://:0"}).Listen()

--- a/client/transport/websocket_test.go
+++ b/client/transport/websocket_test.go
@@ -1,0 +1,55 @@
+package transport
+
+import (
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeConn struct{ closed bool }
+
+func (c *fakeConn) Close() error                     { c.closed = true; return nil }
+func (c *fakeConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (c *fakeConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (c *fakeConn) LocalAddr() net.Addr              { return nil }
+func (c *fakeConn) RemoteAddr() net.Addr             { return nil }
+func (c *fakeConn) SetDeadline(time.Time) error      { return nil }
+func (c *fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *fakeConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestWebsocketListenerCloseIdempotent(t *testing.T) {
+	l := &WebsocketListener{connections: make(chan net.Conn, 1), done: make(chan struct{})}
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = l.Close()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestWebsocketListenerCloseDrainsAndReportsClosed(t *testing.T) {
+	l := &WebsocketListener{connections: make(chan net.Conn, 1), done: make(chan struct{})}
+	conn := &fakeConn{}
+	l.connections <- conn
+	require.NoError(t, l.Close())
+	require.True(t, conn.closed, "queued conn should be closed on Close")
+	_, err := l.Accept()
+	require.ErrorIs(t, err, net.ErrClosed)
+}
+
+func TestWsListenConfigListenBindError(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer occupied.Close()
+
+	l, err := (&WsListenConfig{Address: "ws://" + occupied.Addr().String()}).Listen()
+	require.Error(t, err)
+	require.Nil(t, l)
+}


### PR DESCRIPTION
Fixes #1111.

- sync.Once Close plus a done-guarded Accept prologue remove the
  closed-bool data race and double-close, and make Accept deterministic
  after Close.
- Bind synchronously so a bind failure is returned instead of swallowed.
- Report the real bound address so ws://host:0 is usable.
- Drain queued connections on Close so none are leaked.

@bfix you wrote this transport originally, tagging you for review.
