### PR TITLE
kpclientd: add optional session dbus name for activation

### DIFF
--- a/CONFIG_CHANGES.md
+++ b/CONFIG_CHANGES.md
@@ -338,6 +338,11 @@ The client TOML had the most substantial reshape, driven by the
       Address = "/var/run/katzenpost/kpclientd.sock"
   ```
 
+- **Added** top-level `DBusName` (string). Optional. A session dbus
+  well-known name the daemon owns for its lifetime, for single-instance
+  ownership and dbus activation. Empty (the default) owns no name and
+  needs no bus; the `--dbus-name` flag overrides it.
+
 - **Added** `PigeonholeGeometry` (table). Pigeonhole protocol
   parameters; required for new pigeonhole channel operations.
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -261,6 +261,9 @@ type Config struct {
 	// "10m" or "30s".
 	SessionGracePeriod time.Duration
 
+	// DBusName is the session dbus name to own; empty owns none.
+	DBusName string
+
 	upstreamProxy *proxy.Config
 }
 

--- a/cmd/kpclientd/dbus.go
+++ b/cmd/kpclientd/dbus.go
@@ -1,0 +1,37 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/godbus/dbus/v5"
+)
+
+type busOwner interface {
+	RequestName(string, dbus.RequestNameFlags) (dbus.RequestNameReply, error)
+	Close() error
+}
+
+func sessionBus() (busOwner, error) {
+	return dbus.ConnectSessionBus()
+}
+
+var connectBus = sessionBus
+
+func ownBusName(name string) (func() error, error) {
+	conn, err := connectBus()
+	if err != nil {
+		return nil, err
+	}
+	reply, err := conn.RequestName(name, dbus.NameFlagDoNotQueue)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if reply != dbus.RequestNameReplyPrimaryOwner {
+		conn.Close()
+		return nil, fmt.Errorf("dbus name %s is already owned", name)
+	}
+	return conn.Close, nil
+}

--- a/cmd/kpclientd/dbus_stub.go
+++ b/cmd/kpclientd/dbus_stub.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package main
+
+import "errors"
+
+func ownBusName(string) (func() error, error) {
+	return nil, errors.New("dbus name ownership is unsupported on this platform")
+}

--- a/cmd/kpclientd/dbus_test.go
+++ b/cmd/kpclientd/dbus_test.go
@@ -1,0 +1,62 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+)
+
+type fakeBus struct {
+	reply  dbus.RequestNameReply
+	err    error
+	closed bool
+}
+
+func (b *fakeBus) RequestName(string, dbus.RequestNameFlags) (dbus.RequestNameReply, error) {
+	return b.reply, b.err
+}
+
+func (b *fakeBus) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestOwnBusName(t *testing.T) {
+	original := connectBus
+	t.Cleanup(func() { connectBus = original })
+	want := errors.New("test")
+	connectBus = func() (busOwner, error) { return nil, want }
+	closeBus, err := ownBusName("test")
+	if !errors.Is(err, want) || closeBus != nil {
+		t.Fatalf("unexpected result: close=%t, err=%v", closeBus != nil, err)
+	}
+	for _, test := range []struct {
+		name string
+		bus  *fakeBus
+	}{
+		{"request", &fakeBus{err: want}},
+		{"owned", &fakeBus{reply: dbus.RequestNameReplyExists}},
+		{"success", &fakeBus{reply: dbus.RequestNameReplyPrimaryOwner}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			connectBus = func() (busOwner, error) { return test.bus, nil }
+			closeBus, err := ownBusName("test")
+			if test.name != "success" {
+				if err == nil || !test.bus.closed {
+					t.Fatalf("got %v, closed %v", err, test.bus.closed)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			closeBus()
+			if !test.bus.closed {
+				t.Fatal("bus not closed")
+			}
+		})
+	}
+}

--- a/cmd/kpclientd/main.go
+++ b/cmd/kpclientd/main.go
@@ -19,10 +19,13 @@ import (
 	"github.com/katzenpost/katzenpost/common/tomlstrict"
 )
 
+const defaultDBusName = "network.katzenpost.kpclientd"
+
 // Config holds the command line configuration
 type Config struct {
 	ConfigFile   string
 	ValidateOnly bool
+	DBusName     string
 }
 
 // newRootCommand creates the root cobra command
@@ -56,7 +59,11 @@ applications to share a single network connection.`,
   kpclientd -c /path/to/custom-client.toml
 
   # Validate the configuration file and exit without side effects
-  kpclientd -c /etc/katzenpost/client.toml --validate-only`,
+  kpclientd -c /etc/katzenpost/client.toml --validate-only
+
+  # Own a session dbus name for the daemon's lifetime
+  kpclientd -c /etc/katzenpost/client.toml --dbus-name=network.katzenpost.kpclientd`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runClientDaemon(cfg)
 		},
@@ -69,6 +76,9 @@ applications to share a single network connection.`,
 	// Operation mode flags
 	cmd.Flags().BoolVar(&cfg.ValidateOnly, "validate-only", false,
 		"load and validate the configuration file, then exit without side effects")
+	cmd.Flags().StringVar(&cfg.DBusName, "dbus-name", "",
+		"own this session dbus name (bare flag defaults to "+defaultDBusName+")")
+	cmd.Flags().Lookup("dbus-name").NoOptDefVal = defaultDBusName
 
 	// Mark required flags
 	cmd.MarkFlagRequired("config")
@@ -96,6 +106,21 @@ func runClientDaemon(cfg Config) error {
 		}
 		fmt.Fprintf(os.Stdout, "configuration file '%v' is valid\n", cfg.ConfigFile)
 		return nil
+	}
+	dbusName := clientCfg.DBusName
+	if cfg.DBusName != "" {
+		dbusName = cfg.DBusName
+	}
+	if dbusName != "" {
+		closeBus, err := ownBusName(dbusName)
+		if err != nil {
+			return fmt.Errorf("failed to own dbus name: %w", err)
+		}
+		defer func() {
+			if err := closeBus(); err != nil {
+				fmt.Fprintf(os.Stderr, "releasing dbus name %q: %v\n", dbusName, err)
+			}
+		}()
 	}
 
 	// Start the prometheus listener before the daemon so that any

--- a/cmd/kpclientd/main_test.go
+++ b/cmd/kpclientd/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestDefaultDBusNameIsValidWellKnownName(t *testing.T) {
+	// A dbus well-known name is two or more '.'-separated elements, each
+	// [A-Za-z_-][A-Za-z0-9_-]*.
+	re := regexp.MustCompile(`^[A-Za-z_-][A-Za-z0-9_-]*(\.[A-Za-z_-][A-Za-z0-9_-]*)+$`)
+	if !re.MatchString(defaultDBusName) {
+		t.Fatalf("defaultDBusName %q is not a valid dbus well-known name", defaultDBusName)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/katzenpost/katzenpost
 go 1.26.2
 
 require (
+	github.com/godbus/dbus/v5 v5.1.0
 	charm.land/lipgloss/v2 v2.0.2
 	github.com/BurntSushi/toml v1.6.0
 	github.com/carlmjohnson/versioninfo v0.22.5

--- a/go.sum
+++ b/go.sum
@@ -820,3 +820,6 @@ rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
 rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=


### PR DESCRIPTION
Adds an optional session dbus name to kpclientd, off by default and Linux
only, behind a --dbus-name flag and DBusName config. The godbus
dependency is stubbed elsewhere so it never blocks other builds.

Rationale, ordered by how a thin_client uses the name:

1. Presence and activation. Is the daemon there? If not, a Peer.Ping
   autostarts it on the host from its .service file. The katzenqt GUI
   runs in a flatpak with no network and cannot spawn a daemon itself,
   so it needs this.
2. Liveness. Is kpclientd running? The name is held only while the
   process runs, so it is a simple explicit signal of the daemon's
   presence rather than an implicit one inferred from a socket. A crashed
   kpclientd stops owning the name at once.
3. Network. Is a mixnet reachable? A separate signal the thin_client gets
   by talking to kpclientd, e.g. polling consensus. When kpclientd is up,
   katzenqt can show useful state, for example a widget saying the daemon
   works but consensus has not formed yet.
4. Single instance. RequestName(DoNotQueue) keeps exactly one owner.
5. Flatpak security. --talk-name is the least-privilege way for the GUI
   to start and reach a host daemon, with no network or process-spawning
   rights granted to the sandbox.

Companion changes harden this same path: one repairs a stale unix socket
on the next bind, another fixes shutdown hangs and connection races. Even
with all of them landed, socket activation alone cannot report whether
kpclientd is up, and a socket's presence, including one freshly rebound
by the repair, does not mean a live daemon is behind it: it may be down,
crash-looping to its restart limit, or stuck without consensus. The dbus
name is held only by a running owner and drops the instant it dies, and
in a flatpak with no network or spawn rights it is the only way for the
GUI to activate and reach a host daemon.

Relationship: independent of the unix-listener changes; merges in any
order. Only touches CONFIG_CHANGES.md in common with them, a trivial
conflict.
