### PR TITLE
client/transport: repair a stale unix socket on bind

### DIFF
--- a/client/transport/unix.go
+++ b/client/transport/unix.go
@@ -6,7 +6,8 @@ package transport
 // UnixListenConfig configures a unix-domain-socket listener.
 type UnixListenConfig struct {
 	// Address is the path to the unix socket file. The parent
-	// directory must exist and be writable by the daemon; any stale
-	// socket file at the path is the operator's responsibility.
+	// directory must exist and be writable by the daemon; a stale
+	// socket file left by a crashed daemon is cleared on the next
+	// bind, but a socket a live daemon still answers on is left alone.
 	Address string `toml:"Address"`
 }

--- a/client/transport/unix_impl.go
+++ b/client/transport/unix_impl.go
@@ -5,13 +5,55 @@
 
 package transport
 
-import "net"
+import (
+	"errors"
+	"net"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+)
 
 // Listen creates a unix-domain-socket listener bound to c.Address.
 func (c *UnixListenConfig) Listen() (Listener, error) {
-	addr, err := net.ResolveUnixAddr("unix", c.Address)
+	return listenUnix(c.Address)
+}
+
+// listenUnix binds a single unix socket, clearing a stale socket file
+// left by a crashed daemon before giving up.
+func listenUnix(address string) (Listener, error) {
+	addr, err := net.ResolveUnixAddr("unix", address)
 	if err != nil {
 		return nil, err
 	}
+	l, err := net.ListenUnix("unix", addr)
+	if err == nil {
+		return l, nil
+	}
+	if !errors.Is(err, syscall.EADDRINUSE) || !staleUnixSocket(address) {
+		return nil, err
+	}
+	if rmErr := os.Remove(address); rmErr != nil {
+		return nil, err
+	}
 	return net.ListenUnix("unix", addr)
+}
+
+// staleUnixSocket reports whether address is a filesystem socket that no
+// live daemon still answers on. An abstract socket (@ prefix) never
+// outlives its owner, so EADDRINUSE there always means a live owner.
+func staleUnixSocket(address string) bool {
+	if strings.HasPrefix(address, "@") {
+		return false
+	}
+	fi, err := os.Stat(address)
+	if err != nil || fi.Mode()&os.ModeSocket == 0 {
+		return false
+	}
+	conn, err := net.DialTimeout("unix", address, 100*time.Millisecond)
+	if err == nil {
+		conn.Close()
+		return false
+	}
+	return errors.Is(err, syscall.ECONNREFUSED)
 }

--- a/client/transport/unix_test.go
+++ b/client/transport/unix_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -94,4 +95,117 @@ func (r *readUntilEOF) Read(p []byte) (int, error) {
 		err = io.EOF
 	}
 	return n, err
+}
+
+func TestUnixListenerRepairsStaleSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stale socket repair relies on POSIX unix socket semantics")
+	}
+	tmpDir := shortSockDir(t)
+	sockPath := filepath.Join(tmpDir, "stale.sock")
+
+	// Emulate a crashed daemon: a listener whose socket file survives
+	// because SetUnlinkOnClose(false) skips the unlink that a clean
+	// shutdown would perform.
+	addr, err := net.ResolveUnixAddr("unix", sockPath)
+	require.NoError(t, err)
+	crashed, err := net.ListenUnix("unix", addr)
+	require.NoError(t, err)
+	crashed.SetUnlinkOnClose(false)
+	require.NoError(t, crashed.Close())
+
+	fi, err := os.Stat(sockPath)
+	require.NoError(t, err, "the stale socket file must survive the crash")
+	require.NotZero(t, fi.Mode()&os.ModeSocket)
+
+	cfg := &UnixListenConfig{Address: sockPath}
+	l, err := cfg.Listen()
+	require.NoError(t, err, "a stale socket must not block the next bind")
+	defer l.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := net.Dial("unix", sockPath)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		conn.Close()
+		errCh <- nil
+	}()
+	acceptedConn, err := l.Accept()
+	require.NoError(t, err)
+	acceptedConn.Close()
+	require.NoError(t, <-errCh)
+}
+
+func TestUnixListenerKeepsLiveSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stale socket repair relies on POSIX unix socket semantics")
+	}
+	tmpDir := shortSockDir(t)
+	sockPath := filepath.Join(tmpDir, "live.sock")
+
+	live := &UnixListenConfig{Address: sockPath}
+	first, err := live.Listen()
+	require.NoError(t, err)
+	defer first.Close()
+
+	// A second bind on a socket a live daemon still answers on must
+	// fail rather than evict the running daemon.
+	_, err = (&UnixListenConfig{Address: sockPath}).Listen()
+	require.Error(t, err)
+
+	fi, statErr := os.Stat(sockPath)
+	require.NoError(t, statErr, "the live socket file must be left in place")
+	require.NotZero(t, fi.Mode()&os.ModeSocket)
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := net.Dial("unix", sockPath)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		conn.Close()
+		errCh <- nil
+	}()
+	acceptedConn, err := first.Accept()
+	require.NoError(t, err, "the original listener must still be serving")
+	acceptedConn.Close()
+	require.NoError(t, <-errCh)
+}
+
+func TestUnixListenerLeavesRegularFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stale socket repair relies on POSIX unix socket semantics")
+	}
+	tmpDir := shortSockDir(t)
+	filePath := filepath.Join(tmpDir, "regular.file")
+	require.NoError(t, os.WriteFile(filePath, []byte("not a socket"), 0600))
+
+	_, err := (&UnixListenConfig{Address: filePath}).Listen()
+	require.Error(t, err, "binding over a regular file must fail")
+
+	got, readErr := os.ReadFile(filePath)
+	require.NoError(t, readErr, "a non-socket file must never be removed")
+	require.Equal(t, []byte("not a socket"), got)
+}
+
+func TestUnixListenerAbstractAddressInUse(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("abstract unix sockets are Linux-only")
+	}
+	address := "@katzenpost-stale-test"
+
+	first, err := (&UnixListenConfig{Address: address}).Listen()
+	require.NoError(t, err)
+	defer first.Close()
+
+	// An abstract socket never outlives its owner, so a second bind
+	// failing means the first is still live: pass the error through
+	// rather than treating it as stale.
+	_, err = (&UnixListenConfig{Address: address}).Listen()
+	require.Error(t, err)
+	require.False(t, staleUnixSocket(address))
 }


### PR DESCRIPTION
Repairs a stale unix socket left behind by a crashed kpclientd.

If kpclientd is killed or crashes, its filesystem socket file survives
and the next start fails to bind with EADDRINUSE. This detects that case:
on EADDRINUSE, if the path is a socket that no live daemon answers on (a
dial is refused), it removes the stale file and rebinds once.

A socket a live daemon still answers on is left in place, so a second
instance cannot evict a running one. Abstract (@ prefix) sockets never
outlive their owner, so EADDRINUSE there is a live owner and is passed
through unchanged. A non-socket file at the path is never removed.

The bind is factored into a small per-address helper so the multi-socket
change can route each of its sockets through the same repair.

Tests: a stale socket is repaired, a live socket is preserved, a regular
file is left untouched, and an abstract address in use is passed through.

The repair applies on POSIX platforms; on Windows the listener keeps its previous behavior.

Relationship: this is one half of the combined unix-listener change. If
the combined PR is merged, close this one. If this and the multi-socket
PR are merged, close the combined PR.