### PR TITLE
kpclientd: fix shutdown hang and connection races

### DIFF
--- a/client/appid_race_test.go
+++ b/client/appid_race_test.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/katzenpost/client/thin"
+	"github.com/katzenpost/katzenpost/core/log"
+)
+
+// TestIncomingConnAppIDRace races currentAppID against handleSessionToken.
+func TestIncomingConnAppIDRace(t *testing.T) {
+	logBackend, err := log.New("", "error", false)
+	require.NoError(t, err)
+	l := &listener{
+		conns:                make(map[[AppIDLength]byte]*incomingConn),
+		connsLock:            new(sync.RWMutex),
+		clientTokens:         make(map[[16]byte]*[AppIDLength]byte),
+		disconnectedSessions: make(map[[AppIDLength]byte]*DisconnectedSession),
+		sessionGracePeriod:   defaultSessionGracePeriod,
+		logBackend:           logBackend,
+	}
+	l.log = logBackend.GetLogger("test")
+
+	oldAppID := &[AppIDLength]byte{1}
+	newAppID := &[AppIDLength]byte{2}
+	token := [16]byte{9}
+	l.clientTokens[token] = oldAppID
+
+	c := &incomingConn{
+		listener: l,
+		appID:    newAppID,
+		sendWake: make(chan struct{}, 1),
+		doneCh:   make(chan struct{}),
+		log:      logBackend.GetLogger("test"),
+	}
+	l.conns[*newAppID] = c
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = c.currentAppID()
+			}
+		}
+	}()
+
+	for i := 0; i < 500; i++ {
+		l.handleSessionToken(c, &thin.SessionToken{ClientInstanceToken: token})
+	}
+	close(stop)
+	wg.Wait()
+
+	require.Equal(t, oldAppID, c.currentAppID())
+}

--- a/client/client.go
+++ b/client/client.go
@@ -49,6 +49,13 @@ type Client struct {
 	DialContextFn func(ctx context.Context, network, address string) (net.Conn, error)
 }
 
+func (c *Client) haltConnection() {
+	if c.conn != nil {
+		c.conn.isShutdown.Store(true)
+		c.conn.Halt()
+	}
+}
+
 // Shutdown cleanly shuts down a given Client instance.
 func (c *Client) Shutdown() {
 	shutdownStart := time.Now()

--- a/client/connection.go
+++ b/client/connection.go
@@ -806,7 +806,7 @@ func (c *connection) sendPacket(pkt []byte) error {
 		return ErrShutdown
 	}
 
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	select {
 	case c.sendCh <- &connSendCtx{
 		pkt: pkt,
@@ -831,7 +831,7 @@ func (c *connection) GetConsensus(ctx context.Context, epoch uint64) (*commands.
 		return nil, ErrNotConnected
 	}
 
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	replyCh := make(chan interface{})
 
 	select {

--- a/client/daemon.go
+++ b/client/daemon.go
@@ -186,6 +186,7 @@ func (d *Daemon) halt() {
 	// Step 2: Stop workers
 	workersStart := time.Now()
 	d.log.Debug("Stopping workers first to prevent channel deadlocks")
+	d.client.haltConnection()
 	d.Halt() // shutdown ingressWorker and egressWorker first
 	d.log.Infof("Workers stopped in %v", time.Since(workersStart))
 

--- a/client/incoming_conn.go
+++ b/client/incoming_conn.go
@@ -53,8 +53,9 @@ type incomingConn struct {
 	listener *listener
 	log      *logging.Logger
 
-	conn  net.Conn
-	appID *[AppIDLength]byte
+	conn    net.Conn
+	appID   *[AppIDLength]byte
+	appIDMu sync.RWMutex
 
 	clientToken   *[16]byte
 	explicitClose bool
@@ -82,6 +83,8 @@ type incomingConn struct {
 	sendQueue   []*Response
 	sendQueueMu sync.Mutex
 
+	writeMu sync.Mutex
+
 	// sendWake is a 1-capacity wake channel; sendResponse signals it
 	// after appending so the writer goroutine notices new work.
 	sendWake chan struct{}
@@ -108,6 +111,12 @@ type incomingConn struct {
 // path and from the writer goroutine if its socket Write fails.
 func (c *incomingConn) closeDone() {
 	c.doneOnce.Do(func() { close(c.doneCh) })
+}
+
+func (c *incomingConn) currentAppID() *[AppIDLength]byte {
+	c.appIDMu.RLock()
+	defer c.appIDMu.RUnlock()
+	return c.appID
 }
 
 // isDone reports whether the conn has already begun teardown.
@@ -147,7 +156,7 @@ func (c *incomingConn) recvRequest() (*Request, error) {
 		c.log.Infof("error decoding cbor from client: %s\n", err)
 		return nil, err
 	}
-	return FromThinRequest(req, c.appID), nil
+	return FromThinRequest(req, c.currentAppID()), nil
 }
 
 func (c *incomingConn) sendPKIDoc(doc []byte) error {
@@ -211,6 +220,8 @@ func (c *incomingConn) drainSendQueue() []*Response {
 // can pin the writer; on deadline the socket Write returns an error and
 // the caller tears down the conn.
 func (c *incomingConn) writeResponse(r *Response) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
 	response := IntoThinResponse(r)
 	blob, err := cbor.Marshal(response)
 	if err != nil {

--- a/client/listener.go
+++ b/client/listener.go
@@ -123,6 +123,8 @@ func (l *listener) updatePKIDocWorker() {
 	}
 }
 
+const acceptRetryDelay = 5 * time.Millisecond
+
 func (l *listener) worker() {
 	addr := l.listener.Addr()
 	l.log.Infof("Listening on: %v", addr)
@@ -141,6 +143,11 @@ func (l *listener) worker() {
 			if e, ok := err.(net.Error); ok && !e.Temporary() {
 				l.log.Errorf("Critical accept failure: %v", err)
 				return
+			}
+			select {
+			case <-l.HaltCh():
+				return
+			case <-time.After(acceptRetryDelay):
 			}
 			continue
 		}
@@ -529,7 +536,9 @@ func (l *listener) handleSessionToken(c *incomingConn, st *thin.SessionToken) {
 
 		l.connsLock.Lock()
 		delete(l.conns, oldAppID)
+		c.appIDMu.Lock()
 		c.appID = existingAppID
+		c.appIDMu.Unlock()
 		l.conns[*existingAppID] = c
 		for i, id := range l.connOrder {
 			if id == oldAppID {

--- a/client/shutdown_write_test.go
+++ b/client/shutdown_write_test.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/katzenpost/client/thin"
+	"github.com/katzenpost/katzenpost/core/log"
+)
+
+// recorderConn records writes and yields mid-write to widen the window
+// for interleaving between two writeResponse callers.
+type recorderConn struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (c *recorderConn) Write(p []byte) (int, error) {
+	runtime.Gosched()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.Write(p)
+}
+
+func (c *recorderConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (c *recorderConn) Close() error                     { return nil }
+func (c *recorderConn) LocalAddr() net.Addr              { return nil }
+func (c *recorderConn) RemoteAddr() net.Addr             { return nil }
+func (c *recorderConn) SetDeadline(time.Time) error      { return nil }
+func (c *recorderConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *recorderConn) SetWriteDeadline(time.Time) error { return nil }
+
+// TestWriteResponseConcurrentFraming checks concurrent writeResponse
+// callers do not interleave their frames on the socket.
+func TestWriteResponseConcurrentFraming(t *testing.T) {
+	logBackend, err := log.New("", "error", false)
+	require.NoError(t, err)
+	rec := &recorderConn{}
+	c := &incomingConn{
+		conn:     rec,
+		sendWake: make(chan struct{}, 1),
+		doneCh:   make(chan struct{}),
+		log:      logBackend.GetLogger("test"),
+	}
+
+	const writers = 8
+	payload := bytes.Repeat([]byte{0xAB}, 512)
+	errs := make(chan error, writers)
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- c.writeResponse(&Response{
+				NewPKIDocumentEvent: &thin.NewPKIDocumentEvent{Payload: payload},
+			})
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	stream := rec.buf.Bytes()
+	frames := 0
+	for len(stream) > 0 {
+		require.GreaterOrEqual(t, len(stream), 4, "truncated length prefix (frames interleaved)")
+		n := binary.BigEndian.Uint32(stream[:4])
+		stream = stream[4:]
+		require.GreaterOrEqual(t, uint32(len(stream)), n, "frame shorter than its prefix (frames interleaved)")
+		var resp thin.Response
+		require.NoError(t, cbor.Unmarshal(stream[:n], &resp), "frame did not decode (frames interleaved)")
+		stream = stream[n:]
+		frames++
+	}
+	require.Equal(t, writers, frames)
+}


### PR DESCRIPTION
Fixes a shutdown deadlock and several connection races in kpclientd.

The deadlock was discovered and confirmed in #1110: shutdown could block
on an in-flight wire send because the send error channels were unbuffered
and isShutdown was not set before halting the connection. Buffering those
channels and setting isShutdown first lets shutdown proceed without
waiting on a send that no one will read.

Also in this change:
- guard incomingConn.appID with a mutex so concurrent access is safe
- serialize per-connection writes
- back off on temporary Accept errors instead of busy-looping

Tests cover the appID race and the shutdown-during-send path.

Relationship: independent of the other kpclientd branches; merges in any
order.
