### PR TITLE
client/config: fix race condition in TestUnmarshalTOML

### DIFF
--- a/client/config/config_validation_test.go
+++ b/client/config/config_validation_test.go
@@ -462,7 +462,13 @@ func TestUnmarshalTOML(t *testing.T) {
 
 		pinnedGateways := raw["PinnedGateways"].(map[string]interface{})
 		gateways := pinnedGateways["Gateways"].([]map[string]interface{})
-		gw0 := gateways[0]
+		gw0Orig := gateways[0]
+
+		// Copy the gateway data to avoid mutating shared test data
+		gw0 := make(map[string]interface{})
+		for k, v := range gw0Orig {
+			gw0[k] = v
+		}
 
 		// Override Addresses with a non-slice
 		gw0["Addresses"] = "not-a-slice"
@@ -480,7 +486,13 @@ func TestUnmarshalTOML(t *testing.T) {
 
 		pinnedGateways := raw["PinnedGateways"].(map[string]interface{})
 		gateways := pinnedGateways["Gateways"].([]map[string]interface{})
-		gw0 := gateways[0]
+		gw0Orig := gateways[0]
+
+		// Copy the gateway data to avoid mutating shared test data
+		gw0 := make(map[string]interface{})
+		for k, v := range gw0Orig {
+			gw0[k] = v
+		}
 
 		gw0["Addresses"] = []interface{}{"http://invalid:1234"}
 		gw := &Gateway{}


### PR DESCRIPTION
The test was mutating shared gateway data across subtests, causing a race condition that manifests as memory corruption on Windows with the race detector enabled. Fix by copying the gateway map before modifying Addresses in each subtest, preventing mutation of the shared parsed TOML data.