### PR TITLE
server: instrument seven silent packet drop sites

### DIFF
--- a/server/internal/gateway/gateway.go
+++ b/server/internal/gateway/gateway.go
@@ -181,12 +181,16 @@ func (p *gateway) onSURBReply(pkt *packet.Packet, recipient []byte) {
 	geo := p.glue.Config().SphinxGeometry
 	if len(pkt.Payload) != geo.PayloadTagLength+geo.ForwardPayloadLength {
 		p.log.Debugf("Refusing to store mis-sized SURB-Reply: %v (%v)", pkt.ID, len(pkt.Payload))
+		instrument.PacketsDropped()
+		instrument.PacketsDroppedByReason("gateway_surb_reply_missized")
 		return
 	}
 
 	// Store the payload in the spool.
 	if err := p.spool.StoreSURBReply(recipient, &pkt.SurbReply.ID, pkt.Payload); err != nil {
 		p.log.Debugf("Failed to store SURB-Reply: %v (%v)", pkt.ID, err)
+		instrument.PacketsDropped()
+		instrument.PacketsDroppedByReason("gateway_spool_surb_reply_failed")
 		return
 	}
 	p.log.Debugf("Stored SURB-Reply: %v", pkt.ID)
@@ -205,6 +209,8 @@ func (p *gateway) onToUser(pkt *packet.Packet, recipient []byte) {
 	// Store the ciphertext in the spool.
 	if err := p.spool.StoreMessage(recipient, ct); err != nil {
 		p.log.Debugf("Failed to store message payload: %v (%v)", pkt.ID, err)
+		instrument.PacketsDropped()
+		instrument.PacketsDroppedByReason("gateway_spool_message_failed")
 		return
 	}
 	p.notifyListeners(recipient)
@@ -214,6 +220,8 @@ func (p *gateway) onToUser(pkt *packet.Packet, recipient []byte) {
 		ackPkt, err := packet.NewPacketFromSURB(surb, nil, p.glue.Config().SphinxGeometry)
 		if err != nil {
 			p.log.Debugf("Failed to generate SURB-ACK: %v (%v)", pkt.ID, err)
+			instrument.PacketsDropped()
+			instrument.PacketsDroppedByReason("gateway_surb_ack_failed")
 			return
 		}
 

--- a/server/internal/gateway/gateway.go
+++ b/server/internal/gateway/gateway.go
@@ -156,24 +156,14 @@ func (p *gateway) worker() {
 		// Post-process the recipient.
 		recipient := pkt.Recipient.ID[:]
 
-		// Process the packet based on type.
+		// The caller checks that the packet is either a SURB-Reply or a
+		// user message, so anything that is not the former is the latter.
 		if pkt.IsSURBReply() {
 			p.onSURBReply(pkt, recipient)
-			pkt.Dispose()
-			continue
 		} else {
-			// Caller checks that the packet is either a SURB-Reply or a user
-			// message, so this must be the latter.
 			p.onToUser(pkt, recipient)
-			pkt.Dispose()
-			continue
 		}
-
-		p.log.Debugf("Dropping packet: %v (Invalid Recipient: '%x')", pkt.ID, recipient)
-		instrument.PacketsDropped()
-		instrument.PacketsDroppedByReason("gateway_invalid_recipient")
 		pkt.Dispose()
-
 	}
 }
 

--- a/server/internal/service/kaetzchen/cbor_plugins.go
+++ b/server/internal/service/kaetzchen/cbor_plugins.go
@@ -105,6 +105,7 @@ func (k *CBORPluginWorker) worker(recipient [constants.RecipientIDLength]byte, p
 	k.Unlock()
 	if !ok {
 		k.log.Debugf("Failed to find handler. Dropping Kaetzchen request: %v", recipient)
+		instrument.PacketsDropped()
 		instrument.PacketsDroppedByReason("cbor_kaetzchen_no_handler")
 		instrument.KaetzchenRequestsDropped(1)
 		return
@@ -146,6 +147,7 @@ func (k *CBORPluginWorker) processKaetzchen(pkt *packet.Packet, pluginClient *cb
 	payload, surb, err := packet.ParseForwardPacket(pkt)
 	if err != nil {
 		k.log.Debugf("%v: Dropping Kaetzchen request: %v (%v)", pluginCap, pkt.ID, err)
+		instrument.PacketsDropped()
 		instrument.PacketsDroppedByReason("cbor_kaetzchen_parse_forward_failed")
 		instrument.KaetzchenRequestsDropped(1)
 		return
@@ -185,6 +187,7 @@ func (k *CBORPluginWorker) sendworker(pluginClient *cborplugin.Client) {
 					// response is probably invalid, so drop it
 					k.log.Errorf("%v: Got response too long: %d > max (%d)",
 						pluginCap, len(r.Payload), k.geo.UserForwardPayloadLength)
+					instrument.PacketsDropped()
 					instrument.PacketsDroppedByReason("cbor_kaetzchen_response_too_long")
 					instrument.KaetzchenRequestsDropped(1)
 					continue
@@ -214,6 +217,7 @@ func (k *CBORPluginWorker) sendworker(pluginClient *cborplugin.Client) {
 			default:
 				// received some unknown command type
 				k.log.Errorf("%v: Failed to handle Kaetzchen request, unknown command type: (%v), response: %s", pluginCap, r, cborResponse)
+				instrument.PacketsDropped()
 				instrument.PacketsDroppedByReason("cbor_kaetzchen_unknown_response_type")
 				instrument.KaetzchenRequestsDropped(1)
 			}

--- a/server/internal/service/kaetzchen/cbor_plugins.go
+++ b/server/internal/service/kaetzchen/cbor_plugins.go
@@ -76,6 +76,8 @@ func (k *CBORPluginWorker) OnKaetzchen(pkt *packet.Packet) {
 	k.Unlock()
 	if !ok {
 		k.log.Debugf("Failed to find handler. Dropping Kaetzchen request: %v", pkt.ID)
+		instrument.PacketsDropped()
+		instrument.PacketsDroppedByReason("cbor_kaetzchen_dispatch_no_handler")
 		return
 	}
 	select {
@@ -192,6 +194,8 @@ func (k *CBORPluginWorker) sendworker(pluginClient *cborplugin.Client) {
 					respPkt, err := packet.NewPacketFromSURB(r.SURB, r.Payload, k.geo)
 					if err != nil {
 						k.log.Debugf("%v: Failed to generate SURB-Reply: %v (%v)", pluginCap, r.ID, err)
+						instrument.PacketsDropped()
+						instrument.PacketsDroppedByReason("cbor_kaetzchen_surb_reply_failed")
 						continue
 					}
 					// Set the packet queue delay

--- a/server/internal/service/kaetzchen/kaetzchen.go
+++ b/server/internal/service/kaetzchen/kaetzchen.go
@@ -265,6 +265,7 @@ func (k *KaetzchenWorker) processKaetzchen(pkt *packet.Packet) {
 	if err != nil {
 		k.log.Debugf("Dropping Kaetzchen request: %v (%v)", pkt.ID, err)
 		k.incrementDropCounter()
+		instrument.PacketsDropped()
 		instrument.PacketsDroppedByReason("kaetzchen_parse_forward_failed")
 		instrument.KaetzchenRequestsDropped(k.getDropCounter())
 		return
@@ -278,6 +279,7 @@ func (k *KaetzchenWorker) processKaetzchen(pkt *packet.Packet) {
 		k.log.Error("KaetzchenWorker does not handle the specified recipient")
 		k.log.Debugf("Dropping Kaetzchen request: %v (%v)", pkt.ID, err)
 		k.incrementDropCounter()
+		instrument.PacketsDropped()
 		instrument.PacketsDroppedByReason("kaetzchen_unknown_recipient")
 		instrument.KaetzchenRequestsDropped(k.getDropCounter())
 		return
@@ -293,6 +295,7 @@ func (k *KaetzchenWorker) processKaetzchen(pkt *packet.Packet) {
 		return
 	default:
 		k.log.Debugf("Failed to handle Kaetzchen request: %v (%v)", pkt.ID, err)
+		instrument.PacketsDropped()
 		instrument.PacketsDroppedByReason("kaetzchen_handler_failed")
 		instrument.KaetzchenRequestsFailed()
 		return

--- a/server/internal/service/kaetzchen/kaetzchen.go
+++ b/server/internal/service/kaetzchen/kaetzchen.go
@@ -303,6 +303,8 @@ func (k *KaetzchenWorker) processKaetzchen(pkt *packet.Packet) {
 		respPkt, err := packet.NewPacketFromSURB(surb, resp, k.glue.Config().SphinxGeometry)
 		if err != nil {
 			k.log.Debugf("Failed to generate SURB-Reply: %v (%v)", pkt.ID, err)
+			instrument.PacketsDropped()
+			instrument.PacketsDroppedByReason("kaetzchen_surb_reply_failed")
 			return
 		}
 


### PR DESCRIPTION
These sites discarded a packet with nothing but a Debugf line, four of them on the gateway's terminal delivery path where every echo ends. They now increment the aggregate and per-reason counters like every other drop site, so the reason breakdown accounts for them.