### PR TITLE
Cbor plugin startup diagnostics

### DIFF
--- a/cmd/courier/main.go
+++ b/cmd/courier/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/katzenpost/katzenpost/common/tomlstrict"
 	"github.com/katzenpost/katzenpost/courier/server"
 	"github.com/katzenpost/katzenpost/courier/server/config"
+	"github.com/katzenpost/katzenpost/server/cborplugin"
 )
 
 func main() {
@@ -36,7 +37,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "configuration file '%v' is invalid: %v\n", configFile, err)
 			os.Exit(1)
 		}
-		panic(err)
+		cborplugin.FailStartup("courier", err)
 	}
 	if validateOnly {
 		if err := tomlstrict.Check(configFile, new(config.Config)); err != nil {
@@ -49,7 +50,7 @@ func main() {
 
 	s, err := server.New(cfg, nil)
 	if err != nil {
-		panic(err)
+		cborplugin.FailStartup("courier", err)
 	}
 
 	// blocks until service node disconnect

--- a/cmd/echo-plugin/main.go
+++ b/cmd/echo-plugin/main.go
@@ -59,19 +59,17 @@ func main() {
 	// Ensure that the log directory exists.
 	s, err := os.Stat(logDir)
 	if os.IsNotExist(err) {
-		fmt.Printf("Log directory '%s' doesn't exist.", logDir)
-		os.Exit(1)
+		cborplugin.FailStartup("echo-plugin", fmt.Errorf("log directory %q doesn't exist", logDir))
 	}
 	if !s.IsDir() {
-		fmt.Println("Log directory must actually be a directory.")
-		os.Exit(1)
+		cborplugin.FailStartup("echo-plugin", fmt.Errorf("log directory %q is not a directory", logDir))
 	}
 
 	// Log to a file.
 	logFile := path.Join(logDir, fmt.Sprintf("echo.%d.log", os.Getpid()))
 	logBackend, err := log.New(logFile, logLevel, false)
 	if err != nil {
-		panic(err)
+		cborplugin.FailStartup("echo-plugin", err)
 	}
 	serverLog := logBackend.GetLogger("echo_server")
 	serverLog.Noticef("Katzenpost echo-plugin version: %s", kpcommon.Version())
@@ -80,7 +78,7 @@ func main() {
 	// start service
 	tmpDir, err := os.MkdirTemp("", "echo_server")
 	if err != nil {
-		panic(err)
+		cborplugin.FailStartup("echo-plugin", err)
 	}
 	socketFile := filepath.Join(tmpDir, fmt.Sprintf("%d.echo.socket", os.Getpid()))
 	echo := new(Echo)

--- a/cmd/http-proxy-server/main.go
+++ b/cmd/http-proxy-server/main.go
@@ -109,19 +109,17 @@ func main() {
 	// Ensure that the log directory exists.
 	s, err := os.Stat(logDir)
 	if os.IsNotExist(err) {
-		fmt.Printf("Log directory '%s' doesn't exist.", logDir)
-		os.Exit(1)
+		cborplugin.FailStartup("http-proxy-server", fmt.Errorf("log directory %q doesn't exist", logDir))
 	}
 	if !s.IsDir() {
-		fmt.Println("Log directory must actually be a directory.")
-		os.Exit(1)
+		cborplugin.FailStartup("http-proxy-server", fmt.Errorf("log directory %q is not a directory", logDir))
 	}
 
 	// Log to a file.
 	logFile := path.Join(logDir, fmt.Sprintf("proxy.%d.log", os.Getpid()))
 	logBackend, err := log.New(logFile, logLevel, false)
 	if err != nil {
-		panic(err)
+		cborplugin.FailStartup("http-proxy-server", err)
 	}
 	serverLog := logBackend.GetLogger("http_proxy")
 	serverLog.Noticef("Katzenpost http-proxy-server version: %s", kpcommon.Version())
@@ -130,7 +128,7 @@ func main() {
 	// start service
 	tmpDir, err := ioutil.TempDir("", "http_proxy")
 	if err != nil {
-		panic(err)
+		cborplugin.FailStartup("http-proxy-server", err)
 	}
 	socketFile := filepath.Join(tmpDir, fmt.Sprintf("%d.http_proxy.socket", os.Getpid()))
 

--- a/core/log/log.go
+++ b/core/log/log.go
@@ -143,6 +143,14 @@ func (b *Backend) Rotate() error {
 	return err
 }
 
+// Close releases the backend's underlying log output, e.g. a file handle.
+func (b *Backend) Close() error {
+	b.Lock()
+	defer b.Unlock()
+
+	return b.w.Close()
+}
+
 func (b *Backend) newBackend() error {
 	lvl, err := logLevelFromString(b.level)
 	if err != nil {

--- a/courier/server/server.go
+++ b/courier/server/server.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"gopkg.in/op/go-logging.v1"
@@ -112,7 +113,7 @@ func (s *Server) initializeLinkKeys() error {
 
 	scheme := schemes.ByName(s.cfg.WireKEMScheme)
 	if scheme == nil {
-		panic("KEM scheme not found")
+		return fmt.Errorf("courier: KEM scheme %q not found", s.cfg.WireKEMScheme)
 	}
 
 	var linkPublicKey kem.PublicKey
@@ -129,9 +130,9 @@ func (s *Server) initializeLinkKeys() error {
 			return err
 		}
 	} else if utils.BothNotExists(linkPrivateKeyFile, linkPublicKeyFile) {
-		panic("No link keys found.")
+		return fmt.Errorf("courier: no link keys found in %q", s.cfg.DataDir)
 	} else {
-		panic("Improbable: Only found one link PEM file.")
+		return fmt.Errorf("courier: only one of the two link key PEM files exists in %q", s.cfg.DataDir)
 	}
 	s.linkPrivKey = linkPrivateKey
 	s.linkPubKey = linkPublicKey

--- a/server/cborplugin/bootstrap.go
+++ b/server/cborplugin/bootstrap.go
@@ -1,0 +1,32 @@
+// bootstrap.go - shared startup-failure reporting for cbor plugins
+// Copyright (C) 2026  David Stainton.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cborplugin
+
+import (
+	"fmt"
+	"os"
+)
+
+// FailStartup reports a plugin initialization failure and exits. Plugins
+// must call this instead of panicking when they fail before completing the
+// socket-path handshake, so the launching service node's captured stderr
+// carries one clean, single-line reason instead of a multi-frame panic
+// trace.
+func FailStartup(component string, err error) {
+	fmt.Fprintf(os.Stderr, "%s: failed to start: %v\n", component, err)
+	os.Exit(1)
+}

--- a/server/cborplugin/client.go
+++ b/server/cborplugin/client.go
@@ -25,15 +25,19 @@ package cborplugin
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os/exec"
+	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/fxamacker/cbor/v2"
+	"gopkg.in/op/go-logging.v1"
+
 	"github.com/katzenpost/katzenpost/core/log"
 	"github.com/katzenpost/katzenpost/core/worker"
-	"gopkg.in/op/go-logging.v1"
 )
 
 // Request is the struct type used in service query requests to plugins.
@@ -157,6 +161,39 @@ type ServicePlugin interface {
 	Halt()
 }
 
+const (
+	maxStderrTailLines = 60
+	maxStderrTailBytes = 8192
+)
+
+// stderrTail keeps a bounded tail of a plugin's stderr output, for
+// inclusion in a startup-failure diagnostic. Safe for concurrent use.
+type stderrTail struct {
+	mu    sync.Mutex
+	lines []string
+	bytes int
+}
+
+func (t *stderrTail) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, line := range strings.Split(strings.TrimRight(string(p), "\n"), "\n") {
+		t.lines = append(t.lines, line)
+		t.bytes += len(line)
+	}
+	for len(t.lines) > 1 && (len(t.lines) > maxStderrTailLines || t.bytes > maxStderrTailBytes) {
+		t.bytes -= len(t.lines[0])
+		t.lines = t.lines[1:]
+	}
+	return len(p), nil
+}
+
+func (t *stderrTail) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return strings.Join(t.lines, "\n")
+}
+
 // Client acts as a client interacting with one or more plugins.
 // The Client type is composite with Worker and therefore
 // has a Halt method. Client implements this interface
@@ -174,6 +211,8 @@ type Client struct {
 	socketFile string
 	cmd        *exec.Cmd
 	//conn       net.Conn
+
+	stderrTail stderrTail
 
 	commandBuilder CommandBuilder
 
@@ -214,7 +253,13 @@ func (c *Client) Start(command string, args []string) error {
 		return err
 	}
 	c.Go(c.reaper)
-	c.socket.Start(true, c.socketFile, c.commandBuilder)
+	// c.HaltCh() is closed by logPluginStderr as soon as the plugin's
+	// stderr pipe closes, which happens shortly after the process exits.
+	// Passing it through lets the dial loop below give up immediately on
+	// a plugin that already died, instead of blind-retrying for ~40s.
+	if err := c.socket.Start(true, c.socketFile, c.commandBuilder, c.HaltCh()); err != nil {
+		return fmt.Errorf("plugin %q failed to start: %w; stderr:\n%s", command, err, c.stderrTail.String())
+	}
 	return nil
 }
 
@@ -232,7 +277,7 @@ func (c *Client) reaper() {
 
 func (c *Client) logPluginStderr(stderr io.ReadCloser) {
 	logWriter := c.logBackend.GetLogWriter(c.cmd.Path, "DEBUG")
-	_, err := io.Copy(logWriter, stderr)
+	_, err := io.Copy(io.MultiWriter(logWriter, &c.stderrTail), stderr)
 	if err != nil {
 		c.log.Errorf("Failed to proxy cborplugin stderr to DEBUG log: %s", err)
 	}
@@ -258,7 +303,7 @@ func (c *Client) launch(command string, args []string) error {
 		return err
 	}
 
-	// proxy stderr to our debug log
+	// proxy stderr to our debug log and a bounded tail buffer
 	// also calls Halt() when stderr closes, if the program crashes or is killed
 	c.Go(func() {
 		c.logPluginStderr(stderr)
@@ -266,10 +311,33 @@ func (c *Client) launch(command string, args []string) error {
 
 	// read and decode plugin stdout
 	stdoutScanner := bufio.NewScanner(stdout)
-	stdoutScanner.Scan()
+	if !stdoutScanner.Scan() {
+		return c.earlyExitError(command, stdoutScanner.Err())
+	}
 	c.socketFile = stdoutScanner.Text()
+	if c.socketFile == "" {
+		return c.earlyExitError(command, fmt.Errorf("plugin printed an empty socket path"))
+	}
 	c.log.Debugf("plugin socket path:'%s'\n", c.socketFile)
 	return nil
+}
+
+// earlyExitError is returned by launch when the plugin's stdout closed
+// without ever providing a usable socket path, i.e. it exited (or crashed)
+// during its own initialization. It waits briefly for the concurrent
+// logPluginStderr goroutine to finish draining stderr, so the captured tail
+// is complete, before reaping the process and composing a diagnostic error.
+func (c *Client) earlyExitError(command string, scanErr error) error {
+	select {
+	case <-c.HaltCh():
+	case <-time.After(2 * time.Second):
+	}
+	c.cmd.Wait()
+	tail := c.stderrTail.String()
+	if scanErr != nil {
+		return fmt.Errorf("plugin %q exited before providing a socket path (%v); stderr:\n%s", command, scanErr, tail)
+	}
+	return fmt.Errorf("plugin %q exited before providing a socket path; stderr:\n%s", command, tail)
 }
 
 func (c *Client) ReadChan() chan Command {

--- a/server/cborplugin/client_test.go
+++ b/server/cborplugin/client_test.go
@@ -1,0 +1,149 @@
+// client_test.go - tests for cbor plugin client startup failure handling
+// Copyright (C) 2026  David Stainton.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cborplugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/katzenpost/katzenpost/core/log"
+)
+
+// TestHelperProcess is not a real test. The tests below re-exec the test
+// binary itself (via os.Args[0]) as a fake plugin subprocess, following the
+// pattern used by the standard library's own os/exec tests. It must return
+// immediately unless GO_WANT_HELPER_PROCESS is set, so that a normal test
+// run of this package treats it as an ordinary no-op test.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	switch os.Getenv("GO_HELPER_BEHAVIOR") {
+	case "exit_silent":
+		os.Exit(1)
+	case "exit_with_stderr":
+		fmt.Fprintln(os.Stderr, "simulated plugin startup failure: permission denied")
+		os.Exit(1)
+	case "handshake_ok":
+		runHandshakeOKHelper()
+	}
+	os.Exit(2)
+}
+
+type fakeServerPlugin struct{}
+
+func (fakeServerPlugin) OnCommand(Command) error  { return nil }
+func (fakeServerPlugin) RegisterConsumer(*Server) {}
+
+func runHandshakeOKHelper() {
+	tmpDir, err := os.MkdirTemp("", "cborplugin_test_helper")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	// core/log's disable=true discard path panics on any write it actually
+	// receives (a separate, pre-existing bug) - log to a real file instead.
+	logBackend, err := log.New(filepath.Join(tmpDir, "helper.log"), "DEBUG", false)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	socketFile := filepath.Join(tmpDir, "helper.socket")
+	srv := NewServer(logBackend.GetLogger("helper"), socketFile, &RequestFactory{}, fakeServerPlugin{})
+	fmt.Println(socketFile)
+	srv.Accept()
+	srv.Wait()
+}
+
+func newTestClient(t *testing.T) *Client {
+	t.Helper()
+	// core/log's disable=true discard path (newDiscardCloser) panics on any
+	// non-empty write (nil embedded io.WriteCloser) — a separate, pre-existing
+	// bug. Route to a real temp file instead of exercising it here.
+	logBackend, err := log.New(filepath.Join(t.TempDir(), "test.log"), "DEBUG", false)
+	if err != nil {
+		t.Fatalf("log.New: %v", err)
+	}
+	return NewClient(logBackend, "test-capability", "test-endpoint", &RequestFactory{})
+}
+
+const helperTimeoutBudget = 5 * time.Second
+
+func TestClientStartPluginExitsSilently(t *testing.T) {
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	t.Setenv("GO_HELPER_BEHAVIOR", "exit_silent")
+
+	client := newTestClient(t)
+	start := time.Now()
+	err := client.Start(os.Args[0], []string{"-test.run=TestHelperProcess"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected Start to return an error")
+	}
+	if elapsed > helperTimeoutBudget {
+		t.Fatalf("Start took %v to fail; expected well under the old ~40s retry budget", elapsed)
+	}
+	if !strings.Contains(err.Error(), "exited before providing a socket path") {
+		t.Fatalf("error does not mention the early exit: %v", err)
+	}
+}
+
+func TestClientStartPluginExitsWithStderr(t *testing.T) {
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	t.Setenv("GO_HELPER_BEHAVIOR", "exit_with_stderr")
+
+	client := newTestClient(t)
+	start := time.Now()
+	err := client.Start(os.Args[0], []string{"-test.run=TestHelperProcess"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected Start to return an error")
+	}
+	if elapsed > helperTimeoutBudget {
+		t.Fatalf("Start took %v to fail; expected well under the old ~40s retry budget", elapsed)
+	}
+	if !strings.Contains(err.Error(), "simulated plugin startup failure: permission denied") {
+		t.Fatalf("error does not include captured stderr: %v", err)
+	}
+}
+
+func TestClientStartHandshakeOK(t *testing.T) {
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	t.Setenv("GO_HELPER_BEHAVIOR", "handshake_ok")
+
+	client := newTestClient(t)
+	err := client.Start(os.Args[0], []string{"-test.run=TestHelperProcess"})
+	if err != nil {
+		t.Fatalf("expected Start to succeed, got: %v", err)
+	}
+	// Kill the helper subprocess directly rather than calling client.Halt():
+	// logPluginStderr already calls Halt() itself once stderr closes, from
+	// within its own Go()-registered goroutine, which can never observe its
+	// own completion; a second concurrent Halt() call here would join that
+	// same wait and hang the test. Killing the process is enough to make
+	// stderr close, which triggers that chain; reaper() then owns the
+	// resulting Wait() call, so we must not also call it here ourselves.
+	t.Cleanup(func() {
+		client.cmd.Process.Kill()
+	})
+}

--- a/server/cborplugin/client_test.go
+++ b/server/cborplugin/client_test.go
@@ -82,6 +82,9 @@ func newTestClient(t *testing.T) *Client {
 	if err != nil {
 		t.Fatalf("log.New: %v", err)
 	}
+	// Close before t.TempDir()'s own cleanup removes the directory: on
+	// Windows, RemoveAll fails on a file that's still open.
+	t.Cleanup(func() { logBackend.Close() })
 	return NewClient(logBackend, "test-capability", "test-endpoint", &RequestFactory{})
 }
 

--- a/server/cborplugin/server.go
+++ b/server/cborplugin/server.go
@@ -46,7 +46,9 @@ func NewServer(log *logging.Logger, socketFile string, commandBuilder CommandBui
 		socket:         NewCommandIO(log),
 	}
 	s.plugin.RegisterConsumer(s)
-	s.socket.Start(false, s.socketFile, s.commandBuilder)
+	// non-initiator side never aborts early and its own failures are
+	// handled internally via c.log.Fatal, so the returned error is unused.
+	_ = s.socket.Start(false, s.socketFile, s.commandBuilder, nil)
 	return s
 }
 

--- a/server/cborplugin/socket.go
+++ b/server/cborplugin/socket.go
@@ -17,6 +17,7 @@
 package cborplugin
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"time"
@@ -67,7 +68,12 @@ func NewCommandIO(log *logging.Logger) *CommandIO {
 	}
 }
 
-func (c *CommandIO) Start(initiator bool, socketFile string, commandBuilder CommandBuilder) {
+// Start connects (initiator) or listens (!initiator) on socketFile. For the
+// initiator case, abortCh lets a caller cut the dial-retry loop short as
+// soon as it knows the plugin process has already died, rather than
+// exhausting the full retry budget against a socket that will never accept.
+// abortCh may be nil, in which case the loop always runs its full budget.
+func (c *CommandIO) Start(initiator bool, socketFile string, commandBuilder CommandBuilder, abortCh <-chan interface{}) error {
 	c.commandBuilder = commandBuilder
 
 	if initiator {
@@ -75,20 +81,24 @@ func (c *CommandIO) Start(initiator bool, socketFile string, commandBuilder Comm
 		// it's possible that the plugin has written the socketFile to its stdout
 		// but the call to Accept hasn't happened yet, so backoff and wait a bit
 		// https://github.com/katzenpost/katzenpost/issues/477
+		const maxTries = 40
 		var err error
 		started := false
-		for tries := 0; tries < 40; tries++ {
+		tries := 0
+		for ; tries < maxTries; tries++ {
 			err = c.dial(socketFile)
-			if err != nil {
-				time.Sleep(time.Second)
-				continue
-			} else {
+			if err == nil {
 				started = true
 				break
 			}
+			select {
+			case <-abortCh:
+				return fmt.Errorf("gave up dialing %q after %d/%d tries, plugin process exited: %w", socketFile, tries+1, maxTries, err)
+			case <-time.After(time.Second):
+			}
 		}
-		if started != true {
-			panic(err)
+		if !started {
+			return fmt.Errorf("gave up dialing %q after %d tries: %w", socketFile, maxTries, err)
 		}
 		c.Go(c.reader)
 		c.Go(c.writer)
@@ -108,6 +118,7 @@ func (c *CommandIO) Start(initiator bool, socketFile string, commandBuilder Comm
 			}
 		}
 	}
+	return nil
 }
 
 func (c *CommandIO) Accept() {

--- a/server/internal/service/kaetzchen/cbor_plugins.go
+++ b/server/internal/service/kaetzchen/cbor_plugins.go
@@ -404,9 +404,10 @@ func (k *CBORPluginWorker) register(pluginConf *config.CBORPluginKaetzchen) erro
 
 	pluginClient, err := k.launch(pluginConf.Command, pluginConf.Capability, pluginConf.Endpoint, args)
 	if err != nil {
-		// Not logged here: the caller (server.New) already logs subsystem
-		// init failures uniformly, and this error can carry a large captured
-		// stderr payload that would otherwise be printed twice.
+		// Full error (which can carry a large captured stderr payload) is
+		// reported on stderr via fang at process exit; server.New logs a
+		// one-line summary to the log backend. Not logged here, to avoid
+		// printing it twice.
 		return err
 	}
 

--- a/server/internal/service/kaetzchen/cbor_plugins.go
+++ b/server/internal/service/kaetzchen/cbor_plugins.go
@@ -404,7 +404,9 @@ func (k *CBORPluginWorker) register(pluginConf *config.CBORPluginKaetzchen) erro
 
 	pluginClient, err := k.launch(pluginConf.Command, pluginConf.Capability, pluginConf.Endpoint, args)
 	if err != nil {
-		k.log.Error("Failed to start a plugin client: %s", err)
+		// Not logged here: the caller (server.New) already logs subsystem
+		// init failures uniformly, and this error can carry a large captured
+		// stderr payload that would otherwise be printed twice.
 		return err
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -119,6 +120,17 @@ func (s *Server) reshadowCryptoWorkers() {
 	for _, w := range s.cryptoWorkers {
 		w.UpdateMixKeys()
 	}
+}
+
+// firstLine returns the first non-empty line of err's message, summarizing
+// a multi-line error (e.g. one carrying a captured plugin stderr tail) to a
+// single log line. The full error text still reaches stderr via fang at
+// process exit.
+func firstLine(err error) string {
+	if err == nil {
+		return ""
+	}
+	return strings.TrimSpace(strings.SplitN(err.Error(), "\n", 2)[0])
 }
 
 // IdentityKey returns the running server's identity public key.
@@ -549,10 +561,12 @@ func New(cfg *config.Config) (*Server, error) {
 
 	// Initialize the provider backend.
 	if s.cfg.Server.IsServiceNode {
-		// Not logged here: fang's boxed error report at process exit
-		// already carries this (and, for a plugin, can be a large
-		// stderr-bearing message); logging it too just repeats it.
+		// Log a one-line summary to the log backend so operators who log to
+		// a file (rather than stdout/stderr) still see startup failures. The
+		// full error, including any captured plugin stderr tail, is carried
+		// to stderr via fang at process exit.
 		if s.serviceNode, err = service.New(goo); err != nil {
+			s.log.Errorf("Failed to initialize provider backend: %s", firstLine(err))
 			return nil, err
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -549,8 +549,10 @@ func New(cfg *config.Config) (*Server, error) {
 
 	// Initialize the provider backend.
 	if s.cfg.Server.IsServiceNode {
+		// Not logged here: fang's boxed error report at process exit
+		// already carries this (and, for a plugin, can be a large
+		// stderr-bearing message); logging it too just repeats it.
 		if s.serviceNode, err = service.New(goo); err != nil {
-			s.log.Errorf("Failed to initialize provider backend: %v", err)
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Here we fix the various bugs that prevent the cbor plugin startup failure from being reported to the operators in the service node log. That is to say, if a given cbor plugin fails to start, then at the very least the service node should print the plugin error to it's log. Why? Because service nodes start the plugins so they can receive error text from stderr, and because the error text may help the operator diagnose problems.