### PR TITLE
kpclientd: support multiple unix listener sockets

### DIFF
--- a/CONFIG_CHANGES.md
+++ b/CONFIG_CHANGES.md
@@ -338,6 +338,16 @@ The client TOML had the most substantial reshape, driven by the
       Address = "/var/run/katzenpost/kpclientd.sock"
   ```
 
+- **Added** `[Listen.Unix].Addresses` (string array). Optional. The unix
+  listener already bound a single `Address`; with `Addresses` it can bind
+  any number of unix sockets, each a filesystem path or, on Linux, an
+  abstract-namespace name with a leading `@`, in any combination. A
+  thin_client may connect on any of them. An abstract socket has no
+  filesystem permissions, so any process in the network namespace can
+  connect; access control relies on kpclientd running per user (a systemd
+  user service or run by the user), and a peer-credential check is
+  deferred until there is a system-wide daemon.
+
 - **Added** `PigeonholeGeometry` (table). Pigeonhole protocol
   parameters; required for new pigeonhole channel operations.
 

--- a/client/listener.go
+++ b/client/listener.go
@@ -646,6 +646,7 @@ func NewListener(client *Client, rates *Rates, egressCh chan *Request, logBacken
 
 	l.decoySender = newSender(l.PickNextRequest, egressCh, client.cfg.Debug.DisableDecoyTraffic, logBackend)
 
+	client.cfg.Listen.SetLogger(l.log)
 	l.listener, err = client.cfg.Listen.Listen()
 	if err != nil {
 		return nil, err

--- a/client/transport/transport.go
+++ b/client/transport/transport.go
@@ -22,6 +22,10 @@ type Listener interface {
 	Addr() net.Addr
 }
 
+type Logger interface {
+	Errorf(format string, args ...interface{})
+}
+
 // ListenConfig is the subtable-discriminated listen configuration.
 // Exactly one of its pointer fields must be non-nil; zero or two or
 // more is a configuration error.
@@ -29,6 +33,12 @@ type ListenConfig struct {
 	Unix *UnixListenConfig `toml:"Unix,omitempty"`
 	Tcp  *TcpListenConfig  `toml:"Tcp,omitempty"`
 	Ws   *WsListenConfig   `toml:"Ws,omitempty"`
+}
+
+func (c *ListenConfig) SetLogger(log Logger) {
+	if c.Unix != nil {
+		c.Unix.log = log
+	}
 }
 
 // ErrNoTransport is returned when a ListenConfig has no inner config
@@ -59,6 +69,9 @@ func (c *ListenConfig) Validate() error {
 	case 0:
 		return ErrNoTransport
 	case 1:
+		if c.Unix != nil {
+			return c.Unix.Validate()
+		}
 		return nil
 	default:
 		return ErrMultipleTransports

--- a/client/transport/unix.go
+++ b/client/transport/unix.go
@@ -3,11 +3,28 @@
 
 package transport
 
+import (
+	"errors"
+)
+
 // UnixListenConfig configures a unix-domain-socket listener.
 type UnixListenConfig struct {
 	// Address is the path to the unix socket file. The parent
 	// directory must exist and be writable by the daemon; a stale
 	// socket file left by a crashed daemon is cleared on the next
 	// bind, but a socket a live daemon still answers on is left alone.
-	Address string `toml:"Address"`
+	Address   string   `toml:"Address"`
+	Addresses []string `toml:"Addresses,omitempty"`
+
+	log Logger
+}
+
+func (c *UnixListenConfig) Validate() error {
+	for _, a := range append([]string{c.Address}, c.Addresses...) {
+		// "" or "@" would autobind a random abstract socket.
+		if a == "" || a == "@" {
+			return errors.New("transport: empty unix socket address")
+		}
+	}
+	return nil
 }

--- a/client/transport/unix_impl.go
+++ b/client/transport/unix_impl.go
@@ -10,13 +10,30 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
 
 // Listen creates a unix-domain-socket listener bound to c.Address.
 func (c *UnixListenConfig) Listen() (Listener, error) {
-	return listenUnix(c.Address)
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	addresses := append([]string{c.Address}, c.Addresses...)
+	listeners := make([]Listener, 0, len(addresses))
+	for _, address := range addresses {
+		listener, err := listenUnix(address)
+		if err != nil {
+			closeListeners(listeners)
+			return nil, err
+		}
+		listeners = append(listeners, listener)
+	}
+	if len(listeners) == 1 {
+		return listeners[0], nil
+	}
+	return newMultiListener(listeners, c.log), nil
 }
 
 // listenUnix binds a single unix socket, clearing a stale socket file
@@ -56,4 +73,123 @@ func staleUnixSocket(address string) bool {
 		return false
 	}
 	return errors.Is(err, syscall.ECONNREFUSED)
+}
+
+type multiListener struct {
+	listeners []Listener
+	log       Logger
+	accepted  chan net.Conn
+	done      chan struct{}
+	drained   chan struct{}
+	closeOnce sync.Once
+	wg        sync.WaitGroup
+}
+
+func newMultiListener(listeners []Listener, log Logger) *multiListener {
+	m := &multiListener{
+		listeners: listeners,
+		log:       log,
+		accepted:  make(chan net.Conn),
+		done:      make(chan struct{}),
+		drained:   make(chan struct{}),
+	}
+	m.wg.Add(len(listeners))
+	for _, listener := range listeners {
+		go m.accept(listener)
+	}
+	go func() {
+		m.wg.Wait()
+		close(m.drained)
+	}()
+	return m
+}
+
+const acceptRetryDelay = 5 * time.Millisecond
+
+func (m *multiListener) accept(listener Listener) {
+	defer m.wg.Done()
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Temporary() {
+				select {
+				case <-time.After(acceptRetryDelay):
+					continue
+				case <-m.done:
+					return
+				}
+			}
+			if m.log != nil && !isClosing(m.done) {
+				m.log.Errorf("unix listener %s retired: %v", listener.Addr(), err)
+			}
+			listener.Close()
+			return
+		}
+		select {
+		case m.accepted <- conn:
+		case <-m.done:
+			conn.Close()
+			return
+		}
+	}
+}
+
+func (m *multiListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-m.accepted:
+		return conn, nil
+	case <-m.done:
+		return nil, net.ErrClosed
+	case <-m.drained:
+		return nil, net.ErrClosed
+	}
+}
+
+func (m *multiListener) Close() error {
+	err := net.ErrClosed
+	m.closeOnce.Do(func() {
+		close(m.done)
+		err = closeListeners(m.listeners)
+	})
+	m.wg.Wait()
+	return err
+}
+
+func (m *multiListener) Addr() net.Addr {
+	addrs := make(multiAddr, len(m.listeners))
+	for i, l := range m.listeners {
+		addrs[i] = l.Addr()
+	}
+	return addrs
+}
+
+type multiAddr []net.Addr
+
+func (m multiAddr) Network() string { return m[0].Network() }
+
+func (m multiAddr) String() string {
+	s := make([]string, len(m))
+	for i, a := range m {
+		s[i] = a.String()
+	}
+	return strings.Join(s, ", ")
+}
+
+func isClosing(done chan struct{}) bool {
+	select {
+	case <-done:
+		return true
+	default:
+		return false
+	}
+}
+
+func closeListeners(listeners []Listener) error {
+	errs := make([]error, 0, len(listeners))
+	for _, listener := range listeners {
+		if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/client/transport/unix_test.go
+++ b/client/transport/unix_test.go
@@ -4,12 +4,16 @@
 package transport
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -74,27 +78,214 @@ func TestListenConfigListen_Unix(t *testing.T) {
 	require.Equal(t, sockPath, l.Addr().String())
 }
 
-// readUntilEOF wraps a net.Conn and signals EOF after n bytes so
-// io.ReadAll terminates. The thin-client framing layer uses a length
-// prefix; the tests here do not, and need an explicit stopping rule.
-type readUntilEOF struct {
-	r         net.Conn
-	remaining int
+func TestUnixListenerMultiple(t *testing.T) {
+	tmpDir := shortSockDir(t)
+	paths := []string{filepath.Join(tmpDir, "one.sock"), filepath.Join(tmpDir, "two.sock")}
+	l, err := (&UnixListenConfig{Address: paths[0], Addresses: paths[1:]}).Listen()
+	require.NoError(t, err)
+	require.Contains(t, l.Addr().String(), paths[0])
+	require.Contains(t, l.Addr().String(), paths[1])
+	defer l.Close()
+	for _, path := range paths {
+		client, err := net.Dial("unix", path)
+		require.NoError(t, err)
+		server, err := l.Accept()
+		require.NoError(t, err)
+		require.NoError(t, client.Close())
+		require.NoError(t, server.Close())
+	}
+	require.NoError(t, l.Close())
+	_, err = l.Accept()
+	require.Error(t, err)
 }
 
-func (r *readUntilEOF) Read(p []byte) (int, error) {
-	if r.remaining <= 0 {
-		return 0, io.EOF
+func TestUnixListenerClosesAfterBindFailure(t *testing.T) {
+	tmpDir := shortSockDir(t)
+	first := filepath.Join(tmpDir, "one.sock")
+	l, err := (&UnixListenConfig{Address: first, Addresses: []string{filepath.Join(tmpDir, "missing", "two.sock")}}).Listen()
+	require.Error(t, err)
+	require.Nil(t, l)
+	_, err = net.Dial("unix", first)
+	require.Error(t, err)
+}
+
+func TestUnixListenerAbstractAndFile(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("abstract unix sockets are Linux-only")
 	}
-	if len(p) > r.remaining {
-		p = p[:r.remaining]
+	tmpDir := shortSockDir(t)
+	// Unique per process: abstract names share one namespace-global table.
+	abstract := fmt.Sprintf("@kpclientd-test-%d.sock", os.Getpid())
+	file := filepath.Join(tmpDir, "file.sock")
+	l, err := (&UnixListenConfig{Address: abstract, Addresses: []string{file}}).Listen()
+	require.NoError(t, err)
+	require.Contains(t, l.Addr().String(), abstract)
+	require.Contains(t, l.Addr().String(), file)
+	defer l.Close()
+
+	for _, name := range []string{abstract, file} {
+		client, err := net.Dial("unix", name)
+		require.NoError(t, err, "dial %s", name)
+		server, err := l.Accept()
+		require.NoError(t, err)
+		require.NoError(t, client.Close())
+		require.NoError(t, server.Close())
 	}
-	n, err := r.r.Read(p)
-	r.remaining -= n
-	if err == nil && r.remaining <= 0 {
-		err = io.EOF
+
+	// The file socket exists on disk; the abstract one does not.
+	_, err = os.Stat(file)
+	require.NoError(t, err)
+	_, err = os.Stat(abstract)
+	require.Error(t, err)
+}
+
+// Close must not hang or leak with a connection accepted but undelivered.
+func TestUnixListenerCloseDrainsInFlight(t *testing.T) {
+	tmpDir := shortSockDir(t)
+	paths := []string{filepath.Join(tmpDir, "one.sock"), filepath.Join(tmpDir, "two.sock")}
+	l, err := (&UnixListenConfig{Address: paths[0], Addresses: paths[1:]}).Listen()
+	require.NoError(t, err)
+
+	client, err := net.Dial("unix", paths[1])
+	require.NoError(t, err)
+	defer client.Close()
+	// Let the accept goroutine park on the unbuffered channel with no reader.
+	time.Sleep(50 * time.Millisecond)
+
+	closeErr := make(chan error, 1)
+	go func() { closeErr <- l.Close() }()
+	select {
+	case err := <-closeErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close hung with an in-flight connection")
 	}
-	return n, err
+
+	_, err = l.Accept()
+	require.ErrorIs(t, err, net.ErrClosed)
+}
+
+func TestUnixListenerRejectsEmptyAddress(t *testing.T) {
+	l, err := (&UnixListenConfig{Address: ""}).Listen()
+	require.Error(t, err)
+	require.Nil(t, l)
+	// A bare '@' is a nameless abstract socket (kernel autobind); reject.
+	l, err = (&UnixListenConfig{Address: "@"}).Listen()
+	require.Error(t, err)
+	require.Nil(t, l)
+}
+
+func TestUnixListenConfigValidateRejectsEmpty(t *testing.T) {
+	require.Error(t, (&ListenConfig{Unix: &UnixListenConfig{Address: ""}}).Validate())
+	require.Error(t, (&ListenConfig{Unix: &UnixListenConfig{Address: "@"}}).Validate())
+	require.NoError(t, (&ListenConfig{Unix: &UnixListenConfig{Address: "/tmp/x.sock"}}).Validate())
+}
+
+// tempError is a net.Error reporting itself as temporary, like EMFILE.
+type tempError struct{}
+
+func (tempError) Error() string   { return "temporary" }
+func (tempError) Timeout() bool   { return false }
+func (tempError) Temporary() bool { return true }
+
+// fakeListener drives multiListener's accept goroutine from a test.
+type fakeListener struct {
+	closed    chan struct{}
+	closeOnce sync.Once
+	acceptFn  func(closed <-chan struct{}) (net.Conn, error)
+}
+
+func newFake(fn func(closed <-chan struct{}) (net.Conn, error)) *fakeListener {
+	return &fakeListener{closed: make(chan struct{}), acceptFn: fn}
+}
+
+func (f *fakeListener) Accept() (net.Conn, error) { return f.acceptFn(f.closed) }
+func (f *fakeListener) Close() error              { f.closeOnce.Do(func() { close(f.closed) }); return nil }
+func (f *fakeListener) Addr() net.Addr            { return &net.UnixAddr{Name: "fake", Net: "unix"} }
+
+type fakeLogger struct {
+	mu  sync.Mutex
+	msg string
+}
+
+func (l *fakeLogger) Errorf(format string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.msg = fmt.Sprintf(format, args...)
+}
+
+func (l *fakeLogger) last() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.msg
+}
+
+func TestMultiListenerMemberFailureKeepsServing(t *testing.T) {
+	dir := shortSockDir(t)
+	path := filepath.Join(dir, "live.sock")
+	live, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	require.NoError(t, err)
+	failing := newFake(func(<-chan struct{}) (net.Conn, error) { return nil, errors.New("boom") })
+
+	log := &fakeLogger{}
+	m := newMultiListener([]Listener{live, failing}, log)
+	defer m.Close()
+
+	client, err := net.Dial("unix", path)
+	require.NoError(t, err)
+	defer client.Close()
+	conn, err := m.Accept()
+	require.NoError(t, err) // the failing member's error is not surfaced
+	require.NoError(t, conn.Close())
+
+	// The failing member was closed on retirement so dialers get refused,
+	// and the retirement was logged.
+	require.Eventually(t, func() bool {
+		select {
+		case <-failing.closed:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Contains(t, log.last(), "retired")
+}
+
+func TestMultiListenerAllMembersFailDrains(t *testing.T) {
+	dead := func(<-chan struct{}) (net.Conn, error) { return nil, errors.New("dead") }
+	m := newMultiListener([]Listener{newFake(dead), newFake(dead)}, nil)
+	_, err := m.Accept()
+	require.ErrorIs(t, err, net.ErrClosed)
+	require.NoError(t, m.Close())
+}
+
+func TestMultiListenerTemporaryErrorRetries(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close()
+	var mu sync.Mutex
+	var calls int
+	fake := newFake(func(closed <-chan struct{}) (net.Conn, error) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		switch n {
+		case 1:
+			return nil, tempError{} // must be retried, not retired
+		case 2:
+			return server, nil
+		default:
+			<-closed
+			return nil, net.ErrClosed
+		}
+	})
+	m := newMultiListener([]Listener{fake}, nil)
+	defer m.Close()
+
+	conn, err := m.Accept()
+	require.NoError(t, err)
+	require.Equal(t, server, conn)
+	require.NoError(t, conn.Close())
 }
 
 func TestUnixListenerRepairsStaleSocket(t *testing.T) {
@@ -196,7 +387,7 @@ func TestUnixListenerAbstractAddressInUse(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("abstract unix sockets are Linux-only")
 	}
-	address := "@katzenpost-stale-test"
+	address := fmt.Sprintf("@kpclientd-stale-%d", os.Getpid())
 
 	first, err := (&UnixListenConfig{Address: address}).Listen()
 	require.NoError(t, err)
@@ -208,4 +399,27 @@ func TestUnixListenerAbstractAddressInUse(t *testing.T) {
 	_, err = (&UnixListenConfig{Address: address}).Listen()
 	require.Error(t, err)
 	require.False(t, staleUnixSocket(address))
+}
+
+// readUntilEOF wraps a net.Conn and signals EOF after n bytes so
+// io.ReadAll terminates. The thin-client framing layer uses a length
+// prefix; the tests here do not, and need an explicit stopping rule.
+type readUntilEOF struct {
+	r         net.Conn
+	remaining int
+}
+
+func (r *readUntilEOF) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, io.EOF
+	}
+	if len(p) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, err := r.r.Read(p)
+	r.remaining -= n
+	if err == nil && r.remaining <= 0 {
+		err = io.EOF
+	}
+	return n, err
 }


### PR DESCRIPTION
Let kpclientd bind more than one unix listener socket.

Based on the stale-socket repair branch (PR base is that branch), so this
PR's own diff is just the multi-socket feature. Merge the stale-socket PR
first.

We already had a single unix socket listener. This adds
[Listen.Unix].Addresses so the daemon can bind several at once, in any
combination of filesystem paths and leading-@ abstract names. A single
Address behaves exactly as before, so existing configs are unaffected.
Addresses are validated up front, and a bind failure on any one closes
the sockets already opened. Each socket is bound through the stale-socket
repair, so a crashed daemon's leftover socket does not block a restart.

Coverage: TestUnixListenerMultiple binds several sockets and accepts a
connection on each; TestUnixListenerAbstractAndFile does the same across
a mixed abstract and filesystem set; and the multiListener tests cover a
member failing, all members failing, and temporary accept errors.

Relationship: this is the other half of the combined unix-listener
change. If the combined PR is merged, close this one and the stale-socket
PR. If this and the stale-socket PR are merged, close the combined PR.
