### PR TITLE
courier: retry a transient replication failure during Copy

### DIFF
--- a/courier/server/copy_dispatch_test.go
+++ b/courier/server/copy_dispatch_test.go
@@ -215,6 +215,54 @@ func TestDispatchCopyEnvelopeSingleBoxAlreadyExistsAborts(t *testing.T) {
 	}
 }
 
+// TestDispatchCopyEnvelopeReplicationFailedRetries pins that a transient
+// ReplicaErrorReplicationFailed (a peer-replica blip) is retried rather
+// than aborting the Copy, and succeeds once the blip clears.
+func TestDispatchCopyEnvelopeReplicationFailedRetries(t *testing.T) {
+	courier := createTestCourier(t)
+	conn := newFakeConnector()
+	courier.server.connector = conn
+
+	envelope := buildTestCourierEnvelope()
+	envHash := envelope.EnvelopeHash()
+
+	type result struct {
+		ok   bool
+		code uint8
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		ok, code := courier.dispatchCopyEnvelope(envelope)
+		resultCh <- result{ok, code}
+	}()
+
+	waitForSends := func(round int) {
+		for i := 0; i < 2; i++ {
+			select {
+			case <-conn.sendCalledCh:
+			case <-time.After(3 * time.Second):
+				t.Fatalf("round %d SendMessage %d not observed in time", round, i+1)
+			}
+		}
+	}
+
+	waitForSends(1)
+	courier.HandleReply(&commands.ReplicaMessageReply{EnvelopeHash: envHash, ReplicaID: 1, ErrorCode: pigeonhole.ReplicaErrorReplicationFailed})
+	courier.HandleReply(&commands.ReplicaMessageReply{EnvelopeHash: envHash, ReplicaID: 2, ErrorCode: pigeonhole.ReplicaErrorReplicationFailed})
+
+	waitForSends(2)
+	courier.HandleReply(&commands.ReplicaMessageReply{EnvelopeHash: envHash, ReplicaID: 1, ErrorCode: pigeonhole.ReplicaSuccess})
+	courier.HandleReply(&commands.ReplicaMessageReply{EnvelopeHash: envHash, ReplicaID: 2, ErrorCode: pigeonhole.ReplicaSuccess})
+
+	select {
+	case r := <-resultCh:
+		require.True(t, r.ok, "a transient ReplicationFailed must be retried, not aborted")
+		require.Equal(t, uint8(0), r.code)
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatchCopyEnvelope did not return in time")
+	}
+}
+
 // TestDispatchCopyEnvelopeAllSuccess is the happy path — both
 // intermediates write cleanly.
 func TestDispatchCopyEnvelopeAllSuccess(t *testing.T) {

--- a/courier/server/copy_errors.go
+++ b/courier/server/copy_errors.go
@@ -39,3 +39,17 @@ func classifyReplicaErrorForCopyRead(code uint8) replicaErrorCategory {
 	}
 	return replicaErrorPermanent
 }
+
+// classifyReplicaErrorForCopyWrite mirrors classifyReplicaErrorForCopyRead
+// for the Copy write path, without ReplicaErrorBoxIDNotFound, which is a
+// read-only outcome.
+func classifyReplicaErrorForCopyWrite(code uint8) replicaErrorCategory {
+	switch code {
+	case pigeonhole.ReplicaErrorStorageFull,
+		pigeonhole.ReplicaErrorDatabaseFailure,
+		pigeonhole.ReplicaErrorInternalError,
+		pigeonhole.ReplicaErrorReplicationFailed:
+		return replicaErrorTemporary
+	}
+	return replicaErrorPermanent
+}

--- a/courier/server/copy_errors_test.go
+++ b/courier/server/copy_errors_test.go
@@ -56,3 +56,34 @@ func TestClassifyReplicaErrorForCopyReadUnknown(t *testing.T) {
 			"unknown code %d must classify as permanent", code)
 	}
 }
+
+// TestClassifyReplicaErrorForCopyWrite pins the write-path reaction,
+// which matches the read path except that BoxIDNotFound is permanent on
+// a write (it is a read-only outcome) and unknown codes fail closed.
+func TestClassifyReplicaErrorForCopyWrite(t *testing.T) {
+	temporary := []uint8{
+		pigeonhole.ReplicaErrorStorageFull,
+		pigeonhole.ReplicaErrorDatabaseFailure,
+		pigeonhole.ReplicaErrorInternalError,
+		pigeonhole.ReplicaErrorReplicationFailed,
+	}
+	for _, code := range temporary {
+		require.Equal(t, replicaErrorTemporary,
+			classifyReplicaErrorForCopyWrite(code), "code=%d", code)
+	}
+
+	permanent := []uint8{
+		pigeonhole.ReplicaErrorBoxIDNotFound,
+		pigeonhole.ReplicaErrorInvalidBoxID,
+		pigeonhole.ReplicaErrorInvalidSignature,
+		pigeonhole.ReplicaErrorInvalidPayload,
+		pigeonhole.ReplicaErrorInvalidEpoch,
+		pigeonhole.ReplicaErrorBoxAlreadyExists,
+		pigeonhole.ReplicaErrorTombstone,
+		42, 255,
+	}
+	for _, code := range permanent {
+		require.Equal(t, replicaErrorPermanent,
+			classifyReplicaErrorForCopyWrite(code), "code=%d", code)
+	}
+}

--- a/courier/server/plugin.go
+++ b/courier/server/plugin.go
@@ -1082,16 +1082,17 @@ func (e *Courier) processCopyCommand(copyCmd *pigeonhole.CopyCommand) *pigeonhol
 //     only (no replica reply ever arrived).
 //
 // The replica state layer treats byte-identical retries as idempotent
-// success (see replica/state.go), so a non-Success reply reflects a
-// genuine conflict — retrying will not change the verdict and the
-// dispatch aborts on the first one. Retries are reserved for
-// transport-level failures: SendMessage errors and "no replies before
-// the deadline." No shard-level failover is available on the write
-// path because the two intermediate replicas are MKEM-baked into the
-// client's envelope.
+// success (see replica/state.go). A permanent non-Success reply (e.g.
+// BoxAlreadyExists) reflects a genuine conflict and aborts the dispatch
+// at once; a transient one (e.g. a ReplicationFailed peer-replica blip)
+// is retried with backoff, as are transport-level failures (SendMessage
+// errors and "no replies before the deadline"). No shard-level failover
+// is available on the write path because the two intermediate replicas
+// are MKEM-baked into the client's envelope.
 func (e *Courier) dispatchCopyEnvelope(envelope *pigeonhole.CourierEnvelope) (bool, uint8) {
 	envHash := envelope.EnvelopeHash()
 
+	lastTransientErr := uint8(0)
 	for attempt := 0; attempt < maxCopyWriteAttempts; attempt++ {
 		if attempt > 0 {
 			time.Sleep(copyAttemptBackoff(attempt - 1))
@@ -1140,19 +1141,26 @@ func (e *Courier) dispatchCopyEnvelope(envelope *pigeonhole.CourierEnvelope) (bo
 			}
 		}
 
-		// Any non-Success reply is terminal. Prefer BoxAlreadyExists
-		// as the reportable code — it's the most diagnostic signal
-		// for the client's Copy failure report.
-		if len(replies) > 0 {
-			bestErr := replies[0].ErrorCode
-			for _, r := range replies {
-				if r.ErrorCode == pigeonhole.ReplicaErrorBoxAlreadyExists {
-					bestErr = r.ErrorCode
-					break
+		// A permanent non-Success reply aborts at once (preferring
+		// BoxAlreadyExists as the most diagnostic code); a transient one
+		// falls through to the retry loop.
+		permanentErr := uint8(0)
+		for _, r := range replies {
+			if classifyReplicaErrorForCopyWrite(r.ErrorCode) == replicaErrorPermanent {
+				if permanentErr == 0 || r.ErrorCode == pigeonhole.ReplicaErrorBoxAlreadyExists {
+					permanentErr = r.ErrorCode
 				}
+			} else {
+				lastTransientErr = r.ErrorCode
 			}
-			e.log.Warningf("dispatchCopyEnvelope: replica error %d, aborting Copy", bestErr)
-			return false, bestErr
+		}
+		if permanentErr != 0 {
+			e.log.Warningf("dispatchCopyEnvelope: replica error %d, aborting Copy", permanentErr)
+			return false, permanentErr
+		}
+		if len(replies) > 0 {
+			e.log.Warningf("dispatchCopyEnvelope: attempt %d transient replica error %d, retrying", attempt+1, lastTransientErr)
+			continue
 		}
 
 		// No replies before the deadline — transport failure. Retry.
@@ -1161,7 +1169,7 @@ func (e *Courier) dispatchCopyEnvelope(envelope *pigeonhole.CourierEnvelope) (bo
 
 	e.log.Errorf("dispatchCopyEnvelope: exhausted %d attempts, aborting Copy", maxCopyWriteAttempts)
 	instrument.DroppedByReason("copy_dispatch_exhausted")
-	return false, 0
+	return false, lastTransientErr
 }
 
 // readNextBox reads a single box from the shard replicas, decrypts it,


### PR DESCRIPTION
Retry a transient replication failure during a Copy command instead of
aborting it.

The Copy read path already classifies ReplicaErrorReplicationFailed as a
temporary peer-replica blip and retries it. The write path did not:
dispatchCopyEnvelope treated any non-Success reply as terminal and
aborted the whole Copy on the first one. A replica returns
ReplicaErrorReplicationFailed (replica/handlers.go) when its own
write-proxy sweep to a shard peer transiently fails, so under load one
intermediate replica's momentary blip aborts the Copy with
"replication failed (failed envelope index N)".

This is an intermittent docker e2e failure in the Copy tests
(TestCreateCourierEnvelopesFromPayload, TestCopyCommandMultiChannel,
TestFromMultiPayloadMultiCall).

The fix classifies write-path replies the same way as the read path: a
permanent error such as BoxAlreadyExists still aborts at once, but a
transient one is retried with backoff under the existing
maxCopyWriteAttempts budget. Byte-identical rewrites are idempotent
(replica/state.go), so the retry is safe; on exhaustion the last
transient code is reported instead of 0.

Tests: a dispatch test asserts a ReplicationFailed reply is retried and
then succeeds, plus a classifier test for the write path. Verified with
the full courier/server package under -race.

Note: this fixes only the "replication failed" Copy flake. A separate
e2e flake (echo "timed out waiting for reply", e.g.
TestDockerMultiplexClients) is unrelated and not addressed here.
