### PR TITLE
cmd: add version flags to remaining commands

### DIFF
--- a/cmd/courier/main.go
+++ b/cmd/courier/main.go
@@ -4,9 +4,11 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
 
 	kpcommon "github.com/katzenpost/katzenpost/common"
 	"github.com/katzenpost/katzenpost/common/tomlstrict"
@@ -15,36 +17,58 @@ import (
 	"github.com/katzenpost/katzenpost/server/cborplugin"
 )
 
-func main() {
-	var configFile string
-	var printVersion bool
-	var validateOnly bool
+type courierConfig struct {
+	configFile   string
+	validateOnly bool
+}
 
-	flag.StringVar(&configFile, "c", "", "configuration file")
-	flag.BoolVar(&printVersion, "v", false, "print version and exit")
-	flag.BoolVar(&validateOnly, "validate-only", false,
-		"load and validate the configuration file, then exit without side effects")
-	flag.Parse()
-
-	if printVersion {
-		fmt.Fprintln(os.Stdout, kpcommon.Version())
-		os.Exit(0)
+func newRootCommand() *cobra.Command {
+	var cfg courierConfig
+	cmd := &cobra.Command{
+		Use:   "courier",
+		Short: "Katzenpost storage courier service",
+		Run: func(cmd *cobra.Command, args []string) {
+			runCourier(cfg)
+		},
 	}
 
-	cfg, err := config.LoadFile(configFile)
+	cmd.Flags().StringVarP(&cfg.configFile, "config", "c", "", "configuration file")
+	cmd.Flags().BoolVar(&cfg.validateOnly, "validate-only", false,
+		"load and validate the configuration file, then exit without side effects")
+	return cmd
+}
+
+func main() {
+	cmd := newRootCommand()
+	cmd.SetArgs(normalizeLegacyArgs(os.Args[1:]))
+	kpcommon.ExecuteWithFang(cmd)
+}
+
+func normalizeLegacyArgs(args []string) []string {
+	normalized := append([]string(nil), args...)
+	for i, arg := range normalized {
+		if strings.SplitN(arg, "=", 2)[0] == "-validate-only" {
+			normalized[i] = "-" + arg
+		}
+	}
+	return normalized
+}
+
+func runCourier(cmdCfg courierConfig) {
+	cfg, err := config.LoadFile(cmdCfg.configFile)
 	if err != nil {
-		if validateOnly {
-			fmt.Fprintf(os.Stderr, "configuration file '%v' is invalid: %v\n", configFile, err)
+		if cmdCfg.validateOnly {
+			fmt.Fprintf(os.Stderr, "configuration file '%v' is invalid: %v\n", cmdCfg.configFile, err)
 			os.Exit(1)
 		}
 		cborplugin.FailStartup("courier", err)
 	}
-	if validateOnly {
-		if err := tomlstrict.Check(configFile, new(config.Config)); err != nil {
-			fmt.Fprintf(os.Stderr, "configuration file '%v' is invalid: %v\n", configFile, err)
+	if cmdCfg.validateOnly {
+		if err := tomlstrict.Check(cmdCfg.configFile, new(config.Config)); err != nil {
+			fmt.Fprintf(os.Stderr, "configuration file '%v' is invalid: %v\n", cmdCfg.configFile, err)
 			os.Exit(1)
 		}
-		fmt.Fprintf(os.Stdout, "configuration file '%v' is valid\n", configFile)
+		fmt.Fprintf(os.Stdout, "configuration file '%v' is valid\n", cmdCfg.configFile)
 		os.Exit(0)
 	}
 

--- a/cmd/courier/main.go
+++ b/cmd/courier/main.go
@@ -6,7 +6,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -40,18 +39,12 @@ func newRootCommand() *cobra.Command {
 
 func main() {
 	cmd := newRootCommand()
-	cmd.SetArgs(normalizeLegacyArgs(os.Args[1:]))
+	cmd.SetArgs(normalizeLegacyArgs(cmd, os.Args[1:]))
 	kpcommon.ExecuteWithFang(cmd)
 }
 
-func normalizeLegacyArgs(args []string) []string {
-	normalized := append([]string(nil), args...)
-	for i, arg := range normalized {
-		if strings.SplitN(arg, "=", 2)[0] == "-validate-only" {
-			normalized[i] = "-" + arg
-		}
-	}
-	return normalized
+func normalizeLegacyArgs(cmd *cobra.Command, args []string) []string {
+	return kpcommon.NormalizeLegacyLongFlags(cmd, args, "validate-only")
 }
 
 func runCourier(cmdCfg courierConfig) {

--- a/cmd/courier/main_test.go
+++ b/cmd/courier/main_test.go
@@ -19,7 +19,7 @@ func TestVersionFlags(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			cmd.SetOut(&stdout)
 			cmd.SetErr(&stderr)
-			cmd.SetArgs(normalizeLegacyArgs([]string{"-validate-only", arg}))
+			cmd.SetArgs(normalizeLegacyArgs(cmd, []string{"-validate-only", arg}))
 
 			if err := fang.Execute(context.Background(), cmd, fang.WithVersion("test-version")); err != nil {
 				t.Fatalf("execute %s: %v: %s", arg, err, stderr.String())
@@ -31,5 +31,28 @@ func TestVersionFlags(t *testing.T) {
 				t.Fatalf("version output for %s did not contain version: %q", arg, stdout.String())
 			}
 		})
+	}
+}
+
+func TestLegacyFlagReachesRun(t *testing.T) {
+	cmd := newRootCommand()
+	ran := false
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ran = true
+		validateOnly, err := cmd.Flags().GetBool("validate-only")
+		if err != nil {
+			t.Fatalf("get validate-only: %v", err)
+		}
+		if !validateOnly {
+			t.Fatal("legacy -validate-only flag was not parsed")
+		}
+	}
+	cmd.SetArgs(normalizeLegacyArgs(cmd, []string{"-validate-only"}))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute legacy flag: %v", err)
+	}
+	if !ran {
+		t.Fatal("command did not run")
 	}
 }

--- a/cmd/courier/main_test.go
+++ b/cmd/courier/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/fang"
+	"github.com/spf13/cobra"
+)
+
+func TestVersionFlags(t *testing.T) {
+	for _, arg := range []string{"-v", "--version"} {
+		t.Run(arg, func(t *testing.T) {
+			cmd := newRootCommand()
+			ran := false
+			cmd.Run = func(cmd *cobra.Command, args []string) { ran = true }
+			var stdout, stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetArgs(normalizeLegacyArgs([]string{"-validate-only", arg}))
+
+			if err := fang.Execute(context.Background(), cmd, fang.WithVersion("test-version")); err != nil {
+				t.Fatalf("execute %s: %v: %s", arg, err, stderr.String())
+			}
+			if ran {
+				t.Fatalf("command ran for %s", arg)
+			}
+			if !strings.Contains(stdout.String(), "test-version") {
+				t.Fatalf("version output for %s did not contain version: %q", arg, stdout.String())
+			}
+		})
+	}
+}

--- a/cmd/echo-plugin/main.go
+++ b/cmd/echo-plugin/main.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -58,19 +57,12 @@ func (e *Echo) RegisterConsumer(s *cborplugin.Server) {
 
 func main() {
 	cmd := newRootCommand()
-	cmd.SetArgs(normalizeLegacyArgs(os.Args[1:]))
+	cmd.SetArgs(normalizeLegacyArgs(cmd, os.Args[1:]))
 	kpcommon.ExecuteWithFang(cmd)
 }
 
-func normalizeLegacyArgs(args []string) []string {
-	normalized := append([]string(nil), args...)
-	for i, arg := range normalized {
-		switch strings.SplitN(arg, "=", 2)[0] {
-		case "-log_dir", "-log_level":
-			normalized[i] = "-" + arg
-		}
-	}
-	return normalized
+func normalizeLegacyArgs(cmd *cobra.Command, args []string) []string {
+	return kpcommon.NormalizeLegacyLongFlags(cmd, args, "log_dir", "log_level")
 }
 
 func newRootCommand() *cobra.Command {

--- a/cmd/echo-plugin/main.go
+++ b/cmd/echo-plugin/main.go
@@ -18,16 +18,23 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
 
 	kpcommon "github.com/katzenpost/katzenpost/common"
 	"github.com/katzenpost/katzenpost/core/log"
 	"github.com/katzenpost/katzenpost/server/cborplugin"
 )
+
+type echoConfig struct {
+	logDir   string
+	logLevel string
+}
 
 type Echo struct {
 	write func(cborplugin.Command)
@@ -50,24 +57,49 @@ func (e *Echo) RegisterConsumer(s *cborplugin.Server) {
 }
 
 func main() {
-	var logLevel string
-	var logDir string
-	flag.StringVar(&logDir, "log_dir", "", "logging directory")
-	flag.StringVar(&logLevel, "log_level", "DEBUG", "logging level could be set to: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL")
-	flag.Parse()
+	cmd := newRootCommand()
+	cmd.SetArgs(normalizeLegacyArgs(os.Args[1:]))
+	kpcommon.ExecuteWithFang(cmd)
+}
 
+func normalizeLegacyArgs(args []string) []string {
+	normalized := append([]string(nil), args...)
+	for i, arg := range normalized {
+		switch strings.SplitN(arg, "=", 2)[0] {
+		case "-log_dir", "-log_level":
+			normalized[i] = "-" + arg
+		}
+	}
+	return normalized
+}
+
+func newRootCommand() *cobra.Command {
+	var cfg echoConfig
+	cmd := &cobra.Command{
+		Use:   "echo-plugin",
+		Short: "Katzenpost echo service plugin",
+		Run: func(cmd *cobra.Command, args []string) {
+			runEcho(cfg)
+		},
+	}
+	cmd.Flags().StringVar(&cfg.logDir, "log_dir", "", "logging directory")
+	cmd.Flags().StringVar(&cfg.logLevel, "log_level", "DEBUG", "logging level could be set to: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL")
+	return cmd
+}
+
+func runEcho(cfg echoConfig) {
 	// Ensure that the log directory exists.
-	s, err := os.Stat(logDir)
+	s, err := os.Stat(cfg.logDir)
 	if os.IsNotExist(err) {
-		cborplugin.FailStartup("echo-plugin", fmt.Errorf("log directory %q doesn't exist", logDir))
+		cborplugin.FailStartup("echo-plugin", fmt.Errorf("log directory %q doesn't exist", cfg.logDir))
 	}
 	if !s.IsDir() {
-		cborplugin.FailStartup("echo-plugin", fmt.Errorf("log directory %q is not a directory", logDir))
+		cborplugin.FailStartup("echo-plugin", fmt.Errorf("log directory %q is not a directory", cfg.logDir))
 	}
 
 	// Log to a file.
-	logFile := path.Join(logDir, fmt.Sprintf("echo.%d.log", os.Getpid()))
-	logBackend, err := log.New(logFile, logLevel, false)
+	logFile := path.Join(cfg.logDir, fmt.Sprintf("echo.%d.log", os.Getpid()))
+	logBackend, err := log.New(logFile, cfg.logLevel, false)
 	if err != nil {
 		cborplugin.FailStartup("echo-plugin", err)
 	}

--- a/cmd/echo-plugin/main_test.go
+++ b/cmd/echo-plugin/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/fang"
+	"github.com/spf13/cobra"
+)
+
+func TestVersionFlags(t *testing.T) {
+	for _, arg := range []string{"-v", "--version"} {
+		t.Run(arg, func(t *testing.T) {
+			cmd := newRootCommand()
+			ran := false
+			cmd.Run = func(cmd *cobra.Command, args []string) { ran = true }
+			var stdout, stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetArgs(normalizeLegacyArgs([]string{"-log_dir", "/missing", arg}))
+
+			if err := fang.Execute(context.Background(), cmd, fang.WithVersion("test-version")); err != nil {
+				t.Fatalf("execute %s: %v: %s", arg, err, stderr.String())
+			}
+			if ran {
+				t.Fatalf("command ran for %s", arg)
+			}
+			if !strings.Contains(stdout.String(), "test-version") {
+				t.Fatalf("version output for %s did not contain version: %q", arg, stdout.String())
+			}
+		})
+	}
+}

--- a/cmd/echo-plugin/main_test.go
+++ b/cmd/echo-plugin/main_test.go
@@ -19,7 +19,7 @@ func TestVersionFlags(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			cmd.SetOut(&stdout)
 			cmd.SetErr(&stderr)
-			cmd.SetArgs(normalizeLegacyArgs([]string{"-log_dir", "/missing", arg}))
+			cmd.SetArgs(normalizeLegacyArgs(cmd, []string{"-log_dir", "/missing", arg}))
 
 			if err := fang.Execute(context.Background(), cmd, fang.WithVersion("test-version")); err != nil {
 				t.Fatalf("execute %s: %v: %s", arg, err, stderr.String())
@@ -31,5 +31,28 @@ func TestVersionFlags(t *testing.T) {
 				t.Fatalf("version output for %s did not contain version: %q", arg, stdout.String())
 			}
 		})
+	}
+}
+
+func TestLegacyFlagReachesRun(t *testing.T) {
+	cmd := newRootCommand()
+	ran := false
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ran = true
+		logDir, err := cmd.Flags().GetString("log_dir")
+		if err != nil {
+			t.Fatalf("get log_dir: %v", err)
+		}
+		if logDir != "/missing" {
+			t.Fatalf("log_dir = %q, want %q", logDir, "/missing")
+		}
+	}
+	cmd.SetArgs(normalizeLegacyArgs(cmd, []string{"-log_dir", "/missing"}))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute legacy flag: %v", err)
+	}
+	if !ran {
+		t.Fatal("command did not run")
 	}
 }

--- a/cmd/http-proxy-client/main.go
+++ b/cmd/http-proxy-client/main.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
-	"strings"
 	"time"
 
 	cbor "github.com/fxamacker/cbor/v2"
@@ -141,19 +140,12 @@ func (k *kttp) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	cmd := newRootCommand()
-	cmd.SetArgs(normalizeLegacyArgs(os.Args[1:]))
+	cmd.SetArgs(normalizeLegacyArgs(cmd, os.Args[1:]))
 	kpcommon.ExecuteWithFang(cmd)
 }
 
-func normalizeLegacyArgs(args []string) []string {
-	normalized := append([]string(nil), args...)
-	for i, arg := range normalized {
-		switch strings.SplitN(arg, "=", 2)[0] {
-		case "-cfg", "-ep", "-log_level", "-port", "-retry", "-delay":
-			normalized[i] = "-" + arg
-		}
-	}
-	return normalized
+func normalizeLegacyArgs(cmd *cobra.Command, args []string) []string {
+	return kpcommon.NormalizeLegacyLongFlags(cmd, args, "cfg", "ep", "log_level", "port", "retry", "delay")
 }
 
 func newRootCommand() *cobra.Command {

--- a/cmd/http-proxy-client/main.go
+++ b/cmd/http-proxy-client/main.go
@@ -21,15 +21,17 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"os"
+	"strings"
 	"time"
 
 	cbor "github.com/fxamacker/cbor/v2"
 	"github.com/katzenpost/hpqc/hash"
+	"github.com/spf13/cobra"
 	"gopkg.in/op/go-logging.v1"
 
 	"github.com/katzenpost/katzenpost/client/config"
@@ -38,24 +40,24 @@ import (
 	"github.com/katzenpost/katzenpost/quic/proxy/common"
 )
 
-var (
-	cfgFile  = flag.String("cfg", "proxy.toml", "thin client config file")
-	epName   = flag.String("ep", "http", "endpoint name")
-	logLevel = flag.String("log_level", "DEBUG", "logging level could be set to: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL")
-	port     = flag.Int("port", 8080, "listener address")
-	retry    = flag.Int("retry", -1, "limit number of reconnection attempts")
-	delay    = flag.Int("delay", 30, "time to wait between connection attempts (seconds)>")
-)
+type proxyClientConfig struct {
+	cfgFile  string
+	epName   string
+	logLevel string
+	port     int
+	retry    int
+	delay    int
+}
 
 // getThinClient connects to the client daemon and returns a ThinClient
-func getThinClient(cfgFile string) (*thin.ThinClient, error) {
-	cfg, err := thin.LoadFile(cfgFile)
+func getThinClient(cmdCfg proxyClientConfig) (*thin.ThinClient, error) {
+	cfg, err := thin.LoadFile(cmdCfg.cfgFile)
 	if err != nil {
 		return nil, err
 	}
 
 	logging := &config.Logging{
-		Level: *logLevel,
+		Level: cmdCfg.logLevel,
 	}
 	client := thin.NewThinClient(cfg, logging)
 
@@ -66,8 +68,8 @@ func getThinClient(cfgFile string) (*thin.ThinClient, error) {
 		case nil:
 			return client, nil
 		default:
-			<-time.After(time.Duration(*delay) * time.Second)
-			if retries == *retry {
+			<-time.After(time.Duration(cmdCfg.delay) * time.Second)
+			if retries == cmdCfg.retry {
 				return nil, errors.New("failed to connect within retry limit")
 			}
 		}
@@ -78,10 +80,11 @@ func getThinClient(cfgFile string) (*thin.ThinClient, error) {
 type kttp struct {
 	client *thin.ThinClient
 	log    *logging.Logger
+	epName string
 }
 
 func (k *kttp) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	d, err := k.client.GetService(*epName)
+	d, err := k.client.GetService(k.epName)
 	if err != nil {
 		k.log.Errorf("Err getting service: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -137,8 +140,42 @@ func (k *kttp) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	flag.Parse()
-	client, err := getThinClient(*cfgFile)
+	cmd := newRootCommand()
+	cmd.SetArgs(normalizeLegacyArgs(os.Args[1:]))
+	kpcommon.ExecuteWithFang(cmd)
+}
+
+func normalizeLegacyArgs(args []string) []string {
+	normalized := append([]string(nil), args...)
+	for i, arg := range normalized {
+		switch strings.SplitN(arg, "=", 2)[0] {
+		case "-cfg", "-ep", "-log_level", "-port", "-retry", "-delay":
+			normalized[i] = "-" + arg
+		}
+	}
+	return normalized
+}
+
+func newRootCommand() *cobra.Command {
+	var cfg proxyClientConfig
+	cmd := &cobra.Command{
+		Use:   "http-proxy-client",
+		Short: "Katzenpost HTTP proxy client",
+		Run: func(cmd *cobra.Command, args []string) {
+			runProxyClient(cfg)
+		},
+	}
+	cmd.Flags().StringVar(&cfg.cfgFile, "cfg", "proxy.toml", "thin client config file")
+	cmd.Flags().StringVar(&cfg.epName, "ep", "http", "endpoint name")
+	cmd.Flags().StringVar(&cfg.logLevel, "log_level", "DEBUG", "logging level could be set to: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL")
+	cmd.Flags().IntVar(&cfg.port, "port", 8080, "listener address")
+	cmd.Flags().IntVar(&cfg.retry, "retry", -1, "limit number of reconnection attempts")
+	cmd.Flags().IntVar(&cfg.delay, "delay", 30, "time to wait between connection attempts (seconds)>")
+	return cmd
+}
+
+func runProxyClient(cfg proxyClientConfig) {
+	client, err := getThinClient(cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -148,7 +185,7 @@ func main() {
 	clientLog.Noticef("Katzenpost http-proxy-client version: %s", kpcommon.Version())
 	clientLog.Notice("Katzenpost is still pre-alpha.  DO NOT DEPEND ON IT FOR STRONG SECURITY OR ANONYMITY.")
 
-	addr := fmt.Sprintf(":%d", *port)
-	handler := &kttp{client: client, log: clientLog}
+	addr := fmt.Sprintf(":%d", cfg.port)
+	handler := &kttp{client: client, log: clientLog, epName: cfg.epName}
 	http.ListenAndServe(addr, handler)
 }

--- a/cmd/http-proxy-client/main_test.go
+++ b/cmd/http-proxy-client/main_test.go
@@ -19,7 +19,7 @@ func TestVersionFlags(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			cmd.SetOut(&stdout)
 			cmd.SetErr(&stderr)
-			cmd.SetArgs(normalizeLegacyArgs([]string{"-cfg", "/missing", arg}))
+			cmd.SetArgs(normalizeLegacyArgs(cmd, []string{"-cfg", "/missing", arg}))
 
 			if err := fang.Execute(context.Background(), cmd, fang.WithVersion("test-version")); err != nil {
 				t.Fatalf("execute %s: %v: %s", arg, err, stderr.String())
@@ -31,5 +31,28 @@ func TestVersionFlags(t *testing.T) {
 				t.Fatalf("version output for %s did not contain version: %q", arg, stdout.String())
 			}
 		})
+	}
+}
+
+func TestLegacyFlagReachesRun(t *testing.T) {
+	cmd := newRootCommand()
+	ran := false
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ran = true
+		cfg, err := cmd.Flags().GetString("cfg")
+		if err != nil {
+			t.Fatalf("get cfg: %v", err)
+		}
+		if cfg != "/missing" {
+			t.Fatalf("cfg = %q, want %q", cfg, "/missing")
+		}
+	}
+	cmd.SetArgs(normalizeLegacyArgs(cmd, []string{"-cfg", "/missing"}))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute legacy flag: %v", err)
+	}
+	if !ran {
+		t.Fatal("command did not run")
 	}
 }

--- a/cmd/http-proxy-client/main_test.go
+++ b/cmd/http-proxy-client/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/fang"
+	"github.com/spf13/cobra"
+)
+
+func TestVersionFlags(t *testing.T) {
+	for _, arg := range []string{"-v", "--version"} {
+		t.Run(arg, func(t *testing.T) {
+			cmd := newRootCommand()
+			ran := false
+			cmd.Run = func(cmd *cobra.Command, args []string) { ran = true }
+			var stdout, stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetArgs(normalizeLegacyArgs([]string{"-cfg", "/missing", arg}))
+
+			if err := fang.Execute(context.Background(), cmd, fang.WithVersion("test-version")); err != nil {
+				t.Fatalf("execute %s: %v: %s", arg, err, stderr.String())
+			}
+			if ran {
+				t.Fatalf("command ran for %s", arg)
+			}
+			if !strings.Contains(stdout.String(), "test-version") {
+				t.Fatalf("version output for %s did not contain version: %q", arg, stdout.String())
+			}
+		})
+	}
+}

--- a/cmd/http-proxy-server/main.go
+++ b/cmd/http-proxy-server/main.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 
 	cbor "github.com/fxamacker/cbor/v2"
 	"github.com/spf13/cobra"
@@ -106,19 +105,12 @@ func (p proxy) OnCommand(cmd cborplugin.Command) error {
 
 func main() {
 	cmd := newRootCommand()
-	cmd.SetArgs(normalizeLegacyArgs(os.Args[1:]))
+	cmd.SetArgs(normalizeLegacyArgs(cmd, os.Args[1:]))
 	kpcommon.ExecuteWithFang(cmd)
 }
 
-func normalizeLegacyArgs(args []string) []string {
-	normalized := append([]string(nil), args...)
-	for i, arg := range normalized {
-		switch strings.SplitN(arg, "=", 2)[0] {
-		case "-log_dir", "-log_level", "-host":
-			normalized[i] = "-" + arg
-		}
-	}
-	return normalized
+func normalizeLegacyArgs(cmd *cobra.Command, args []string) []string {
+	return kpcommon.NormalizeLegacyLongFlags(cmd, args, "log_dir", "log_level", "host")
 }
 
 func newRootCommand() *cobra.Command {

--- a/cmd/http-proxy-server/main.go
+++ b/cmd/http-proxy-server/main.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -28,8 +27,10 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	cbor "github.com/fxamacker/cbor/v2"
+	"github.com/spf13/cobra"
 	"gopkg.in/op/go-logging.v1"
 
 	kpcommon "github.com/katzenpost/katzenpost/common"
@@ -37,6 +38,12 @@ import (
 	"github.com/katzenpost/katzenpost/quic/proxy/common"
 	"github.com/katzenpost/katzenpost/server/cborplugin"
 )
+
+type proxyServerConfig struct {
+	host     string
+	logDir   string
+	logLevel string
+}
 
 type proxy struct {
 	allowedHost map[string]struct{}
@@ -98,26 +105,50 @@ func (p proxy) OnCommand(cmd cborplugin.Command) error {
 }
 
 func main() {
-	var logLevel string
-	var logDir string
-	var host string
-	flag.StringVar(&logDir, "log_dir", "", "logging directory")
-	flag.StringVar(&logLevel, "log_level", "DEBUG", "logging level could be set to: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL")
-	flag.StringVar(&host, "host", "*", "wildcard allow proxy to any http.Request.Host")
-	flag.Parse()
+	cmd := newRootCommand()
+	cmd.SetArgs(normalizeLegacyArgs(os.Args[1:]))
+	kpcommon.ExecuteWithFang(cmd)
+}
 
+func normalizeLegacyArgs(args []string) []string {
+	normalized := append([]string(nil), args...)
+	for i, arg := range normalized {
+		switch strings.SplitN(arg, "=", 2)[0] {
+		case "-log_dir", "-log_level", "-host":
+			normalized[i] = "-" + arg
+		}
+	}
+	return normalized
+}
+
+func newRootCommand() *cobra.Command {
+	var cfg proxyServerConfig
+	cmd := &cobra.Command{
+		Use:   "http-proxy-server",
+		Short: "Katzenpost HTTP proxy service plugin",
+		Run: func(cmd *cobra.Command, args []string) {
+			runProxyServer(cfg)
+		},
+	}
+	cmd.Flags().StringVar(&cfg.logDir, "log_dir", "", "logging directory")
+	cmd.Flags().StringVar(&cfg.logLevel, "log_level", "DEBUG", "logging level could be set to: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL")
+	cmd.Flags().StringVar(&cfg.host, "host", "*", "wildcard allow proxy to any http.Request.Host")
+	return cmd
+}
+
+func runProxyServer(cfg proxyServerConfig) {
 	// Ensure that the log directory exists.
-	s, err := os.Stat(logDir)
+	s, err := os.Stat(cfg.logDir)
 	if os.IsNotExist(err) {
-		cborplugin.FailStartup("http-proxy-server", fmt.Errorf("log directory %q doesn't exist", logDir))
+		cborplugin.FailStartup("http-proxy-server", fmt.Errorf("log directory %q doesn't exist", cfg.logDir))
 	}
 	if !s.IsDir() {
-		cborplugin.FailStartup("http-proxy-server", fmt.Errorf("log directory %q is not a directory", logDir))
+		cborplugin.FailStartup("http-proxy-server", fmt.Errorf("log directory %q is not a directory", cfg.logDir))
 	}
 
 	// Log to a file.
-	logFile := path.Join(logDir, fmt.Sprintf("proxy.%d.log", os.Getpid()))
-	logBackend, err := log.New(logFile, logLevel, false)
+	logFile := path.Join(cfg.logDir, fmt.Sprintf("proxy.%d.log", os.Getpid()))
+	logBackend, err := log.New(logFile, cfg.logLevel, false)
 	if err != nil {
 		cborplugin.FailStartup("http-proxy-server", err)
 	}
@@ -133,7 +164,7 @@ func main() {
 	socketFile := filepath.Join(tmpDir, fmt.Sprintf("%d.http_proxy.socket", os.Getpid()))
 
 	p := &proxy{allowedHost: make(map[string]struct{}), log: serverLog}
-	p.allowedHost[host] = struct{}{}
+	p.allowedHost[cfg.host] = struct{}{}
 
 	cmdBuilder := new(cborplugin.RequestFactory)
 	server := cborplugin.NewServer(serverLog, socketFile, cmdBuilder, p)

--- a/cmd/http-proxy-server/main_test.go
+++ b/cmd/http-proxy-server/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/fang"
+	"github.com/spf13/cobra"
+)
+
+func TestVersionFlags(t *testing.T) {
+	for _, arg := range []string{"-v", "--version"} {
+		t.Run(arg, func(t *testing.T) {
+			cmd := newRootCommand()
+			ran := false
+			cmd.Run = func(cmd *cobra.Command, args []string) { ran = true }
+			var stdout, stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetArgs(normalizeLegacyArgs([]string{"-log_dir", "/missing", arg}))
+
+			if err := fang.Execute(context.Background(), cmd, fang.WithVersion("test-version")); err != nil {
+				t.Fatalf("execute %s: %v: %s", arg, err, stderr.String())
+			}
+			if ran {
+				t.Fatalf("command ran for %s", arg)
+			}
+			if !strings.Contains(stdout.String(), "test-version") {
+				t.Fatalf("version output for %s did not contain version: %q", arg, stdout.String())
+			}
+		})
+	}
+}

--- a/cmd/http-proxy-server/main_test.go
+++ b/cmd/http-proxy-server/main_test.go
@@ -19,7 +19,7 @@ func TestVersionFlags(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			cmd.SetOut(&stdout)
 			cmd.SetErr(&stderr)
-			cmd.SetArgs(normalizeLegacyArgs([]string{"-log_dir", "/missing", arg}))
+			cmd.SetArgs(normalizeLegacyArgs(cmd, []string{"-log_dir", "/missing", arg}))
 
 			if err := fang.Execute(context.Background(), cmd, fang.WithVersion("test-version")); err != nil {
 				t.Fatalf("execute %s: %v: %s", arg, err, stderr.String())
@@ -31,5 +31,28 @@ func TestVersionFlags(t *testing.T) {
 				t.Fatalf("version output for %s did not contain version: %q", arg, stdout.String())
 			}
 		})
+	}
+}
+
+func TestLegacyFlagReachesRun(t *testing.T) {
+	cmd := newRootCommand()
+	ran := false
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ran = true
+		logDir, err := cmd.Flags().GetString("log_dir")
+		if err != nil {
+			t.Fatalf("get log_dir: %v", err)
+		}
+		if logDir != "/missing" {
+			t.Fatalf("log_dir = %q, want %q", logDir, "/missing")
+		}
+	}
+	cmd.SetArgs(normalizeLegacyArgs(cmd, []string{"-log_dir", "/missing"}))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute legacy flag: %v", err)
+	}
+	if !ran {
+		t.Fatal("command did not run")
 	}
 }

--- a/common/cli.go
+++ b/common/cli.go
@@ -27,6 +27,72 @@ func ExecuteWithFang(cmd *cobra.Command) {
 	}
 }
 
+// NormalizeLegacyLongFlags converts selected long flags from the legacy
+// single-dash form to the double-dash form expected by pflag. Flag values are
+// left untouched, including values that happen to match a legacy flag name.
+func NormalizeLegacyLongFlags(cmd *cobra.Command, args []string, names ...string) []string {
+	legacyNames := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		legacyNames[name] = struct{}{}
+	}
+
+	normalized := append([]string(nil), args...)
+	expectValue := false
+	for i, arg := range normalized {
+		if expectValue {
+			expectValue = false
+			continue
+		}
+		if arg == "--" {
+			break
+		}
+
+		flagName, hasInlineValue, isLegacy := legacyLongFlag(arg, legacyNames)
+		if isLegacy {
+			normalized[i] = "-" + arg
+			expectValue = flagNeedsValue(cmd, flagName, hasInlineValue)
+			continue
+		}
+
+		flagName, hasInlineValue = commandFlag(arg)
+		expectValue = flagNeedsValue(cmd, flagName, hasInlineValue)
+	}
+	return normalized
+}
+
+func legacyLongFlag(arg string, names map[string]struct{}) (string, bool, bool) {
+	if !strings.HasPrefix(arg, "-") || strings.HasPrefix(arg, "--") {
+		return "", false, false
+	}
+
+	nameAndValue := strings.TrimPrefix(arg, "-")
+	name, _, hasInlineValue := strings.Cut(nameAndValue, "=")
+	_, ok := names[name]
+	return name, hasInlineValue, ok
+}
+
+func commandFlag(arg string) (string, bool) {
+	if !strings.HasPrefix(arg, "-") || arg == "-" {
+		return "", false
+	}
+
+	nameAndValue := strings.TrimLeft(arg, "-")
+	name, _, hasInlineValue := strings.Cut(nameAndValue, "=")
+	return name, hasInlineValue
+}
+
+func flagNeedsValue(cmd *cobra.Command, name string, hasInlineValue bool) bool {
+	if name == "" || hasInlineValue {
+		return false
+	}
+
+	flag := cmd.Flags().Lookup(name)
+	if flag == nil && len(name) == 1 {
+		flag = cmd.Flags().ShorthandLookup(name)
+	}
+	return flag != nil && flag.NoOptDefVal == ""
+}
+
 // ErrorHandlerWithUsage creates a custom error handler that displays error messages
 // followed by usage help for CLI argument errors. This provides better user experience
 // by showing both the error and how to use the command correctly.

--- a/common/cli_test.go
+++ b/common/cli_test.go
@@ -1,0 +1,66 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNormalizeLegacyLongFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "separate value",
+			args: []string{"-log_dir", "/tmp/log"},
+			want: []string{"--log_dir", "/tmp/log"},
+		},
+		{
+			name: "inline value",
+			args: []string{"-log_level=INFO"},
+			want: []string{"--log_level=INFO"},
+		},
+		{
+			name: "value matching legacy flag",
+			args: []string{"-log_dir", "-log_level"},
+			want: []string{"--log_dir", "-log_level"},
+		},
+		{
+			name: "terminator",
+			args: []string{"--", "-log_dir", "/tmp/log"},
+			want: []string{"--", "-log_dir", "/tmp/log"},
+		},
+		{
+			name: "boolean followed by value flag",
+			args: []string{"-validate-only", "-log_dir", "/tmp/log"},
+			want: []string{"--validate-only", "--log_dir", "/tmp/log"},
+		},
+		{
+			name: "short flag value matching legacy flag",
+			args: []string{"-c", "-validate-only"},
+			want: []string{"-c", "-validate-only"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			cmd.Flags().String("log_dir", "", "")
+			cmd.Flags().String("log_level", "", "")
+			cmd.Flags().Bool("validate-only", false, "")
+			cmd.Flags().StringP("config", "c", "", "")
+
+			original := append([]string(nil), test.args...)
+			got := NormalizeLegacyLongFlags(cmd, test.args, "log_dir", "log_level", "validate-only")
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("NormalizeLegacyLongFlags() = %q, want %q", got, test.want)
+			}
+			if !reflect.DeepEqual(test.args, original) {
+				t.Fatalf("NormalizeLegacyLongFlags() modified input: got %q, want %q", test.args, original)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add the shared Cobra/Fang CLI path to `courier`, `echo-plugin`, `http-proxy-client`, and `http-proxy-server`
- support both `-v` and `--version` with consistent version output
- exit before configuration loading, connections, sockets, or service startup
- preserve the legacy single-dash long flags used by the plugin launcher and existing proxy commands

## Testing

- `go test -count=1 ./cmd/courier ./cmd/echo-plugin ./cmd/http-proxy-client ./cmd/http-proxy-server`
- `go test -run '^$' ./cmd/courier ./cmd/echo-plugin ./cmd/http-proxy-client ./cmd/http-proxy-server`
- `go vet ./cmd/courier ./cmd/echo-plugin ./cmd/http-proxy-client ./cmd/http-proxy-server`
- CLI smoke tests for both version aliases with legacy arguments
- `git diff --check`

Fixes #1131
