### PR TITLE
client/thin: bound the resend wait with an optional context

### DIFF
--- a/client/thin/pigeonhole.go
+++ b/client/thin/pigeonhole.go
@@ -5,6 +5,7 @@ package thin
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 
@@ -497,7 +498,12 @@ func (t *ThinClient) EncryptWrite(plaintext []byte, writeCap *bacap.WriteCap, me
 //	}
 //	fmt.Printf("Received: %s\n", result.Plaintext)
 func (t *ThinClient) StartResendingEncryptedMessage(readCap *bacap.ReadCap, writeCap *bacap.WriteCap, messageBoxIndex []byte, replyIndex *uint8, envelopeDescriptor []byte, messageCiphertext []byte, envelopeHash *[32]byte) (*StartResendingResult, error) {
-	return t.startResendingEncryptedMessageImpl(readCap, writeCap, messageBoxIndex, replyIndex, envelopeDescriptor, messageCiphertext, envelopeHash, false, false)
+	return t.startResendingEncryptedMessageImpl(context.Background(), readCap, writeCap, messageBoxIndex, replyIndex, envelopeDescriptor, messageCiphertext, envelopeHash, false, false)
+}
+
+// StartResendingEncryptedMessageWithContext stops waiting when ctx is done.
+func (t *ThinClient) StartResendingEncryptedMessageWithContext(ctx context.Context, readCap *bacap.ReadCap, writeCap *bacap.WriteCap, messageBoxIndex []byte, replyIndex *uint8, envelopeDescriptor []byte, messageCiphertext []byte, envelopeHash *[32]byte) (*StartResendingResult, error) {
+	return t.startResendingEncryptedMessageImpl(ctx, readCap, writeCap, messageBoxIndex, replyIndex, envelopeDescriptor, messageCiphertext, envelopeHash, false, false)
 }
 
 // StartResendingEncryptedMessageNoRetry behaves exactly like
@@ -508,7 +514,7 @@ func (t *ThinClient) StartResendingEncryptedMessage(readCap *bacap.ReadCap, writ
 //
 // An in-flight call may be cancelled via CancelResendingEncryptedMessage.
 func (t *ThinClient) StartResendingEncryptedMessageNoRetry(readCap *bacap.ReadCap, writeCap *bacap.WriteCap, messageBoxIndex []byte, replyIndex *uint8, envelopeDescriptor []byte, messageCiphertext []byte, envelopeHash *[32]byte) (*StartResendingResult, error) {
-	return t.startResendingEncryptedMessageImpl(readCap, writeCap, messageBoxIndex, replyIndex, envelopeDescriptor, messageCiphertext, envelopeHash, true, false)
+	return t.startResendingEncryptedMessageImpl(context.Background(), readCap, writeCap, messageBoxIndex, replyIndex, envelopeDescriptor, messageCiphertext, envelopeHash, true, false)
 }
 
 // StartResendingEncryptedMessageReturnBoxExists behaves exactly like
@@ -524,7 +530,7 @@ func (t *ThinClient) StartResendingEncryptedMessageNoRetry(readCap *bacap.ReadCa
 //
 // An in-flight call may be cancelled via CancelResendingEncryptedMessage.
 func (t *ThinClient) StartResendingEncryptedMessageReturnBoxExists(readCap *bacap.ReadCap, writeCap *bacap.WriteCap, messageBoxIndex []byte, replyIndex *uint8, envelopeDescriptor []byte, messageCiphertext []byte, envelopeHash *[32]byte) (*StartResendingResult, error) {
-	return t.startResendingEncryptedMessageImpl(readCap, writeCap, messageBoxIndex, replyIndex, envelopeDescriptor, messageCiphertext, envelopeHash, false, true)
+	return t.startResendingEncryptedMessageImpl(context.Background(), readCap, writeCap, messageBoxIndex, replyIndex, envelopeDescriptor, messageCiphertext, envelopeHash, false, true)
 }
 
 // startResendingEncryptedMessageImpl is the shared implementation behind
@@ -535,6 +541,7 @@ func (t *ThinClient) StartResendingEncryptedMessageReturnBoxExists(readCap *baca
 // daemon to fetch and return the replica's BoxAlreadyExists code
 // rather than swallowing it as idempotent success.
 func (t *ThinClient) startResendingEncryptedMessageImpl(
+	ctx context.Context,
 	readCap *bacap.ReadCap,
 	writeCap *bacap.WriteCap,
 	messageBoxIndex []byte,
@@ -585,15 +592,13 @@ func (t *ThinClient) startResendingEncryptedMessageImpl(
 		return nil, err
 	}
 
-	// Wait for reply from daemon — blocks forever until success, error, or Close()
-	// For writes: daemon sends reply after receiving ACK (or payload, if
-	// noIdempotentBoxAlreadyExists is set — two round-trips in that case).
-	// For reads: daemon sends reply after receiving payload (after ACK).
-	// The daemon may also send error responses (e.g., BoxIDNotFound) which will cause this to exit.
+	// Wait for the daemon's reply, ctx cancellation, or Close().
 	for {
 		var event Event
 		select {
 		case event = <-eventSink:
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		case <-t.HaltCh():
 			return nil, errHalting
 		}

--- a/client/thin/pigeonhole_test.go
+++ b/client/thin/pigeonhole_test.go
@@ -4,9 +4,11 @@
 package thin
 
 import (
+	"context"
 	"errors"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/fxamacker/cbor/v2"
 
@@ -429,6 +431,27 @@ func TestStartResendingEncryptedMessageWriteSuccess(t *testing.T) {
 	require.NotNil(t, result)
 	require.Equal(t, courierHash, result.CourierIdentityHash)
 	require.Equal(t, []byte("queue1"), result.CourierQueueID)
+}
+
+func TestStartResendingEncryptedMessageWithContextDeadline(t *testing.T) {
+	tc, server := setupMockDaemon(t)
+
+	go func() { _, _ = readRequest(server) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := tc.StartResendingEncryptedMessageWithContext(
+		ctx,
+		nil,
+		newTestWriteCap(t),
+		nil,
+		nil,
+		[]byte("desc"),
+		[]byte("cipher"),
+		&[32]byte{7, 8, 9},
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestStartResendingEncryptedMessageReadSuccess(t *testing.T) {


### PR DESCRIPTION
Give a caller a way to bound how long StartResendingEncryptedMessage
waits for the daemon. The wait had no deadline, so a stalled operation
blocked the caller indefinitely; in the docker end-to-end suite a copy
that never completed hung the whole run until its one-hour cap.

This threads a context through the wait and adds
StartResendingEncryptedMessageWithContext. The three existing methods
pass context.Background(), so reads that wait for a not-yet-written box
keep their unbounded behavior; only a caller that opts into a context can
time the wait out. Underlying copy stalls are fixed at the courier
separately (the copy-replication PR); this is defense in depth.
