### PR TITLE
client: wait longer than the worst-case round trip in sendAndWait

### DIFF
--- a/client/docker_test_helpers.go
+++ b/client/docker_test_helpers.go
@@ -24,6 +24,10 @@ import (
 const (
 	defaultThinClientConfigFile = "testdata/thinclient.toml"
 	defaultTestLogLevel         = "DEBUG"
+
+	// Above the docker testnet's ~54s worst-case round trip, so a
+	// tail-latency reply is not mistaken for a lost one.
+	replyWaitTimeout = 3 * time.Minute
 )
 
 var (
@@ -139,7 +143,7 @@ func sendAndWait(t *testing.T, client *thin.ThinClient, message []byte, nodeID *
 		return nil, fmt.Errorf("SendMessage: %w", err)
 	}
 
-	timeout := time.After(1 * time.Minute)
+	timeout := time.After(replyWaitTimeout)
 	for {
 		var event thin.Event
 		select {


### PR DESCRIPTION
Fix a CI flake in the docker end-to-end tests (TestDockerMultiplexClients
and other sendAndWait callers).

sendAndWait waited a fixed one minute for a reply, but the docker
testnet's own worst-case round trip is about 54s (the run-ping banner
reports it). A reply that draws the tail of the per-hop Poisson delay,
plus crypto and scheduling overhead the Sphinx delay does not encode and
that -race inflates further, can exceed a minute and time out a healthy
reply, failing all of retrySubtest's attempts.

This raises the wait to three minutes so only a genuinely lost reply
times out. Test-only; retrySubtest still bounds attempts. It is the
fixed-timeout counterpart to the derived timeout cmd/ping already uses.

It does not address the separate 1-hour suite hang seen on some runs,
which is a stalled copy in the courier path.
